### PR TITLE
:fire: Use the directory of an existing mets.xml file as the working dir

### DIFF
--- a/ocrd/resolver.py
+++ b/ocrd/resolver.py
@@ -159,10 +159,10 @@ class Resolver(object):
         if url.startswith('file://'):
             self._copy_or_symlink(url[len('file://'):], outfilename, prefer_symlink)
         else:
+            response = requests.get(url)
+            if response.status_code != 200:
+                raise Exception("Not found: %s (HTTP %d)" % (url, response.status_code))
             with open(outfilename, 'wb') as outfile:
-                response = requests.get(url)
-                if response.status_code != 200:
-                    raise Exception("Not found: %s (HTTP %d)" % (url, response.status_code))
                 outfile.write(response.content)
 
         return outfilename

--- a/ocrd/resolver.py
+++ b/ocrd/resolver.py
@@ -213,7 +213,7 @@ class Resolver(object):
             else:
                 self.download_to_directory(directory, mets_url, basename=mets_basename, prefer_symlink=False)
 
-        workspace = Workspace(self, directory)
+        workspace = Workspace(self, directory, mets_basename=mets_basename)
 
         if download_local or download:
             for file_grp in workspace.mets.file_groups:

--- a/ocrd/resolver.py
+++ b/ocrd/resolver.py
@@ -167,7 +167,7 @@ class Resolver(object):
 
         return outfilename
 
-    def workspace_from_url(self, mets_url, directory=None, clobber_mets=False, mets_basename='mets.xml', download=False, download_local=False):
+    def workspace_from_url(self, mets_url, directory=None, clobber_mets=False, mets_basename=None, download=False, download_local=False):
         """
         Create a workspace from a METS by URL.
 
@@ -195,6 +195,13 @@ class Resolver(object):
             else:
                 directory = tempfile.mkdtemp(prefix=TMP_PREFIX)
                 log.debug("Creating workspace '%s' for METS @ <%s>", directory, mets_url)
+
+        # if mets_basename is not given, use the last URL segment of the mets_url
+        if mets_basename is None:
+            mets_basename = mets_url \
+                .rsplit('/', 1)[-1] \
+                .split('?')[0] \
+                .split('#')[0]
 
         mets_fpath = os.path.join(directory, mets_basename)
         log.debug("Copying mets url '%s' to '%s'", mets_url, mets_fpath)

--- a/ocrd/resolver.py
+++ b/ocrd/resolver.py
@@ -197,7 +197,7 @@ class Resolver(object):
                 log.debug("Creating workspace '%s' for METS @ <%s>", directory, mets_url)
 
         mets_fpath = os.path.join(directory, mets_basename)
-        log.debug("Using existing workspace '%s'", mets_fpath)
+        log.debug("Copying mets url '%s' to '%s'", mets_url, mets_fpath)
         if 'file://' + mets_fpath == mets_url:
             log.debug("Target and source mets are identical")
         else:

--- a/ocrd/resolver.py
+++ b/ocrd/resolver.py
@@ -175,16 +175,26 @@ class Resolver(object):
         """
         if directory is not None and not directory.startswith('/'):
             directory = os.path.abspath(directory)
+
         if mets_url is None:
             if directory is None:
                 raise Exception("Must pass mets_url and/or directory to workspace_from_url")
             else:
                 mets_url = 'file://%s/%s' % (directory, mets_basename)
         if mets_url.find('://') == -1:
-            mets_url = 'file://' + os.path.abspath(mets_url)
+            # resolve to absolute
+            mets_url = os.path.abspath(mets_url)
+            mets_url = 'file://' + mets_url
         if directory is None:
-            directory = tempfile.mkdtemp(prefix=TMP_PREFIX)
-            log.debug("Creating workspace '%s' for METS @ <%s>", directory, mets_url)
+            # if mets_url is a file-url assume working directory to be  where
+            # the mets.xml resides
+            if mets_url.startswith('file://'):
+                # if directory was not given and mets_url is a file assume that
+                # directory should be the directory where the mets.xml resides
+                directory = os.path.dirname(mets_url[len('file://'):])
+            else:
+                directory = tempfile.mkdtemp(prefix=TMP_PREFIX)
+                log.debug("Creating workspace '%s' for METS @ <%s>", directory, mets_url)
 
         mets_fpath = os.path.join(directory, mets_basename)
         log.debug("Using existing workspace '%s'", mets_fpath)

--- a/ocrd/validator.py
+++ b/ocrd/validator.py
@@ -165,7 +165,7 @@ class WorkspaceValidator(object):
             self.report.add_error("METS has no unique identifier")
 
     def _validate_pixel_density(self):
-        for f in self.mets.find_files(mimetype='image/tiff'):
+        for f in [f for f in self.mets.find_files() if f.mimetype.startswith('image/')]:
             exif = self.workspace.resolve_image_exif(f.url)
             for k in ['xResolution', 'yResolution']:
                 v = exif.__dict__.get(k)

--- a/ocrd/workspace.py
+++ b/ocrd/workspace.py
@@ -20,7 +20,7 @@ class Workspace(object):
 
         directory (string) : Folder to work in
         mets (:class:`OcrdMets`) : OcrdMets representing this workspace. Loaded from 'mets.xml' if ``None``.
-        mets_basename (string) : Basename of the METS XML file. Default: mets.xml
+        mets_basename (string) : Basename of the METS XML file. Default: Last URL segment of the mets_url.
     """
 
     def __init__(self, resolver, directory, mets=None, mets_basename='mets.xml'):

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -8,7 +8,6 @@ from ocrd.validator import (
     ParameterValidator,
     OcrdToolValidator
 )
-METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/mets_one_file.xml')
 
 class TestValidationReport(TestCase):
 
@@ -32,7 +31,7 @@ class TestWorkspaceValidator(TestCase):
         self.resolver = Resolver()
 
     def runTest(self):
-        report = WorkspaceValidator.validate_url(self.resolver, METS_HEROLD_SMALL)
+        report = WorkspaceValidator.validate_url(self.resolver, assets.url_of('SBB0000F29300010000/mets_one_file.xml'))
         print(report.to_xml())
 
 class TestOcrdToolValidator(TestCase):
@@ -41,13 +40,15 @@ class TestOcrdToolValidator(TestCase):
         report = OcrdToolValidator.validate_json(json.loads('''
         {
             "git_url": "https://github.com/ocr-d/foo",
-            "tools": [
-                {
-                    "xxx binary": "foo",
+            "version": "0.0.1",
+            "tools": {
+                "ocrd-xyz": {
+                    "executable": "ocrd-xyz",
                     "description": "bars all the foos",
-                    "category": "preprocess"
+                    "categories": ["Layout analysis"],
+                    "steps": ["layout/analysis"]
                 }
-            ]
+            }
         }
         '''))
         print(report.to_xml())


### PR DESCRIPTION
…if none other was specified.

This will use the "original" mets file for output files/file groups and write files to the directory of the original files.

Less clean but more intuitive.

Needs testing to make sure we're not clobbering files.