### PR TITLE
Parameter validation defaults

### DIFF
--- a/ocrd/decorators.py
+++ b/ocrd/decorators.py
@@ -5,14 +5,14 @@ import click
 from ocrd.resolver import Resolver
 from ocrd.processor.base import run_processor
 
-def ocrd_cli_wrap_processor(processorClass, mets=None, working_dir=None, cache_enabled=True, *args, **kwargs):
+def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_dir=None, cache_enabled=True, *args, **kwargs):
     if mets.find('://') == -1:
         mets = 'file://' + mets
     if mets.startswith('file://') and not os.path.exists(mets[len('file://'):]):
         raise Exception("File does not exist: %s" % mets)
     resolver = Resolver(cache_enabled=cache_enabled)
     workspace = resolver.workspace_from_url(mets, working_dir)
-    run_processor(processorClass, mets, workspace=workspace, *args, **kwargs)
+    run_processor(processorClass, ocrd_tool, mets, workspace=workspace, *args, **kwargs)
 
 def ocrd_cli_options(f):
     """

--- a/ocrd/model/ocrd_mets.py
+++ b/ocrd/model/ocrd_mets.py
@@ -5,8 +5,8 @@ from .ocrd_file import OcrdFile
 
 class OcrdMets(OcrdXmlDocument):
 
-    def __init__(self, file_by_id=None, *args, **kwargs):
-        super(OcrdMets, self).__init__(*args, **kwargs)
+    def __init__(self, file_by_id=None, **kwargs):
+        super(OcrdMets, self).__init__(**kwargs)
         if file_by_id is None:
             file_by_id = {}
         self._file_by_id = file_by_id

--- a/ocrd/model/ocrd_page.py
+++ b/ocrd/model/ocrd_page.py
@@ -1,4 +1,8 @@
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 from datetime import datetime
 
 # pylint: disable=unused-import

--- a/ocrd/model/ocrd_page.py
+++ b/ocrd/model/ocrd_page.py
@@ -1,4 +1,4 @@
-from io import StringIO
+from StringIO import StringIO
 from datetime import datetime
 
 # pylint: disable=unused-import

--- a/ocrd/model/yaml/ocrd_tool.schema.yml
+++ b/ocrd/model/yaml/ocrd_tool.schema.yml
@@ -48,6 +48,7 @@ properties:
             - layout/segmentation
             - layout/segmentation/region
             - layout/segmentation/line
+            - layout/segmentation/word
             - layout/segmentation/classification
             - layout/analysis
         tags:

--- a/ocrd/model/yaml/ocrd_tool.schema.yml
+++ b/ocrd/model/yaml/ocrd_tool.schema.yml
@@ -48,7 +48,6 @@ properties:
             - layout/segmentation
             - layout/segmentation/region
             - layout/segmentation/line
-            - layout/segmentation/word
             - layout/segmentation/classification
             - layout/analysis
         tags:

--- a/ocrd/processor/base.py
+++ b/ocrd/processor/base.py
@@ -40,7 +40,7 @@ def run_processor(
         with open(fname, 'r') as param_json_file:
             parameter = json.load(param_json_file)
     log.debug("Running processor %s", processorClass)
-    processor = processorClass(workspace, ocrd_tool, input_file_grp=input_file_grp, output_file_grp=output_file_grp, parameter=parameter)
+    processor = processorClass(workspace, ocrd_tool=ocrd_tool, input_file_grp=input_file_grp, output_file_grp=output_file_grp, parameter=parameter)
     log.debug("Processor instance %s", processor)
     processor.process()
     #  workspace.persist()

--- a/ocrd/validator.py
+++ b/ocrd/validator.py
@@ -14,7 +14,7 @@ def extend_with_default(validator_class):
     validate_properties = validator_class.VALIDATORS["properties"]
 
     def set_defaults(validator, properties, instance, schema):
-        for prop, subschema in properties.iteritems():
+        for prop, subschema in properties.items():
             if "default" in subschema:
                 instance.setdefault(prop, subschema["default"])
 

--- a/ocrd/workspace.py
+++ b/ocrd/workspace.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import shutil
 
 import cv2
@@ -108,6 +109,8 @@ class Workspace(object):
 
         if content is not None:
             with open(local_filename, 'wb') as f:
+                if sys.version_info >= (3, 0) and isinstance(content, str):
+                    content = bytes(content, 'utf-8')
                 f.write(content)
 
     def move_file(self, fobj, dst):

--- a/test/test_resolver.py
+++ b/test/test_resolver.py
@@ -30,6 +30,7 @@ class TestResolver(TestCase):
 
     def test_workspace_from_folder(self):
         workspace = self.resolver.workspace_from_folder(self.folder, clobber_mets=True)
+        #  print([ f.url for f in workspace.mets.find_files() ])
         self.assertEqual(len(workspace.mets.find_files()), 6, '6 files total')
 
     def test_workspace_from_url(self):

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -1,7 +1,13 @@
 import json
-from ocrd.resolver import Resolver
-from ocrd.validator import ValidationReport, WorkspaceValidator, OcrdToolValidator
 from test.base import TestCase, assets, main
+
+from ocrd.resolver import Resolver
+from ocrd.validator import (
+    ValidationReport,
+    WorkspaceValidator,
+    ParameterValidator,
+    OcrdToolValidator
+)
 METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/mets_one_file.xml')
 
 class TestValidationReport(TestCase):

--- a/test/validation/test_parameter_validator.py
+++ b/test/validation/test_parameter_validator.py
@@ -1,0 +1,21 @@
+from test.base import TestCase, main
+from ocrd.validator import ParameterValidator
+
+class TestParameterValidator(TestCase):
+
+    def setUp(self):
+        self.ocrd_tool = {
+            "parameters": {
+                "num-param": {"type": "number", "default": 1}
+            }
+        }
+
+    def runTest(self):
+        validator = ParameterValidator(self.ocrd_tool)
+        obj = {}
+        validator.validate(obj)
+        self.assertEqual(obj, {"num-param": 1})
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
* Enforce processor subclasses to pass ocrd_tool.json to constructor
* Validate parameters for the tools and fill in defaults so they are available at process time in `self.parameter`
* Some py2/py3 compat fixes