### PR TITLE
resolver.workspace_from_url: cover relative paths, too

### DIFF
--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -146,7 +146,7 @@ class Resolver():
 
         if download:
             for f in workspace.mets.find_files():
-                workspace.download_file(f)
+                workspace.download_url(f.url, basename='%s/%s' % (f.fileGrp, f.ID))
 
         return workspace
 


### PR DESCRIPTION
This (at least partially) fixes #96, i.e. `workspace_from_url` failing to download files that had relative paths. The reason was that `workspace.download_file` does not know anything about `baseurl`, i.e. it cannot concatenate the source path before copying locally. In contrast, `download_url` does wrap this case correctly.