### PR TITLE
fix __init__ docstring order/markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <!-- BEGIN-MARKDOWN-TOC -->
 * [Introduction](#introduction)
-* [Modules](#modules)
+* [Packages](#packages)
 	* [ocrd_utils](#ocrd_utils)
 	* [ocrd_models](#ocrd_models)
 	* [ocrd_modelfactory](#ocrd_modelfactory)
@@ -29,10 +29,10 @@
 
 ## Introduction
 
-This repository contains the python modules that form the base for tools within the
+This repository contains the python packages that form the base for tools within the
 [OCR-D ecosphere](https://github.com/topics/ocr-d).
 
-All modules are also published to [PyPI](https://pypi.org/search/?q=ocrd).
+All packages are also published to [PyPI](https://pypi.org/search/?q=ocrd).
 
 The easiest way to install is via `pip`:
 
@@ -46,11 +46,11 @@ pip install ocrd_modelfactory
 
 All python software released by [OCR-D](https://github.com/OCR-D) requires Python 3.5 or higher.
 
-## Modules
+## Packages
 
 ### ocrd_utils
 
-Contains helpers and utilities, e.g. for unified logging, path normalization etc.
+Contains utilities and constants, e.g. for logging, path normalization, coordinate calculation etc.
 
 See [README for `ocrd_utils`](./ocrd_utils/README.md) for further information.
 
@@ -74,7 +74,7 @@ See [README for `ocrd_validators`](./ocrd_validators/README.md) for further info
 
 ### ocrd
 
-Contains all of the above and in addition decorators for creating OCR-D processors and CLI.
+Depends on all of the above, also contains decorators and classes for creating OCR-D processors and CLIs.
 
 Also contains the command line tool `ocrd`.
 

--- a/ocrd/ocrd/__init__.py
+++ b/ocrd/ocrd/__init__.py
@@ -1,5 +1,19 @@
+"""
+OCR-D reference implementation, base package: decorators and classes for processors and CLIs.
+
+Related (and dependent) packages:
+* ``ocrd_utils``
+  Contains utilities and constants, e.g. for logging, path normalization, coordinate calculation etc.
+* ``ocrd_models``
+  Contains file format wrappers for PAGE-XML, METS, EXIF metadata etc.
+* ``ocrd_modelfactory``
+  Code to instantiate models from existing data.
+* ``ocrd_validators``
+  Schemas and routines for validating BagIt, ``ocrd-tool.json``, workspaces, METS, page, CLI parameters etc.
+"""
+
 from ocrd.processor.base import run_processor, run_cli, Processor
-from ocrd_models import OcrdMets, OcrdExif, OcrdFile
+from ocrd_models import OcrdMets, OcrdExif, OcrdFile, OcrdAgent
 from ocrd.resolver import Resolver
 from ocrd_validators import *
 from ocrd.workspace import Workspace

--- a/ocrd_models/ocrd_models/__init__.py
+++ b/ocrd_models/ocrd_models/__init__.py
@@ -1,5 +1,5 @@
 """
-API to various file formats in the OCR domain.
+APIs and schemas for various file formats in the OCR domain.
 """
 from .ocrd_agent import OcrdAgent
 from .ocrd_exif import OcrdExif

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -1,5 +1,5 @@
 """
-Utility methods usable in various circumstances.
+Utility functions and constants usable in various circumstances.
 
 * ``coordinates_of_segment``, ``coordinates_for_segment``, ``rotate_coordinates``
    

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -1,44 +1,49 @@
 """
 Utility methods usable in various circumstances.
 
-* ``coordinates_of_segment``, ``coordinates_for_segment``, ``rotate_coordinates``, ``xywh_from_points``, ``points_from_xywh``, ``polygon_from_points``
-
-These functions convert polygon outlines for PAGE elements on all hierarchy
-levels (page, region, line, word, glyph) between relative coordinates w.r.t.
-parent segment and absolute coordinates w.r.t. the top-level (source) image.
-This includes rotation and offset correction.
-
+* ``coordinates_of_segment``, ``coordinates_for_segment``, ``rotate_coordinates``
+   
+   These functions convert polygon outlines for PAGE elements on all hierarchy
+   levels (page, region, line, word, glyph) between relative coordinates w.r.t.
+   parent segment and absolute coordinates w.r.t. the top-level (source) image.
+   This includes rotation and offset correction.
+   
 * ``polygon_mask``, ``image_from_polygon``, ``crop_image``
-
-These functions combine PIL.Image with polygons or bboxes.
-The functions have the syntax ``X_from_Y``, where ``X``/``Y`` can be
-
+   
+   These functions combine PIL.Image with polygons or bboxes.
+   
+* ``xywh_from_points``, ``points_from_xywh``, ``polygon_from_points`` etc.
+   
+   These functions have the syntax ``X_from_Y``, where ``X``/``Y`` can be
+   
     * ``bbox`` is a 4-tuple of integers x0, y0, x1, y1 of the bounding box (rectangle)
+      
+      (used by PIL.Image)
     * ``points`` a string encoding a polygon: ``"0,0 100,0 100,100, 0,100"``
+      
+      (used by PAGE-XML)
     * ``polygon`` is a list of 2-lists of integers x, y of points forming an (implicitly closed) polygon path: ``[[0,0], [100,0], [100,100], [0,100]]``
+      
+      (used by opencv2 and higher-level coordinate functions in ocrd_utils)
     * ``xywh`` a dict with keys for x, y, width and height: ``{'x': 0, 'y': 0, 'w': 100, 'h': 100}``
+      
+      (produced by tesserocr and image/coordinate recursion methods in ocrd.workspace)
     * ``x0y0x1y1`` is a 4-list of strings ``x0``, ``y0``, ``x1``, ``y1`` of the bounding box (rectangle)
+      
+      (produced by tesserocr)
     * ``y0x0y1x1`` is the same as ``x0y0x1y1`` with positions of ``x`` and ``y`` in the list swapped
 
-``polygon`` is what opencv2 and higher-level coordinate functions in ocrd_utils expect
-
-``xywh`` and ``x0y0x1y1`` are what tesserocr expects/produces.
-
-``points`` is what PAGE-XML uses.
-
-``bbox`` is what PIL.Image uses.
-
 * ``is_local_filename``, ``safe_filename``, ``abspath``
-
-FS-related utilities
+   
+   FS-related utilities
 
 * ``is_string``, ``membername``, ``concat_padded``
-
-String and OOP utilities
+   
+   String and OOP utilities
 
 * ``MIMETYPE_PAGE``, ``EXT_TO_MIME``, ``VERSION``
 
-Constants
+   Constants
 """
 
 __all__ = [


### PR DESCRIPTION
- re-instate item for coordinate conversion utils (not first any longer)
- improve RST indentation