### PR TITLE
validate PAGE and image exif height/width match, fix #229

### DIFF
--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -3,7 +3,9 @@ Validating a workspace.
 """
 import re
 
-from ocrd_utils import getLogger, MIMETYPE_PAGE
+from ocrd_utils import getLogger, MIMETYPE_PAGE, pushd_popd
+from ocrd_models import OcrdExif
+from ocrd_modelfactory import page_from_file
 from .constants import FILE_GROUP_CATEGORIES, FILE_GROUP_PREFIX
 from .report import ValidationReport
 from .page_validator import PageValidator
@@ -54,7 +56,7 @@ class WorkspaceValidator():
             resolver (:class:`ocrd.Resolver`): Resolver
             mets_url (string): URL of the METS file
             src_dir (string, None): Directory containing mets file
-            skip (list): Tests to skip. One or more of 'mets_unique_identifier', 'mets_file_group_names', 'mets_files', 'pixel_density', 'url'
+            skip (list): Tests to skip. One or more of 'mets_unique_identifier', 'mets_file_group_names', 'mets_files', 'pixel_density', 'dimension', 'url'
             download (boolean): Whether to download files
 
         Returns:
@@ -69,16 +71,19 @@ class WorkspaceValidator():
         """
         try:
             self._resolve_workspace()
-            if 'mets_unique_identifier' not in self.skip:
-                self._validate_mets_unique_identifier()
-            if 'mets_file_group_names' not in self.skip:
-                self._validate_mets_file_group_names()
-            if 'mets_files' not in self.skip:
-                self._validate_mets_files()
-            if 'pixel_density' not in self.skip:
-                self._validate_pixel_density()
-            if 'page' not in self.skip:
-                self._validate_page()
+            with pushd_popd(self.workspace.directory):
+                if 'mets_unique_identifier' not in self.skip:
+                    self._validate_mets_unique_identifier()
+                if 'mets_file_group_names' not in self.skip:
+                    self._validate_mets_file_group_names()
+                if 'mets_files' not in self.skip:
+                    self._validate_mets_files()
+                if 'pixel_density' not in self.skip:
+                    self._validate_pixel_density()
+                if 'dimension' not in self.skip:
+                    self._validate_dimension()
+                if 'page' not in self.skip:
+                    self._validate_page()
         except Exception as e: # pylint: disable=broad-except
             self.report.add_error("Failed to instantiate workspace: %s" % e)
             #  raise e
@@ -100,6 +105,21 @@ class WorkspaceValidator():
         """
         if self.mets.unique_identifier is None:
             self.report.add_error("METS has no unique identifier")
+
+    def _validate_dimension(self):
+        """
+        Validate image height and PAGE imageHeight match
+        """
+        for f in [f for f in self.mets.find_files() if f.mimetype == MIMETYPE_PAGE]:
+            if not f.local_filename and not self.download:
+                self.report.add_notice("Won't download remote PAGE XML <%s>" % f.url)
+                continue
+            page = page_from_file(f).get_Page()
+            _, _, exif = self.workspace.image_from_page(page, f.pageId)
+            if not page.imageHeight == exif.height:
+                self.report.add_error("PAGE '%s': @imageHeight != image's actual height (%s != %s)" % (f.ID, page.imageHeight, exif.height))
+            if not page.imageWidth == exif.width:
+                self.report.add_error("PAGE '%s': @imageWidth != image's actual width (%s != %s)" % (f.ID, page.imageWidth, exif.width))
 
     def _validate_pixel_density(self):
         """

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -4,7 +4,6 @@ Validating a workspace.
 import re
 
 from ocrd_utils import getLogger, MIMETYPE_PAGE, pushd_popd
-from ocrd_models import OcrdExif
 from ocrd_modelfactory import page_from_file
 from .constants import FILE_GROUP_CATEGORIES, FILE_GROUP_PREFIX
 from .report import ValidationReport
@@ -116,9 +115,9 @@ class WorkspaceValidator():
                 continue
             page = page_from_file(f).get_Page()
             _, _, exif = self.workspace.image_from_page(page, f.pageId)
-            if not page.imageHeight == exif.height:
+            if page.imageHeight != exif.height:
                 self.report.add_error("PAGE '%s': @imageHeight != image's actual height (%s != %s)" % (f.ID, page.imageHeight, exif.height))
-            if not page.imageWidth == exif.width:
+            if page.imageWidth != exif.width:
                 self.report.add_error("PAGE '%s': @imageWidth != image's actual width (%s != %s)" % (f.ID, page.imageWidth, exif.width))
 
     def _validate_pixel_density(self):

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -146,7 +146,7 @@ class TestWorkspaceValidator(TestCase):
             wsdir = join(tempdir, 'foo')
             copytree(assets.path_to('kant_aufklaerung_1784/data'), wsdir)
             with pushd_popd(wsdir):
-                os.system("""sed -i 's,imageHeight="2083",imageHeight="1234",' OCR-D-GT-PAGE/PAGE_0017_PAGE.xml""")
+                os.system("""sed -i 's,imageHeight="2083",imageHeight="1234",' OCR-D-GT-PAGE/PAGE_0017_PAGE""")
                 report = WorkspaceValidator.validate(self.resolver, join(wsdir, 'mets.xml'), src_dir=wsdir, skip=[
                     'page', 'mets_unique_identifier', 'mets_file_group_names', 'mets_files', 'pixel_density',
                     ], download=False)


### PR DESCRIPTION
@bertsky Is that a reasonable way to use `workspace.image_from_page` (to get the OcrdExif metadata)?