### PR TITLE
[WIP] workspace backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Changed:
+
+  * `ocrd process` interface change, #205
+
 Fixed:
 
   * Grayscale images can be handled by workspace correctly now, #211

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Changed:
+
+  * Depend on pillow >= 5.3.0 to mitigate https://github.com/python-pillow/Pillow/issues/2926
+
 ## [0.11.0] - 2018-11-21
 
 Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.11.0] - 2018-11-21
+
 Changed:
 
   * `ocrd process` interface change, #205
@@ -359,6 +361,7 @@ Fixed
 Initial Release
 
 <!-- link-labels -->
+[0.11.0]: ../../compare/v0.11.0...v0.10.0
 [0.10.0]: ../../compare/v0.10.0...v0.9.0
 [0.9.0]: ../../compare/v0.9.0...v0.8.8
 [0.8.8]: ../../compare/v0.8.8...v0.8.7

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ gh-pages:
 
 pyclean:
 	rm -f **/*.pyc
-	find ocrd -name '__pycache__' -exec rm -rf '{}' \;
+	find . -name '__pycache__' -exec rm -rf '{}' \;
 	rm -rf .pytest_cache
 
 test-profile:

--- a/ocrd/__init__.py
+++ b/ocrd/__init__.py
@@ -4,3 +4,4 @@ from ocrd.constants import * # pylint: disable=wildcard-import
 from ocrd.resolver import Resolver
 from ocrd.validator import WorkspaceValidator, OcrdToolValidator
 from ocrd.workspace import Workspace
+from ocrd.workspace_backup import WorkspaceBackupManager

--- a/ocrd/cli/__init__.py
+++ b/ocrd/cli/__init__.py
@@ -7,10 +7,12 @@ from ocrd.cli.process import process_cli
 # TODO server CLI disabled
 #  from ocrd.cli.server import server_cli
 from ocrd.cli.bashlib import bashlib_cli
+from ocrd.decorators import ocrd_loglevel
 
 @click.group()
 @click.version_option()
-def cli():
+@ocrd_loglevel
+def cli(**kwargs): # pylint: disable=unused-argument
     """
     CLI to OCR-D
     """

--- a/ocrd/cli/process.py
+++ b/ocrd/cli/process.py
@@ -104,7 +104,7 @@ def process_cli(**kwargs):
         )
 
         # check return code
-        if returncode is not None:
+        if returncode != 0:
             raise Exception("%s exited with non-zero return value %s" % (task.executable, returncode))
 
         log.info("Finished processing task '%s'", task)

--- a/ocrd/cli/workspace.py
+++ b/ocrd/cli/workspace.py
@@ -25,13 +25,13 @@ pass_workspace = click.make_pass_decorator(WorkspaceCtx)
 @click.group("workspace")
 @click.option('-d', '--directory', envvar='WORKSPACE_DIR', default='.', type=click.Path(file_okay=False), metavar='WORKSPACE_DIR', help='Changes the workspace folder location.', show_default=True)
 @click.option('-M', '--mets-basename', default="mets.xml", help='The basename of the METS file.', show_default=True)
-@click.option('--no-backup', default=False, help="Don't backup mets.xml whenever it is saved.", is_flag=True)
+@click.option('--backup', default=False, help="Backup mets.xml whenever it is saved.", is_flag=True)
 @click.pass_context
-def workspace_cli(ctx, directory, mets_basename, no_backup):
+def workspace_cli(ctx, directory, mets_basename, backup):
     """
     Working with workspace
     """
-    ctx.obj = WorkspaceCtx(os.path.abspath(directory), mets_basename, automatic_backup=not(no_backup))
+    ctx.obj = WorkspaceCtx(os.path.abspath(directory), mets_basename, automatic_backup=backup)
 
 # ----------------------------------------------------------------------
 # ocrd workspace validate

--- a/ocrd/cli/workspace.py
+++ b/ocrd/cli/workspace.py
@@ -14,8 +14,6 @@ class WorkspaceCtx(object):
         self.directory = directory
         self.resolver = Resolver()
         self.mets_basename = mets_basename
-        self.config = {}
-        self.verbose = False
 
 pass_workspace = click.make_pass_decorator(WorkspaceCtx)
 
@@ -26,17 +24,12 @@ pass_workspace = click.make_pass_decorator(WorkspaceCtx)
 @click.group("workspace")
 @click.option('-d', '--directory', envvar='WORKSPACE_DIR', default='.', type=click.Path(file_okay=False), metavar='WORKSPACE_DIR', help='Changes the workspace folder location.', show_default=True)
 @click.option('-M', '--mets-basename', default="mets.xml", help='The basename of the METS file.', show_default=True)
-@click.option('-c', '--config', nargs=2, multiple=True, metavar='KEY VALUE', help='Set a config key/value pair.')
-@click.option('-v', '--verbose', is_flag=True, help='Enables verbose mode.')
 @click.pass_context
-def workspace_cli(ctx, directory, mets_basename, config, verbose):
+def workspace_cli(ctx, directory, mets_basename):
     """
     Working with workspace
     """
     ctx.obj = WorkspaceCtx(os.path.abspath(directory), mets_basename)
-    ctx.obj.verbose = verbose
-    for key, value in config:
-        ctx.obj.config[key] = value
 
 # ----------------------------------------------------------------------
 # ocrd workspace validate

--- a/ocrd/cli/workspace.py
+++ b/ocrd/cli/workspace.py
@@ -43,6 +43,7 @@ def workspace_cli(ctx, directory, mets_basename, no_backup):
 
 ''')
 @pass_workspace
+@click.argument('mets_url')
 def validate_workspace(ctx, mets_url=None):
     report = WorkspaceValidator.validate_url(ctx.resolver, mets_url, directory=ctx.directory)
     print(report.to_xml())

--- a/ocrd/constants.py
+++ b/ocrd/constants.py
@@ -53,3 +53,5 @@ OCRD_OAS3_SPEC = yaml.load(resource_string(__name__, 'model/yaml/ocrd_oas3.spec.
 OCRD_TOOL_SCHEMA = yaml.load(resource_string(__name__, 'model/yaml/ocrd_tool.schema.yml'))
 
 BASHLIB_FILENAME = resource_filename(__name__, 'lib.bash')
+
+BACKUP_DIR = '.backup'

--- a/ocrd/processor/base.py
+++ b/ocrd/processor/base.py
@@ -74,7 +74,7 @@ def run_processor(
     workspace.save_mets()
 
 def run_cli(
-        binary,
+        executable,
         mets_url=None,
         resolver=None,
         workspace=None,
@@ -84,12 +84,12 @@ def run_cli(
         output_file_grp=None,
         parameter=None,
         working_dir=None,
-): # pylint: disable=unused-argument
+):
     """
     Create a workspace for mets_url and run MP CLI through it
     """
     workspace = _get_workspace(workspace, resolver, mets_url, working_dir)
-    args = [binary, '--working-dir', workspace.directory]
+    args = [executable, '--working-dir', workspace.directory]
     if mets_url:
         args += ['--mets', mets_url]
     if log_level:
@@ -103,7 +103,7 @@ def run_cli(
     if parameter:
         args += ['--parameter', parameter]
     log.debug("Running subprocess '%s'", ' '.join(args))
-    subprocess.call(args)
+    return subprocess.call(args)
 
 class Processor(object):
     """

--- a/ocrd/workspace.py
+++ b/ocrd/workspace.py
@@ -124,14 +124,6 @@ class Workspace(object):
         """
         shutil.move(fobj.local_filename, os.path.join(self.directory, dst))
 
-    def persist(self):
-        """
-        Persist the workspace using the resolver. Uploads the files in the
-        OUTPUT group to the data repository, sets their URL accordingly.
-        """
-        self.save_mets()
-        raise Exception("NIH")
-
     def save_mets(self):
         """
         Write out the current state of the METS file.

--- a/ocrd/workspace.py
+++ b/ocrd/workspace.py
@@ -25,7 +25,7 @@ class Workspace(object):
         mets_basename (string) : Basename of the METS XML file. Default: Last URL segment of the mets_url.
     """
 
-    def __init__(self, resolver, directory, mets=None, mets_basename='mets.xml', automatic_backup=True):
+    def __init__(self, resolver, directory, mets=None, mets_basename='mets.xml', automatic_backup=False):
         self.resolver = resolver
         self.directory = directory
         self.mets_target = os.path.join(directory, mets_basename)

--- a/ocrd/workspace.py
+++ b/ocrd/workspace.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from ocrd.model import OcrdMets, OcrdExif
 from ocrd.utils import getLogger
+
 log = getLogger('ocrd.workspace')
 
 class Workspace(object):

--- a/ocrd/workspace_backup.py
+++ b/ocrd/workspace_backup.py
@@ -11,8 +11,6 @@ from .constants import BACKUP_DIR
 from .model.ocrd_mets import OcrdMets
 from .utils import getLogger
 
-log = getLogger('ocrd.workspace_backup')
-
 def _chksum(s):
     return hashlib.sha256(s).hexdigest()
 
@@ -53,6 +51,7 @@ class WorkspaceBackupManager(object):
         """
         Restore mets.xml to previous state
         """
+        log = getLogger('ocrd.workspace_backup.restore')
         bak = None
         if isdir(chksum):
             bak = abspath(chksum)
@@ -76,6 +75,7 @@ class WorkspaceBackupManager(object):
         """
         Create a backup in <self.backup_directory>
         """
+        log = getLogger('ocrd.workspace_backup.add')
         mets_str = self.workspace.mets.to_xml()
         chksum = _chksum(mets_str)
         backups = self.list()
@@ -107,6 +107,7 @@ class WorkspaceBackupManager(object):
         """
         Restore to last version
         """
+        log = getLogger('ocrd.workspace_backup.undo')
         backups = self.list()
         if backups:
             last_backup = backups[0]

--- a/ocrd/workspace_backup.py
+++ b/ocrd/workspace_backup.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+import time
+from os import makedirs
+from os.path import join, basename, getsize, isdir, abspath
+from glob import glob
+import sys
+from shutil import copy
+import hashlib
+
+from .constants import BACKUP_DIR
+from .model.ocrd_mets import OcrdMets
+from .utils import getLogger
+
+log = getLogger('ocrd.workspace_backup')
+
+def _chksum(s):
+    return hashlib.sha256(s).hexdigest()
+
+class WorkspaceBackup(object):
+
+    @classmethod
+    def from_path(cls, d):
+        mets_file = join(d, 'mets.xml')
+        (chksum, lastmod) = basename(d).split('.', maxsplit=1)
+        size = getsize(mets_file)
+        mets_xml = OcrdMets(filename=mets_file)
+        return cls(chksum, float(lastmod), size, mets_xml)
+
+    def __init__(self, chksum, lastmod, size, mets_xml):
+        self.chksum = chksum
+        self.lastmod = datetime.fromtimestamp(lastmod)
+        self.size = size
+        self.mets_xml = mets_xml
+
+    def __str__(self):
+        return '%s - %s - %8s B %s' % (
+            self.chksum[0:7],
+            self.lastmod.strftime('%Y-%m-%d %H:%M:%S'),
+            self.size,
+            self.mets_xml.file_groups
+            )
+
+class WorkspaceBackupManager(object):
+    """
+    Manages backups of a workspace in a directory BACKUP_DIR
+    """
+
+    def __init__(self, workspace):
+        self.workspace = workspace
+        self.backup_directory = join(workspace.directory, BACKUP_DIR)
+
+    def restore(self, chksum, choose_first=False):
+        """
+        Restore mets.xml to previous state
+        """
+        bak = None
+        if isdir(chksum):
+            bak = abspath(chksum)
+        else:
+            candidates = glob(join(self.backup_directory, '%s*' % chksum))
+            if not candidates:
+                log.error("No backup found: %s" % chksum)
+                return
+            if len(candidates) > 1 and not choose_first:
+                log.error("Not unique, could be\n%s" % '\n'.join(candidates))
+                return
+            bak = candidates[0]
+        self.add()
+        log.info("Restoring from %s/mets.xml" % bak)
+        src = join(bak, 'mets.xml')
+        dest = join(self.workspace.directory, 'mets.xml')
+        log.debug('cp "%s" "%s"', src, dest)
+        copy(src, dest)
+
+    def add(self):
+        """
+        Create a backup in <self.backup_directory>
+        """
+        mets_str = self.workspace.mets.to_xml()
+        chksum = _chksum(mets_str)
+        backups = self.list()
+        if backups and backups[0].chksum == chksum:
+            log.info('No changes since last backup: %s' % backups[0])
+        else:
+            if sys.version_info.major == 2:
+                timestamp = time.time()
+            else:
+                timestamp = datetime.now().timestamp()
+            d = join(self.backup_directory, '%s.%s' % (chksum, timestamp))
+            mets_file = join(d, 'mets.xml')
+            log.info("Backing up to %s" % mets_file)
+            makedirs(d)
+            with open(mets_file, 'wb') as f:
+                f.write(mets_str)
+
+    def list(self):
+        """
+        List all backups as WorkspaceBackup objects, sorted descending by lastmod.
+        """
+        backups = []
+        for d in glob(join(self.backup_directory, '*')):
+            backups.append(WorkspaceBackup.from_path(d))
+        backups.sort(key=lambda b: b.lastmod, reverse=True)
+        return backups
+
+    def undo(self):
+        """
+        Restore to last version
+        """
+        backups = self.list()
+        if backups:
+            last_backup = backups[0]
+            self.restore(last_backup.chksum, choose_first=True)
+        else:
+            log.info("No backups, nothing to undo.")

--- a/ocrd/workspace_backup.py
+++ b/ocrd/workspace_backup.py
@@ -68,7 +68,7 @@ class WorkspaceBackupManager(object):
         self.add()
         log.info("Restoring from %s/mets.xml" % bak)
         src = join(bak, 'mets.xml')
-        dest = join(self.workspace.directory, 'mets.xml')
+        dest = self.workspace.mets_target
         log.debug('cp "%s" "%s"', src, dest)
         copy(src, dest)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ bagit_profile >= 1.2.0
 click >=7<8
 requests
 lxml
-Pillow
+Pillow >= 5.3.0
 numpy
 opencv-python
 Flask

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'Flask',
-        'Pillow',
+        'Pillow >= 5.3.0',
         'bagit >= 1.7.0',
         'bagit_profile >= 1.2.0',
         'click',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with codecs.open('README.rst', encoding='utf-8') as f:
 
 setup(
     name='ocrd',
-    version='0.10.0',
+    version='0.11.0',
     description='OCR-D framework',
     long_description=README,
     author='Kay-Michael Würzner, Konstantin Baierer',


### PR DESCRIPTION
Here's an implementation of OCR-D/spec#90.

* mets.xml is backed up to a dir '.backup/${sha256 of mets.xml}.${timestamp}'
* <del>backups automatically created on workspace.save_mets unless overridden (`--no-backup` to `ocrd workspace`)</del> backups can be enabled with `--backup` to `ocrd workspace`)
* `ocrd workspace backup list` lists something like:

```
a13cef8 - 2018-11-01 19:51:22 -    32850 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE', 'FOOBAR']
ab4005d - 2018-11-01 19:51:18 -    32705 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE', 'FOOBAR']
54609c9 - 2018-11-01 19:50:37 -    32409 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE', 'FOOBAR']
039ac05 - 2018-11-01 19:50:25 -    32249 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE']
16dca62 - 2018-11-01 19:50:17 -    32442 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE', 'FOOBAR']
54609c9 - 2018-11-01 19:44:42 -    32409 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE', 'FOOBAR']
8e73567 - 2018-11-01 19:44:27 -    32724 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE', 'FOOBAR']
c241c8b - 2018-11-01 19:38:34 -    32584 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE', 'FOOBAR']
4a47526 - 2018-11-01 19:34:49 -    20902 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'FOOBAR']
039ac05 - 2018-11-01 18:11:31 -    32249 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE']
e201bc7 - 2018-11-01 17:12:31 -    20709 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN']
d8e597f - 2018-11-01 17:11:12 -    20726 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN']
e201bc7 - 2018-11-01 16:54:49 -    20709 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN']
039ac05 - 2018-11-01 16:49:43 -    32249 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE']
e201bc7 - 2017-07-26 18:43:03 -    20709 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN']
a38765f - 2009-04-30 12:29:43 -    32262 B ['OCR-D-IMG', 'OCR-D-IMG-BIN-KRAKEN', 'OCR-D-SEG-LINE']
```

The first column are first 7 chars of sha256, that's usually enough (again: git).

Can be restored with

```
ocrd workspace backup restore d8e597f
```

or

```
ocrd workspace backup undo
```

to restore last.
