### PR TITLE
improve bashlib ocrd__parse_argv:

### DIFF
--- a/ocrd/bashlib/src/parse_argv.bash
+++ b/ocrd/bashlib/src/parse_argv.bash
@@ -23,37 +23,38 @@ ocrd__parse_argv () {
             -l|--log-level) ocrd__argv[log_level]=$2 ; shift ;;
             -h|--help|--usage) ocrd__usage; exit ;;
             -J|--dump-json) ocrd__dumpjson; exit ;;
-            -p|--parameter) ocrd__argv[parameter]=$2 ; shift ;;
+            -p|--parameter) ocrd__argv[parameter]="$2" ; shift ;;
             -g|--page-id) ocrd__argv[page_id]=$2 ; shift ;;
             -O|--output-file-grp) ocrd__argv[output_file_grp]=$2 ; shift ;;
             -I|--input-file-grp) ocrd__argv[input_file_grp]=$2 ; shift ;;
-            -w|--working-dir) ocrd__argv[working_dir]=$2 ; shift ;;
-            -m|--mets) ocrd__argv[mets_file]=$2 ; shift ;;
+            -w|--working-dir) ocrd__argv[working_dir]=$(realpath "$2") ; shift ;;
+            -m|--mets) ocrd__argv[mets_file]=$(realpath "$2") ; shift ;;
             -V|--version) ocrd ocrd-tool "$OCRD_TOOL_JSON" version; exit ;;
             *) ocrd__raise "Unknown option '$1'" ;;
         esac
         shift
     done
 
-    if [[ "${ocrd__argv[mets_file]:-}" = "" ]];then
-        ocrd__raise "Option -m/--mets-file required"
+    if [[ ! -r "${ocrd__argv[mets_file]:=$PWD/mets.xml}" ]];then
+        ocrd__raise "METS '${ocrd__argv[mets_file]}' not readable. Use -m/--mets-file to set correctly"
     fi
 
-    if [[ "${ocrd__argv[working_dir]:-}" = "" ]];then
-        ocrd__argv[working_dir]=$(dirname "${ocrd__argv[mets_file]}")
+    if [[ ! -d "${ocrd__argv[working_dir]:=$(dirname "${ocrd__argv[mets_file]}")}" ]];then
+        ocrd__raise "workdir '${ocrd__argv[working_dir]}' not a directory. Use -w/--working-dir to set correctly"
     fi
 
-    if [[ "${ocrd__argv[log_level]:-}" = "" ]];then
-        ocrd__argv[log_level]="INFO"
+    if [[ ! "${ocrd__argv[log_level]:=INFO}" =~ OFF|ERROR|WARN|INFO|DEBUG|TRACE ]];then
+        ocrd__raise "log level '${ocrd__argv[log_level]}' is invalid"
     fi
 
-    if [[ "${ocrd__argv[input_file_grp]:-}" = "" ]];then
-        ocrd__argv[input_file_grp]="OCR-D-IMG"
+    if [[ ! "${ocrd__argv[input_file_grp]:=OCR-D-IMG}" =~ OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})?(,OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})?)* ]];then
+        echo >&2 "WARNING: input fileGrp '${ocrd_argv[input_file_grp]}' does not conform to OCR-D spec"
     fi
 
-    if [[ "${ocrd__argv[output_file_grp]:-}" = "" ]];then
-        ocrd__argv[output_file_grp]="OCR-D-TEXT"
+    if [[ ! "${ocrd__argv[output_file_grp]:=OCR-D-OCR}" =~ OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})?(,OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})?)* ]];then
+        echo >&2 "WARNING: output fileGrp '${ocrd_argv[output_file_grp]}' does not conform to OCR-D spec"
     fi
+
 
     local params_parsed retval
     params_parsed="$(ocrd ocrd-tool "$OCRD_TOOL_JSON" tool $OCRD_TOOL_NAME parse-params -p "${ocrd__argv[parameter]}")"

--- a/ocrd/ocrd/cli/bashlib.py
+++ b/ocrd/ocrd/cli/bashlib.py
@@ -1,6 +1,10 @@
+from __future__ import print_function
+import sys
 import click
 
 from ocrd.constants import BASHLIB_FILENAME
+import ocrd_utils.constants
+import ocrd_models.constants
 
 # ----------------------------------------------------------------------
 # ocrd bashlib
