### PR TITLE
WIP: Wrap execeutable webservice

### DIFF
--- a/ocrd/__init__.py
+++ b/ocrd/__init__.py
@@ -1,4 +1,4 @@
-from ocrd.processor.base import run_processor, run_cli, Processor
+from ocrd.processor.base import run_processor, run_executable, Processor
 from ocrd.model import OcrdMets, OcrdExif, OcrdFile, OcrdSwagger
 from ocrd.constants import * # pylint: disable=wildcard-import
 from ocrd.resolver import Resolver

--- a/ocrd/cli/process.py
+++ b/ocrd/cli/process.py
@@ -3,7 +3,7 @@ import codecs
 
 import click
 
-from ocrd import run_cli, Resolver
+from ocrd import run_executable, Resolver
 from ocrd.decorators import ocrd_cli_options
 
 # ----------------------------------------------------------------------
@@ -33,7 +33,7 @@ def process_cli(mets_url, **kwargs):
             raise Exception("Tool not registered: '%s'" % cmd)
 
     for cmd in kwargs['steps']:
-        run_cli(cmd, mets_url, resolver, workspace)
+        run_executable(cmd, mets_url, resolver, workspace)
 
     workspace.reload_mets()
 

--- a/ocrd/cli/server.py
+++ b/ocrd/cli/server.py
@@ -1,6 +1,7 @@
 import click
 
 from ocrd.webservice.processor import create as create_processor_ws
+from ocrd.webservice.wrap_executable import create as create_wrap_executable
 from ocrd.webservice.repository import create as create_repository_ws
 
 # ----------------------------------------------------------------------
@@ -15,16 +16,28 @@ def server_cli():
 
 @server_cli.command('process')
 @click.option('-p', '--port', help="Port to run processor webservice on", default=5010)
-def _start_processor(port):
+@click.option('-d', '--debug', help="Whether to run in debug mode", is_flag=True, default=True)
+def _start_processor(port, debug):
     """
     Start a server exposing the processors as webservices
     """
-    create_processor_ws().run(port=port)
+    create_processor_ws().run(port=port, debug=debug)
+
+@server_cli.command('wrap-executable')
+@click.option('-p', '--port', help="Port to run processor webservice on", default=5010)
+@click.option('-d', '--debug', help="Whether to run in debug mode", is_flag=True, default=True)
+@click.argument('executable')
+def _wrap_executable(port, debug, executable):
+    """
+    Start a server wrapping the MP CLI
+    """
+    create_wrap_executable(executable).run(port=port, debug=debug)
 
 @server_cli.command('repository')
 @click.option('-p', '--port', help="Port to run repository webservice on", default=5000)
-def _start_repository(port):
+@click.option('-d', '--debug', help="Whether to run in debug mode", is_flag=True, default=True)
+def _start_repository(port, debug):
     """
     Start a minimal repository.
     """
-    create_repository_ws().run(port=port)
+    create_repository_ws().run(port=port, debug=debug)

--- a/ocrd/decorators.py
+++ b/ocrd/decorators.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import json
 
 import click
 
@@ -6,13 +8,19 @@ from ocrd.resolver import Resolver
 from ocrd.processor.base import run_processor
 
 def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_dir=None, cache_enabled=True, *args, **kwargs):
-    if mets.find('://') == -1:
-        mets = 'file://' + mets
-    if mets.startswith('file://') and not os.path.exists(mets[len('file://'):]):
-        raise Exception("File does not exist: %s" % mets)
-    resolver = Resolver(cache_enabled=cache_enabled)
-    workspace = resolver.workspace_from_url(mets, working_dir)
-    run_processor(processorClass, ocrd_tool, mets, workspace=workspace, *args, **kwargs)
+    if kwargs['dump_json']:
+        print(json.dumps(processorClass(None).ocrd_tool))
+    else:
+        if mets is None:
+            print('Error: Missing option "-m" / "--mets"')
+            sys.exit(1)
+        if mets.find('://') == -1:
+            mets = 'file://' + mets
+        if mets.startswith('file://') and not os.path.exists(mets[len('file://'):]):
+            raise Exception("File does not exist: %s" % mets)
+        resolver = Resolver(cache_enabled=cache_enabled)
+        workspace = resolver.workspace_from_url(mets, working_dir)
+        run_processor(processorClass, ocrd_tool, mets, workspace=workspace, **kwargs)
 
 def ocrd_cli_options(f):
     """
@@ -28,14 +36,14 @@ def ocrd_cli_options(f):
             print(mets_url)
     """
     params = [
-        click.option('-m', '--mets', help="METS URL to validate", required=True),
+        click.option('-m', '--mets', help="METS URL to validate"),
         click.option('-w', '--working-dir', help="Working Directory"),
         click.option('-I', '--input-file-grp', help='File group(s) used as input.', default='INPUT'),
         click.option('-O', '--output-file-grp', help='File group(s) used as output.', default='OUTPUT'),
         click.option('-g', '--group-id', help="mets:file GROUPID"),
         click.option('-o', '--output-mets', help="METS URL to write resulting METS to"),
         click.option('-p', '--parameter', type=click.Path()),
-        click.option('-J', '--ocrd-tool', help="Dump tool description as JSON and exit", is_flag=True, default=False),
+        click.option('-J', '--dump-json', help="Dump tool description as JSON and exit", is_flag=True, default=False),
         click.option('-l', '--log-level', help="Log level", type=click.Choice(['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']), default='INFO'),
     ]
     for param in params:

--- a/ocrd/webservice/wrap_executable.py
+++ b/ocrd/webservice/wrap_executable.py
@@ -1,0 +1,39 @@
+from flask import Flask, request
+import json
+import os
+import tempfile
+import subprocess
+import shutil
+from werkzeug.utils import secure_filename
+
+from ocrd import run_executable, TMP_PREFIX
+
+UPLOAD_FOLDER = tempfile.mkdtemp(prefix=TMP_PREFIX)
+
+def create(executable, app=Flask(__name__)):
+
+    if not shutil.which(executable):
+        raise Exception("No such command: %s" % executable)
+
+    ocrd_tool = json.loads(subprocess.check_output([executable, '-J']).decode('utf-8'))
+
+    @app.route('/', methods=['GET'])
+    def _get_ocrd_tool():
+        return json.dumps(ocrd_tool)
+
+    @app.route('/', methods=['POST'])
+    def _run_processor():
+        if 'mets' not in request.files and 'mets' not in request.form:
+            return "Must pass either 'mets' form parameter or send a file 'mets' with form", 400
+        elif 'mets' in request.files:
+            file = request.files['mets']
+            savepath = os.path.join(UPLOAD_FOLDER, file.filename)
+            file.save(savepath)
+            mets_url = 'file://' + savepath
+        else:
+            mets_url = request.form.mets
+        run_executable(executable, mets_url=mets_url, **request.form)
+        return json.dumps(mets_url), 200
+
+    return app
+


### PR DESCRIPTION
This is blocked by OCR-D/spec#30 and needs cleaning up, so WIP for now.

Basically, it allows to do

```
ocrd server wrap-executable --port 1234 ocrd-kraken-binary
```

which will wrap any spec-compliant executable, inspect its [tool description](https://ocr-d.github.io/ocrd_tool) and start a webservice for it that adheres to [our HTTP API specs](https://ocr-d.github.io/swagger).

Then these calls can be used for the same thing:

```
ocrd-kraken-binary -m /path/to/mets.xml

==

http --form POST http://localhost:1234 mets@/path/to/mets.xml
```

We really only need the names of the executables provided, the rest (CLI call, workflow integration, HTTP service, Swagger, service list etc) can be generated from introspection.