### PR TITLE
EXIF handling of PNG metadata

### DIFF
--- a/ocrd/model/ocrd_exif.py
+++ b/ocrd/model/ocrd_exif.py
@@ -73,18 +73,24 @@ class OcrdExif(object):
 
     @staticmethod
     def from_filename(image_filename):
+        if image_filename is None:
+            raise Exception("Must pass 'image_filename' to OcrdExif.from_filename")
         with exiftool.ExifTool() as et:
             exif_props = et.get_metadata(image_filename)
+            print(exif_props)
             return OcrdExif(exif_props)
 
     def __init__(self, props):
-        self.width = props["EXIF:ImageWidth"]
-        self.height = props["EXIF:ImageHeight"]
-        self.xResolution = props["EXIF:XResolution"]
-        self.yResolution = props["EXIF:YResolution"]
-        self.compression = EXIF_COMPRESSION_METHODS.get(props["EXIF:Compression"], "Unknown")
-        self.photometricInterpretation = EXIF_PHOTOMETRICINTERPRETATION_VALUES.get(props["EXIF:PhotometricInterpretation"], "Unknown")
-        self.resolutionUnit = "%s" % EXIF_RESOLUTIONUNIT_VALUES.get(props["EXIF:ResolutionUnit"], "None")
+        self.width = props["EXIF:ImageWidth"] if "EXIF:ImageWidth" in props else props["PNG:ImageWidth"]
+        self.height = props["EXIF:ImageHeight"] if "EXIF:ImageHeight" in props else props["PNG:ImageHeight"]
+        self.xResolution = props["EXIF:XResolution"] if "EXIF:XResolution" in props else 0
+        self.yResolution = props["EXIF:YResolution"] if "EXIF:YResolution" in props else 0
+        if "EXIF:Compression" in props:
+            self.compression = EXIF_COMPRESSION_METHODS.get(props["EXIF:Compression"], "Unknown")
+        if "EXIF:PhotometricInterpretation" in props:
+            self.photometricInterpretation = EXIF_PHOTOMETRICINTERPRETATION_VALUES.get(props["EXIF:PhotometricInterpretation"], "Unknown")
+        if "EXIF:ResolutionUnit" in props:
+            self.resolutionUnit = "%s" % EXIF_RESOLUTIONUNIT_VALUES.get(props["EXIF:ResolutionUnit"], "None")
 
     def to_xml(self):
         ret = '<exif>'

--- a/ocrd/model/ocrd_exif.py
+++ b/ocrd/model/ocrd_exif.py
@@ -77,7 +77,6 @@ class OcrdExif(object):
             raise Exception("Must pass 'image_filename' to OcrdExif.from_filename")
         with exiftool.ExifTool() as et:
             exif_props = et.get_metadata(image_filename)
-            print(exif_props)
             return OcrdExif(exif_props)
 
     def __init__(self, props):

--- a/ocrd/utils.py
+++ b/ocrd/utils.py
@@ -37,6 +37,18 @@ def points_from_xywh(box):
         x, y + h
     )
 
+def points_from_x0y0x1y1(xyxy):
+    """
+    Constructs a polygon representation from a rectangle described as a list [x0, y0, x1, y1]
+    """
+    [x0, y0, x1, y1] = xyxy
+    return "%s,%s %s,%s %s,%s %s,%s" % (
+        x0, y0,
+        x1, y0,
+        x1, y1,
+        x0, y1
+    )
+
 def xywh_from_points(points):
     """
     Constructs an dict representing a rectangle with keys x, y, w, h

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 from test.base import TestCase, main
 from ocrd.utils import (
     points_from_xywh,
+    points_from_x0y0x1y1,
     xywh_from_points,
     polygon_from_points
 )
@@ -14,6 +15,13 @@ class TestResolver(TestCase):
             points_from_xywh({'x': 100, 'y': 100, 'w': 100, 'h': 100}),
             '100,100 200,100 200,200 100,200'
         )
+
+    def test_points_from_x0y0x1y1(self):
+        self.assertEqual(
+            points_from_x0y0x1y1([100, 100, 200, 200]),
+            '100,100 200,100 200,200 100,200'
+        )
+
 
     def test_xywh_from_points(self):
         self.assertEqual(


### PR DESCRIPTION
PNG has a different metadata mechanism than TIFF. I was of the impression that common keys get normalized but apparently they do not. I.e. we must differentiate between `EXIF:ImageWidth` and `PNG:ImageWidth`.

Still has some debugging statements that need to go before merge.