### PR TITLE
mets: record creation date and core version on creating METS, fix #147

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Changed:
+
+  * Creating METS from scratch will set creator agent and creation date, #147
+
 ## [0.8.3] - 2018-09-20
 
 Changed:

--- a/ocrd/model/mets-empty.xml
+++ b/ocrd/model/mets-empty.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-0.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version17/mets.v1-7.xsd http://www.loc.gov/mix/v10 http://www.loc.gov/standards/mix/mix10/mix10.xsd">
-  <mets:metsHdr CREATEDATE="2017-11-30T16:18:26">
-    <mets:agent OTHERTYPE="SOFTWARE" ROLE="CREATOR" TYPE="OTHER">
-      <mets:name>DFG-Koordinierungsprojekt zur Weiterentwicklung von Verfahren der Optical Character Recognition (OCR-D)</mets:name>
-      <mets:note>OCR-D</mets:note>
-    </mets:agent>
-  </mets:metsHdr>
-  <mets:dmdSec ID="DMDLOG_0001">
-    <mets:mdWrap MDTYPE="MODS">
-      <mets:xmlData>
-        <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
-        </mods:mods>
-      </mets:xmlData>
-    </mets:mdWrap>
-  </mets:dmdSec>
-  <mets:amdSec ID="AMD">
-  </mets:amdSec>
-  <mets:fileSec>
-  </mets:fileSec>
+    <mets:metsHdr CREATEDATE="{{ NOW }}">
+        <mets:agent TYPE="OTHER" OTHERTYPE="SOFTWARE" ROLE="CREATOR">
+            <mets:name>ocrd/core v{{ VERSION }}</mets:name>
+        </mets:agent>
+    </mets:metsHdr>
+    <mets:dmdSec ID="DMDLOG_0001">
+        <mets:mdWrap MDTYPE="MODS">
+            <mets:xmlData>
+                <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
+                </mods:mods>
+            </mets:xmlData>
+        </mets:mdWrap>
+    </mets:dmdSec>
+    <mets:amdSec ID="AMD">
+    </mets:amdSec>
+    <mets:fileSec>
+    </mets:fileSec>
 </mets:mets>
 

--- a/ocrd/model/ocrd_mets.py
+++ b/ocrd/model/ocrd_mets.py
@@ -1,9 +1,26 @@
-from ocrd.constants import NAMESPACES as NS, TAG_METS_FILE, TAG_METS_FILEGRP, IDENTIFIER_PRIORITY, TAG_MODS_IDENTIFIER
+from datetime import datetime
+
+from ocrd.constants import (
+    NAMESPACES as NS,
+    TAG_METS_FILE,
+    TAG_METS_FILEGRP,
+    IDENTIFIER_PRIORITY,
+    TAG_MODS_IDENTIFIER,
+    METS_XML_EMPTY,
+    VERSION
+)
 
 from .ocrd_xml_base import OcrdXmlDocument, ET
 from .ocrd_file import OcrdFile
 
 class OcrdMets(OcrdXmlDocument):
+
+    @staticmethod
+    def empty_mets():
+        tpl = METS_XML_EMPTY.decode('utf-8')
+        tpl = tpl.replace('{{ VERSION }}', VERSION)
+        tpl = tpl.replace('{{ NOW }}', '%s' % datetime.now())
+        return OcrdMets(content=tpl.encode('utf-8'))
 
     def __init__(self, file_by_id=None, **kwargs):
         super(OcrdMets, self).__init__(**kwargs)

--- a/ocrd/resolver.py
+++ b/ocrd/resolver.py
@@ -4,7 +4,7 @@ from zipfile import ZipFile
 import tempfile
 import requests
 
-from ocrd.constants import METS_XML_EMPTY, TMP_PREFIX, EXT_TO_MIME
+from ocrd.constants import TMP_PREFIX, EXT_TO_MIME
 from ocrd.utils import getLogger, safe_filename
 from ocrd.workspace import Workspace
 from ocrd.model import OcrdMets
@@ -221,7 +221,7 @@ class Resolver(object):
         mets_fpath = os.path.join(directory, mets_basename)
         if not clobber_mets and os.path.exists(mets_fpath):
             raise Exception("Not clobbering existing mets.xml in '%s'." % directory)
-        mets = OcrdMets(content=METS_XML_EMPTY)
+        mets = OcrdMets.empty_mets()
         with open(mets_fpath, 'wb') as fmets:
             log.info("Writing %s", mets_fpath)
             fmets.write(mets.to_xml(xmllint=True))
@@ -244,7 +244,7 @@ class Resolver(object):
         if not clobber_mets and os.path.exists(os.path.join(directory, 'mets.xml')):
             raise Exception("Not clobbering existing mets.xml in '%s'." % directory)
 
-        mets = OcrdMets(content=METS_XML_EMPTY)
+        mets = OcrdMets.empty_mets()
 
         if not os.path.exists(directory):
             os.makedirs(directory)

--- a/test/model/test_ocrd_mets.py
+++ b/test/model/test_ocrd_mets.py
@@ -1,6 +1,6 @@
 from test.base import TestCase, main, assets
 
-from ocrd.constants import MIMETYPE_PAGE, METS_XML_EMPTY
+from ocrd.constants import MIMETYPE_PAGE, VERSION
 from ocrd.model import OcrdMets
 
 class TestOcrdMets(TestCase):
@@ -14,10 +14,13 @@ class TestOcrdMets(TestCase):
         self.assertEqual(self.mets.unique_identifier, 'foo', 'Right identifier after change')
 
     def test_unique_identifier_from_nothing(self):
-        self.mets = OcrdMets(content=METS_XML_EMPTY)
-        self.assertEqual(self.mets.unique_identifier, None, 'no identifier')
-        self.mets.unique_identifier = 'foo'
-        self.assertEqual(self.mets.unique_identifier, 'foo', 'Right identifier after change')
+        mets = OcrdMets.empty_mets()
+        self.assertEqual(mets.unique_identifier, None, 'no identifier')
+        mets.unique_identifier = 'foo'
+        self.assertEqual(mets.unique_identifier, 'foo', 'Right identifier after change')
+        as_string = mets.to_xml().decode('utf-8')
+        self.assertIn('ocrd/core v%s' % VERSION, as_string)
+        self.assertIn('CREATEDATE="2018-', as_string)
 
     def test_file_groups(self):
         self.assertEqual(len(self.mets.file_groups), 17, '17 file groups')


### PR DESCRIPTION
When running

```sh
ocrd workspace init
```

this is the output now:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:                  
schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-0.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.
xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version17/mets.v1-7.xsd http://www.loc.gov/mix/v10 http://www.loc.gov/standards/mix/mix10/mix10.xsd">
    <mets:metsHdr CREATEDATE="2018-09-20 14:14:30.849365">
        <mets:agent TYPE="OTHER" OTHERTYPE="SOFTWARE" ROLE="CREATOR">
            <mets:name>ocrd/core v0.8.3</mets:name>
        </mets:agent>
    </mets:metsHdr>
    <mets:dmdSec ID="DMDLOG_0001">
        <mets:mdWrap MDTYPE="MODS">
            <mets:xmlData>
                <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
                </mods:mods>
            </mets:xmlData>
        </mets:mdWrap>
    </mets:dmdSec>
    <mets:amdSec ID="AMD">
    </mets:amdSec>
    <mets:fileSec>
    </mets:fileSec>
</mets:mets>
```

`CREATEDATE` and mets:agent are set dynamically now.