### PR TITLE
process: replace -m/--mets requirement by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Changed:
+
+  * `-m/--mets` is not required anymore, #301
+
 Fixed:
 
   * typos in docstrings

--- a/ocrd/ocrd/cli/process.py
+++ b/ocrd/ocrd/cli/process.py
@@ -14,7 +14,7 @@ from ..decorators import ocrd_loglevel
 # ----------------------------------------------------------------------
 @click.command('process')
 @ocrd_loglevel
-@click.option('-m', '--mets', help="METS to process", required=True)
+@click.option('-m', '--mets', help="METS to process", default="mets.xml")
 @click.option('-g', '--page-id', help="ID(s) of the pages to process")
 @click.argument('tasks', nargs=-1, required=True)
 def process_cli(log_level, mets, page_id, tasks):

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -58,7 +58,7 @@ def ocrd_cli_options(f):
             print(mets_url)
     """
     params = [
-        click.option('-m', '--mets', help="METS URL to validate"),
+        click.option('-m', '--mets', help="METS URL to validate", default="mets.xml"),
         click.option('-w', '--working-dir', help="Working Directory"),
         click.option('-I', '--input-file-grp', help='File group(s) used as input.', default='INPUT'),
         click.option('-O', '--output-file-grp', help='File group(s) used as output.', default='OUTPUT'),

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -70,11 +70,6 @@ class TestDecorators(TestCase):
         result = self.runner.invoke(cli_dummy_processor, ['--version'])
         self.assertEqual(result.exit_code, 0)
 
-    def test_processor_no_mets(self):
-        result = self.runner.invoke(cli_dummy_processor)
-        self.assertIn('Error: Missing option "-m" / "--mets".', result.output)
-        self.assertEqual(result.exit_code, 1)
-
     def test_processor_non_existing_mets(self):
         result = self.runner.invoke(cli_dummy_processor, ['--mets', 'file:///does/not/exist.xml'])
         self.assertIn('File does not exist: file:///does/not/exist.xml', result.output)


### PR DESCRIPTION
When running processors (core CLI or other), it should **not** be required to give `-m mets.xml` but default instead.