@@ -22,3 +26,30 @@ def bashlib_filename():
     Dump the bash library filename for sourcing by shell scripts
     """
     print(BASHLIB_FILENAME)
+
+@bashlib_cli.command('constants')
+@click.argument('name')
+def bashlib_constants(name):
+    """
+    Query constants from ocrd_utils and ocrd_models
+    """
+    if name in ['*', 'KEYS', '__all__']:
+        for symbol in ocrd_utils.constants.__all__:
+            print(symbol)
+        for symbol in ocrd_models.constants.__all__:
+            print(symbol)
+    elif (name in ocrd_utils.constants.__all__ or
+          name in ocrd_models.constants.__all__):
+        if name in ocrd_utils.constants.__all__:
+            constant = ocrd_utils.constants.__dict__[name]
+        else:
+            constant = ocrd_models.constants.__dict__[name]
+        if isinstance(constant, dict):
+            # make this bash-friendly (show initialization for associative array)
+            for key in constant:
+                print("[%s]=%s" % (key, constant[key]), end=' ')
+        else:
+            print(constant)
+    else:
+        print("ERROR: name '%s' is not a known constant" % name, file=sys.stderr)
+        sys.exit(1)

--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -77,36 +77,36 @@ ocrd__parse_argv () {
             -l|--log-level) ocrd__argv[log_level]=$2 ; shift ;;
             -h|--help|--usage) ocrd__usage; exit ;;
             -J|--dump-json) ocrd__dumpjson; exit ;;
-            -p|--parameter) ocrd__argv[parameter]=$2 ; shift ;;
+            -p|--parameter) ocrd__argv[parameter]="$2" ; shift ;;
             -g|--page-id) ocrd__argv[page_id]=$2 ; shift ;;
             -O|--output-file-grp) ocrd__argv[output_file_grp]=$2 ; shift ;;
             -I|--input-file-grp) ocrd__argv[input_file_grp]=$2 ; shift ;;
-            -w|--working-dir) ocrd__argv[working_dir]=$2 ; shift ;;
-            -m|--mets) ocrd__argv[mets_file]=$2 ; shift ;;
+            -w|--working-dir) ocrd__argv[working_dir]=$(realpath "$2") ; shift ;;
+            -m|--mets) ocrd__argv[mets_file]=$(realpath "$2") ; shift ;;
             -V|--version) ocrd ocrd-tool "$OCRD_TOOL_JSON" version; exit ;;
             *) ocrd__raise "Unknown option '$1'" ;;
         esac
         shift
     done
 
-    if [[ "${ocrd__argv[mets_file]:-}" = "" ]];then
-        ocrd__raise "Option -m/--mets-file required"
+    if [[ ! -r "${ocrd__argv[mets_file]:=$PWD/mets.xml}" ]];then
+        ocrd__raise "METS '${ocrd__argv[mets_file]}' not readable. Use -m/--mets-file to set correctly"
     fi
 
-    if [[ "${ocrd__argv[working_dir]:-}" = "" ]];then
-        ocrd__argv[working_dir]=$(dirname "${ocrd__argv[mets_file]}")
+    if [[ ! -d "${ocrd__argv[working_dir]:=$(dirname "${ocrd__argv[mets_file]}")}" ]];then
+        ocrd__raise "workdir '${ocrd__argv[working_dir]}' not a directory. Use -w/--working-dir to set correctly"
     fi
 
-    if [[ "${ocrd__argv[log_level]:-}" = "" ]];then
-        ocrd__argv[log_level]="INFO"
+    if [[ ! "${ocrd__argv[log_level]:=INFO}" =~ OFF|ERROR|WARN|INFO|DEBUG|TRACE ]];then
+        ocrd__raise "log level '${ocrd__argv[log_level]}' is invalid"
     fi
 
-    if [[ "${ocrd__argv[input_file_grp]:-}" = "" ]];then
-        ocrd__argv[input_file_grp]="OCR-D-IMG"
+    if [[ ! "${ocrd__argv[input_file_grp]:=OCR-D-IMG}" =~ OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})? ]];then
+        echo >&2 "WARNING: input fileGrp '${ocrd_argv[input_file_grp]}' does not conform to OCR-D spec"
     fi
 
-    if [[ "${ocrd__argv[output_file_grp]:-}" = "" ]];then
-        ocrd__argv[output_file_grp]="OCR-D-TEXT"
+    if [[ ! "${ocrd__argv[output_file_grp]:=OCR-D-OCR}" =~ OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})? ]];then
+        echo >&2 "WARNING: output fileGrp '${ocrd_argv[output_file_grp]}' does not conform to OCR-D spec"
     fi
 
     local params_parsed retval

--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -101,11 +101,11 @@ ocrd__parse_argv () {
         ocrd__raise "log level '${ocrd__argv[log_level]}' is invalid"
     fi
 
-    if [[ ! "${ocrd__argv[input_file_grp]:=OCR-D-IMG}" =~ OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})? ]];then
+    if [[ ! "${ocrd__argv[input_file_grp]:=OCR-D-IMG}" =~ OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})?(,OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})?)* ]];then
         echo >&2 "WARNING: input fileGrp '${ocrd_argv[input_file_grp]}' does not conform to OCR-D spec"
     fi
 
-    if [[ ! "${ocrd__argv[output_file_grp]:=OCR-D-OCR}" =~ OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})? ]];then
+    if [[ ! "${ocrd__argv[output_file_grp]:=OCR-D-OCR}" =~ OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})?(,OCR-D-(GT-)?(IMG|SEG|OCR|COR)(-[A-Z0-9\-]{3,})?)* ]];then
         echo >&2 "WARNING: output fileGrp '${ocrd_argv[output_file_grp]}' does not conform to OCR-D spec"
     fi
 

--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -109,6 +109,7 @@ ocrd__parse_argv () {
         echo >&2 "WARNING: output fileGrp '${ocrd_argv[output_file_grp]}' does not conform to OCR-D spec"
     fi
 
+
     local params_parsed retval
     params_parsed="$(ocrd ocrd-tool "$OCRD_TOOL_JSON" tool $OCRD_TOOL_NAME parse-params -p "${ocrd__argv[parameter]}")"
     retval=$?

--- a/ocrd_models/ocrd_models/constants.py
+++ b/ocrd_models/ocrd_models/constants.py
@@ -3,6 +3,30 @@ Constants for ocrd_models.
 """
 from pkg_resources import resource_string
 
+__all__ = [
+    'IDENTIFIER_PRIORITY',
+    'METS_XML_EMPTY',
+    'NAMESPACES',
+    'TAG_METS_AGENT',
+    'TAG_METS_DIV',
+    'TAG_METS_FILE',
+    'TAG_METS_FILEGRP',
+    'TAG_METS_FILESEC',
+    'TAG_METS_FPTR',
+    'TAG_METS_FLOCAT',
+    'TAG_METS_METSHDR',
+    'TAG_METS_NAME',
+    'TAG_METS_STRUCTMAP',
+    'TAG_MODS_IDENTIFIER',
+    'TAG_PAGE_ALTERNATIVEIMAGE',
+    'TAG_PAGE_COORDS',
+    'TAG_PAGE_READINGORDER',
+    'TAG_PAGE_REGIONREFINDEXED',
+    'TAG_PAGE_TEXTLINE',
+    'TAG_PAGE_TEXTEQUIV',
+    'TAG_PAGE_TEXTREGION'
+]
+    
 IDENTIFIER_PRIORITY = ['purl', 'urn', 'doi', 'url']
 
 METS_XML_EMPTY = resource_string(__name__, 'mets-empty.xml')
@@ -29,6 +53,7 @@ TAG_METS_STRUCTMAP        = '{%s}structMap' % NAMESPACES['mets']
 
 TAG_MODS_IDENTIFIER       = '{%s}identifier' % NAMESPACES['mods']
 
+TAG_PAGE_ALTERNATIVEIMAGE = '{%s}AlternativeImage' % NAMESPACES['page']
 TAG_PAGE_COORDS           = '{%s}Coords' % NAMESPACES['page']
 TAG_PAGE_READINGORDER     = '{%s}ReadingOrder' % NAMESPACES['page']
 TAG_PAGE_REGIONREFINDEXED = '{%s}RegionRefIndexed' % NAMESPACES['page']

--- a/ocrd_models/ocrd_models/constants.py
+++ b/ocrd_models/ocrd_models/constants.py
@@ -26,7 +26,7 @@ __all__ = [
     'TAG_PAGE_TEXTEQUIV',
     'TAG_PAGE_TEXTREGION'
 ]
-    
+
 IDENTIFIER_PRIORITY = ['purl', 'urn', 'doi', 'url']
 
 METS_XML_EMPTY = resource_string(__name__, 'mets-empty.xml')


### PR DESCRIPTION
- quote all FS path parameters to prevent tokenization
- convert mets_file and working_dir to absolute paths
  (to ensure this still works after chdir; fixes #283)
- do not just set defaults, also validate values:
  - mets_file must be readable, otherwise fail
  - working_dir must be directory, otherwise fail
  - log_level must conform to spec, otherwise fail
  - input_file_grp must conform to spec, otherwise warn
  - output_file_grp must conform to spec, otherwise warn