### PR TITLE
Escape from file hell

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -21,7 +21,8 @@ disable =
     useless-object-inheritance,
     useless-import-alias,
     no-else-return,
-    logging-not-lazy
+    logging-not-lazy,
+    bad-continuation
 
 [FORMAT]
 no-space-check=empty-line

--- a/.pylintrc
+++ b/.pylintrc
@@ -22,8 +22,7 @@ disable =
     useless-import-alias,
     bad-continuation,
     no-else-return,
-    logging-not-lazy,
-    bad-continuation
+    logging-not-lazy
 
 [FORMAT]
 no-space-check=empty-line

--- a/.pylintrc
+++ b/.pylintrc
@@ -20,6 +20,7 @@ disable =
     ungrouped-imports,
     useless-object-inheritance,
     useless-import-alias,
+    bad-continuation,
     no-else-return,
     logging-not-lazy,
     bad-continuation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changed:
   * OcrdFile: Default fileGrp to `TEMP`
   * OcrdFile: Accept url constructor arg
   * Workspace: Simplify file download code, add extensions to files
+  * Processor: `chdir` to workspace directory on init so relative files resolve properly
 
 Added:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 Changed:
 
   * `-m/--mets` is not required anymore, #301
+  * `ocrd workspace prune-files`: Throw on error removing non-existant file
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changed:
 
   * OcrdFile: Default fileGrp to `TEMP`
   * OcrdFile: Accept url constructor arg
+  * Workspace: Simplify file download code, add extensions to files
 
 Added:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Changed:
+
+  * OcrdFile: Default fileGrp to `TEMP`
+  * OcrdFile: Accept url constructor arg
+
+Added:
+
+  * utils: `MIME_TO_EXT` to map mime types to preferred extension
+
 ## [1.0.0b17] - 2019-08-21
 
 Fixed:

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -242,10 +242,10 @@ def prune_files(ctx):
     with pushd_popd(workspace.directory):
         for f in workspace.mets.find_files():
             try:
-                if exists(f.local_filename):
-                    workspace.mets.remove_file(f)
+                if not f.local_filename or not exists(f.local_filename):
+                    workspace.mets.remove_file(f.ID)
             except Exception as e:
-                log.debug("Error removing %f: %s", f, e)
+                log.warning("Error removing %f: %s", f, e)
         workspace.save_mets()
 
 # ----------------------------------------------------------------------

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -135,16 +135,14 @@ def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, force, local_f
     #  log.error(local_filename)
     if not local_filename.startswith(ctx.directory):
         log.debug("File '%s' is not in workspace, copying", local_filename)
-        local_filename = ctx.resolver.download_to_directory(ctx.directory, "file://" + local_filename, subdir=file_grp)
+        local_filename = ctx.resolver.download_to_directory(ctx.directory, local_filename, subdir=file_grp)
     local_filename = relpath(local_filename, ctx.directory)
-
-    url = local_filename
 
     workspace.mets.add_file(
         fileGrp=file_grp,
         ID=file_id,
         mimetype=mimetype,
-        url=url,
+        url=local_filename,
         pageId=page_id,
         force=force,
         local_filename=local_filename

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -245,7 +245,7 @@ def prune_files(ctx):
                 if not exists(f.url):
                     workspace.mets.remove_file(f.ID)
             except Exception as e:
-                log.debug(e)
+                log.debug("Error removing %f: %s", f, e)
         workspace.save_mets()
 
 # ----------------------------------------------------------------------

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -242,8 +242,8 @@ def prune_files(ctx):
     with pushd_popd(workspace.directory):
         for f in workspace.mets.find_files():
             try:
-                if not exists(f.url):
-                    workspace.mets.remove_file(f.ID)
+                if exists(f.local_filename):
+                    workspace.mets.remove_file(f)
             except Exception as e:
                 log.debug("Error removing %f: %s", f, e)
         workspace.save_mets()

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -6,7 +6,7 @@ from tempfile import mkdtemp
 import click
 
 from ocrd import Resolver, Workspace, WorkspaceValidator, WorkspaceBackupManager
-from ocrd_utils import getLogger, pushd_popd, is_local_filename
+from ocrd_utils import getLogger, pushd_popd
 from ..constants import TMP_PREFIX
 
 log = getLogger('ocrd.cli.workspace')
@@ -245,7 +245,8 @@ def prune_files(ctx):
                 if not f.local_filename or not exists(f.local_filename):
                     workspace.mets.remove_file(f.ID)
             except Exception as e:
-                log.warning("Error removing %f: %s", f, e)
+                log.exception("Error removing %f: %s", f, e)
+                raise(e)
         workspace.save_mets()
 
 # ----------------------------------------------------------------------
@@ -306,7 +307,7 @@ def get_id(ctx):
 """)
 @click.argument('ID')
 @pass_workspace
-def set_id(ctx, id):
+def set_id(ctx, id):   # pylint: disable=redefined-builtin
     workspace = Workspace(ctx.resolver, directory=ctx.directory, mets_basename=ctx.mets_basename, automatic_backup=ctx.automatic_backup)
     workspace.mets.unique_identifier = id
     workspace.save_mets()

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -1,8 +1,11 @@
 import os
+from os.path import isfile
 
 import click
 
 from ocrd_utils import (
+    is_local_filename,
+    get_local_filename,
     setOverrideLogLevel,
     VERSION as OCRD_VERSION
 )
@@ -29,9 +32,7 @@ def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_d
         print(msg)
         raise Exception(msg)
     else:
-        if mets.find('://') == -1:
-            mets = 'file://' + os.path.abspath(mets)
-        if mets.startswith('file://') and not os.path.exists(mets[len('file://'):]):
+        if is_local_filename(mets) and not isfile(get_local_filename(mets)):
             msg = "File does not exist: %s" % mets
             print(msg)
             raise Exception(msg)

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -10,6 +10,7 @@ from ocrd_utils import (
     VERSION as OCRD_VERSION
 )
 
+from ocrd_utils import getLogger
 from .resolver import Resolver
 from .processor.base import run_processor
 
@@ -22,6 +23,7 @@ loglevel_option = click.option('-l', '--log-level', help="Log level",
                                default=None, callback=_set_root_logger_version)
 
 def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_dir=None, dump_json=False, version=False, **kwargs):
+    LOG = getLogger('ocrd_cli_wrap_processor')
     if dump_json:
         processorClass(workspace=None, dump_json=True)
     elif version:
@@ -29,12 +31,12 @@ def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_d
         print("Version %s, ocrd/core %s" % (p.version, OCRD_VERSION))
     elif mets is None:
         msg = 'Error: Missing option "-m" / "--mets".'
-        print(msg)
+        LOG.error(msg)
         raise Exception(msg)
     else:
         if is_local_filename(mets) and not isfile(get_local_filename(mets)):
             msg = "File does not exist: %s" % mets
-            print(msg)
+            LOG.error(msg)
             raise Exception(msg)
         resolver = Resolver()
         workspace = resolver.workspace_from_url(mets, working_dir)

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -2,8 +2,10 @@ import os
 
 import click
 
-from ocrd_utils import VERSION as OCRD_VERSION
-from ocrd_utils.logging import setOverrideLogLevel
+from ocrd_utils import (
+    setOverrideLogLevel,
+    VERSION as OCRD_VERSION
+)
 
 from .resolver import Resolver
 from .processor.base import run_processor

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -1,7 +1,7 @@
 import os
 import json
 import subprocess
-from ocrd_utils import getLogger
+from ocrd_utils import getLogger, is_local_filename, get_local_filename
 from ocrd_validators import ParameterValidator
 
 log = getLogger('ocrd.processor')
@@ -40,9 +40,9 @@ def run_processor(
         mets_url,
         working_dir
     )
-    if parameter is not None:
-        if not '://' in parameter:
-            fname = os.path.abspath(parameter)
+    if parameter:
+        if is_local_filename(parameter):
+            fname = os.path.abspath(get_local_filename(parameter))
         else:
             fname = workspace.download_url(parameter)
         with open(fname, 'r') as param_json_file:

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -130,6 +130,11 @@ class Processor(object):
         self.ocrd_tool = ocrd_tool
         self.version = version
         self.workspace = workspace
+        # FIXME HACK would be better to use pushd_popd(self.workspace.directory)
+        # but there is no way to do that in process here since it's an
+        # overridden method. chdir is almost always an anti-pattern.
+        if self.workspace:
+            os.chdir(self.workspace.directory)
         self.input_file_grp = input_file_grp
         self.output_file_grp = output_file_grp
         self.page_id = None if page_id == [] or page_id is None else page_id

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -34,7 +34,7 @@ class Resolver():
             directory (string): Directory to download files to
             basename (string, None): basename part of the filename on disk.
             url (string): URL to download from
-            if_exists (string, "skip"): Waht to do if target file already exists. One of ``skip`` (default), ``overwrite`` or ``raise``
+            if_exists (string, "skip"): What to do if target file already exists. One of ``skip`` (default), ``overwrite`` or ``raise``
             subdir (string, None): Subdirectory to create within the directory. Think fileGrp.
 
         Returns:

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -1,5 +1,5 @@
 from os import makedirs
-from os.path import exists, isfile, join, isdir, abspath, dirname
+from os.path import exists, isfile, join, isdir, dirname
 from shutil import copyfile
 import tempfile
 
@@ -95,8 +95,6 @@ class Resolver():
         Returns:
             Workspace
         """
-        if dst_dir and not dst_dir.startswith('/'):
-            dst_dir = abspath(dst_dir)
 
         if mets_url is None:
             if baseurl is None:

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -1,5 +1,5 @@
 from os import makedirs
-from os.path import exists, isfile, join, isdir, dirname
+from os.path import exists, join, isdir, dirname
 from shutil import copyfile
 import tempfile
 
@@ -129,8 +129,7 @@ class Resolver():
         else:
             if exists(dst_mets) and not clobber_mets:
                 raise Exception("File '%s' already exists but clobber_mets is false" % dst_mets)
-            else:
-                self.download_to_directory(dst_dir, mets_url, basename=mets_basename)
+            self.download_to_directory(dst_dir, mets_url, basename=mets_basename)
 
         workspace = Workspace(self, dst_dir, mets_basename=mets_basename, baseurl=baseurl)
 

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -81,7 +81,7 @@ class Resolver():
 
     def workspace_from_url(self, mets_url, dst_dir=None, clobber_mets=False, mets_basename=None, download=False, baseurl=None):
         """
-        Create a workspace from a METS by URL.
+        Create a workspace from a METS by URL (i.e. clone it).
 
         Sets the mets.xml file
 

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -50,12 +50,12 @@ class Resolver():
 
         directory = Path(directory)
         directory.mkdir(parents=True, exist_ok=True)
-        directory = directory.resolve()
+        directory = str(directory.resolve())
 
         subdir_path = Path(subdir if subdir else '')
         basename_path = Path(basename if basename else nth_url_segment(url))
         ret = str(Path(subdir_path, basename_path))
-        dst_path = directory / ret
+        dst_path = Path(directory, ret)
 
         #  log.info("\n\tdst_path='%s \n\turl=%s", dst_path, url)
         #  print('url=%s', url)

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -101,8 +101,16 @@ class Resolver():
                 raise Exception("Must pass mets_url and/or baseurl to workspace_from_url")
             else:
                 mets_url = '%s/%s' % (baseurl, mets_basename if mets_basename else 'mets.xml')
+
+        # if mets_basename is not given, use the last URL segment of the mets_url
+        if mets_basename is None:
+            mets_basename = mets_url \
+                .rsplit('/', 1)[-1] \
+                .split('?')[0] \
+                .split('#')[0]
+
         if baseurl is None:
-            baseurl = mets_url.rsplit('/', 1)[0]
+            baseurl = mets_url[0:-len(mets_basename)].rsplit('/', 1)[0]
         log.debug("workspace_from_url\nmets_url='%s'\nbaseurl='%s'\ndst_dir='%s'", mets_url, baseurl, dst_dir)
 
         if dst_dir is None:
@@ -114,13 +122,6 @@ class Resolver():
             else:
                 dst_dir = tempfile.mkdtemp(prefix=TMP_PREFIX)
                 log.debug("Creating workspace '%s' for METS @ <%s>", dst_dir, mets_url)
-
-        # if mets_basename is not given, use the last URL segment of the mets_url
-        if mets_basename is None:
-            mets_basename = mets_url \
-                .rsplit('/', 1)[-1] \
-                .split('?')[0] \
-                .split('#')[0]
 
         dst_mets = join(dst_dir, mets_basename)
         log.debug("Copying mets url '%s' to '%s'", mets_url, dst_mets)

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -75,7 +75,7 @@ class Resolver():
 
         # Respect 'overwrite' arg
         if dst_path.exists() and not overwrite:
-            raise Exception("File already exists and 'overwrite' not set: %s" % (dst_path))
+            raise FileExistsError("File already exists and 'overwrite' not set: %s" % (dst_path))
 
         # Create dst_path parent dir
         dst_path.parent.mkdir(parents=True, exist_ok=True)
@@ -111,7 +111,7 @@ class Resolver():
         """
 
         if mets_url is None:
-            raise Exception("Must pass 'mets_url' workspace_from_url")
+            raise ValueError("Must pass 'mets_url' workspace_from_url")
 
         # if mets_basename is not given, use the last URL segment of the mets_url
         if mets_basename is None:
@@ -151,7 +151,7 @@ class Resolver():
         Path(directory).mkdir(parents=True, exist_ok=True)
         mets_path = Path(directory, mets_basename)
         if mets_path.exists() and not clobber_mets:
-            raise Exception("METS '%s' already exists in '%s' and clobber_mets not set." % (mets_basename, directory))
+            raise FileExistsError("METS '%s' already exists in '%s' and clobber_mets not set." % (mets_basename, directory))
         mets = OcrdMets.empty_mets()
         log.info("Writing METS to%s", mets_path)
         mets_path.write_bytes(mets.to_xml(xmllint=True))

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -23,7 +23,7 @@ class Resolver():
 
     def download_to_directory(self, directory, url, basename=None, if_exists='skip', subdir=None):
         """
-        Download a file to the workspace.
+        Download a file to a directory.
 
         Early Shortcut: If url is a local file and that file is already in the directory, keep it there.
 
@@ -128,10 +128,13 @@ class Resolver():
 
         # resolve dst_dir
         if not dst_dir:
-            log.debug("Creating ephemereal workspace '%s' for METS @ <%s>", dst_dir, mets_url)
-            dst_dir = tempfile.mkdtemp(prefix=TMP_PREFIX)
-        else:
-            dst_dir = str(Path(dst_dir).resolve(strict=True))
+            if is_local_filename(mets_url):
+                log.debug("Deriving dst_dir %s from %s", Path(mets_url).parent, mets_url)
+                dst_dir = Path(mets_url).parent
+            else:
+                log.debug("Creating ephemereal workspace '%s' for METS @ <%s>", dst_dir, mets_url)
+                dst_dir = tempfile.mkdtemp(prefix=TMP_PREFIX)
+        dst_dir = str(Path(dst_dir).resolve(strict=True))
 
         log.debug("workspace_from_url\nmets_basename='%s'\nmets_url='%s'\nsrc_baseurl='%s'\ndst_dir='%s'",
             mets_basename, mets_url, src_baseurl, dst_dir)

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -61,7 +61,7 @@ class Resolver():
             return outfilename
 
         outfiledir = outfilename.rsplit('/', 1)[0]
-        #  print(outfiledir)
+        #  print(">>>>>>> %s" % outfiledir)
         if not isdir(outfiledir):
             makedirs(outfiledir)
 

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -99,8 +99,7 @@ class Resolver():
         if mets_url is None:
             if baseurl is None:
                 raise Exception("Must pass mets_url and/or baseurl to workspace_from_url")
-            else:
-                mets_url = '%s/%s' % (baseurl, mets_basename if mets_basename else 'mets.xml')
+            mets_url = '%s/%s' % (baseurl, mets_basename if mets_basename else 'mets.xml')
 
         # if mets_basename is not given, use the last URL segment of the mets_url
         if mets_basename is None:

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -103,10 +103,7 @@ class Resolver():
 
         # if mets_basename is not given, use the last URL segment of the mets_url
         if mets_basename is None:
-            mets_basename = mets_url \
-                .rsplit('/', 1)[-1] \
-                .split('?')[0] \
-                .split('#')[0]
+            mets_basename = nth_url_segment(mets_url, -1)
 
         if baseurl is None:
             baseurl = mets_url[0:-len(mets_basename)].rsplit('/', 1)[0]

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -404,8 +404,8 @@ class Workspace():
     # pylint: disable=redefined-builtin
     def save_image_file(self, image,
                         file_id,
+                        file_grp,
                         page_id=None,
-                        file_grp='OCR-D-IMG',  # or -BIN?
                         format='PNG',
                         force=True):
         """Store and reference an image as file into the workspace.

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -10,12 +10,13 @@ from deprecated.sphinx import deprecated
 
 from ocrd_models import OcrdMets, OcrdExif
 from ocrd_utils import (
-    abspath,
     coordinates_of_segment,
     crop_image,
     getLogger,
     image_from_polygon,
     is_local_filename,
+    get_local_filename,
+    pushd_popd,
     polygon_from_points,
     xywh_from_points,
     pushd_popd,
@@ -88,11 +89,10 @@ class Workspace():
         """
         Download a :py:mod:`ocrd.model.ocrd_file.OcrdFile` to the workspace.
         """
-        #  os.chdir(self.directory)
-        #  log.info('f=%s' % f)
+        log.debug('Downloading OcrdFile %s' % f)
         with pushd_popd(self.directory):
             if is_local_filename(f.url):
-                f.local_filename = abspath(f.url)
+                f.local_filename = get_local_filename(f.url)
             else:
                 if f.local_filename:
                     log.debug("Already downloaded: %s", f.local_filename)
@@ -227,7 +227,8 @@ class Workspace():
             image_filename = self.download_url(image_url)
 
         if image_url not in self.image_cache['pil']:
-            self.image_cache['pil'][image_url] = Image.open(image_filename)
+            with pushd_popd(self.directory):
+                self.image_cache['pil'][image_url] = Image.open(image_filename)
 
         pil_image = self.image_cache['pil'][image_url]
 

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -1,6 +1,6 @@
 import io
 from os import makedirs, unlink
-from os.path import join as pjoin, isdir
+from pathlib import Path
 
 import cv2
 from PIL import Image
@@ -43,7 +43,7 @@ class Workspace():
     def __init__(self, resolver, directory, mets=None, mets_basename='mets.xml', automatic_backup=False, baseurl=None):
         self.resolver = resolver
         self.directory = directory
-        self.mets_target = pjoin(directory, mets_basename)
+        self.mets_target = str(Path(directory, mets_basename))
         if mets is None:
             mets = OcrdMets(filename=self.mets_target)
         self.mets = mets
@@ -164,7 +164,7 @@ class Workspace():
         with pushd_popd(self.directory):
             if 'local_filename' in kwargs:
                 local_filename_dir = kwargs['local_filename'].rsplit('/', 1)[0]
-                if not isdir(local_filename_dir):
+                if not Path(local_filename_dir).is_dir():
                     makedirs(local_filename_dir)
                 if 'url' not in kwargs:
                     kwargs['url'] = kwargs['local_filename']
@@ -419,7 +419,7 @@ class Workspace():
         """
         image_bytes = io.BytesIO()
         image.save(image_bytes, format=format)
-        file_path = pjoin(file_grp, file_id + '.' + format.lower())
+        file_path = str(Path(file_grp, '%s.%s' % (file_id, format.lower())))
         out = self.add_file(
             ID=file_id,
             file_grp=file_grp,

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -101,11 +101,12 @@ class Workspace():
                     log.debug("Present in the directory, nothing to do")
                     f.local_filename = url_local_filename
                     return f
+            basename = '%s%s' % (f.ID, MIME_TO_EXT.get(f.mimetype, '')) if f.ID else f.basename
             f.local_filename = self.resolver.download_to_directory(
                 self.directory,
                 f.url,
                 subdir=f.fileGrp,
-                basename='%s%s' % (f.ID, MIME_TO_EXT.get(f.mimetype, ''))
+                basename=basename
             )
 
         #  print(f)

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -71,6 +71,7 @@ class Workspace():
         self.mets = OcrdMets(filename=self.mets_target)
 
 
+    @deprecated(version='1.0.0', reason="Use workspace.download_file")
     def download_url(self, url, **kwargs):
         """
         Download a URL to the workspace.
@@ -101,8 +102,10 @@ class Workspace():
                 if _recursion_count >= 1:
                     raise Exception("Already tried prepending baseurl '%s'. Cannot retrieve '%s'" % (self.baseurl, f.url))
                 log.debug("First run of resolver.download_to_directory(%s) failed, try prepending baseurl '%s': %s", f.url, self.baseurl, e)
+                # XXX FIXME HACK
                 f.url = '%s/%s' % (self.baseurl, f.url)
                 f.url = self.download_file(f, _recursion_count + 1).local_filename
+                f.local_filename = f.url
             return f
 
     def remove_file(self, ID, force=False):

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -1,6 +1,7 @@
 import io
 from os import makedirs, unlink
 from os.path import join as pjoin, isdir, exists, abspath
+from pathlib import Path
 
 import cv2
 from PIL import Image
@@ -83,7 +84,7 @@ class Workspace():
         Returns:
             The local filename of the downloaded file
         """
-        return abspath(self.download_file(OcrdFile(None, url=url, **kwargs)).local_filename)
+        return self.download_file(OcrdFile(None, url=url, **kwargs)).local_filename
 
     def download_file(self, f, _recursion_count=0):
         """
@@ -91,25 +92,26 @@ class Workspace():
         """
         log.debug('Workspace.download_file(%s, _recursion_count=%s', f, _recursion_count)
         with pushd_popd(self.directory):
-            if is_local_filename(f.url):
-                url_local_filename = get_local_filename(f.url)
-                if not exists(url_local_filename):
-                    if self.baseurl and _recursion_count == 0:
-                        f.url = pjoin(self.baseurl, url_local_filename)
-                        return self.download_file(f, _recursion_count + 1)
-                    raise Exception("Cannot retrieve non-existant local file %s" % (url_local_filename))
-                log.debug("url_local_filename_abs=%s\tself.directory=%s" % (abspath(url_local_filename), self.directory))
-                if abspath(url_local_filename).startswith(self.directory):
-                    log.debug("Present in the directory, nothing to do")
-                    f.local_filename = url_local_filename
-                    return f
             basename = '%s%s' % (f.ID, MIME_TO_EXT.get(f.mimetype, '')) if f.ID else f.basename
-            f.local_filename = self.resolver.download_to_directory(
-                self.directory,
-                f.url,
-                subdir=f.fileGrp,
-                basename=basename
-            )
+            try:
+                self.resolver.download_to_directory(self.directory, f.url, subdir=f.fileGrp, basename=basename)
+            except Exception as e:
+                if is_local_filename(f.url):
+                    url_path = Path(get_local_filename(f.url))
+                    if not url_path.is_absolute() and self.baseurl and _recursion_count == 0:
+                        log.debug('Failed to copy file on the first try, try prepending baseurl')
+                        f.url = '%s/%s' % (self.baseurl, str(url_path))
+                        return self.download_file(f, _recursion_count + 1)
+                raise e
+            #  if is_local_filename(f.url):
+            #      url_path = Path(get_local_filename(f.url))
+            #      if not url_path.exists():
+            #          if self.baseurl and _recursion_count == 0:
+            #              f.url = pjoin(self.baseurl, str(url_path))
+            #              return self.download_file(f, _recursion_count + 1)
+            #          raise Exception("Cannot retrieve non-existant local file %s" % (url_path))
+            #      log.debug("url_local_filename_abs=%s\tself.directory=%s" % (url_path.resolve(strict=False), self.directory))
+
 
         #  print(f)
         return f

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -59,8 +59,9 @@ class Workspace():
         }
 
     def __str__(self):
-        return 'Workspace[directory=%s, file_groups=%s, files=%s]' % (
+        return 'Workspace[directory=%s, baseurl=%s, file_groups=%s, files=%s]' % (
             self.directory,
+            self.baseurl,
             self.mets.file_groups,
             [str(f) for f in self.mets.find_files()],
         )
@@ -88,7 +89,7 @@ class Workspace():
         """
         Download a :py:mod:`ocrd.model.ocrd_file.OcrdFile` to the workspace.
         """
-        log.debug('Downloading OcrdFile %s', f)
+        log.debug('Workspace.download_file(%s, recursion_count=%s', f, recursion_count)
         with pushd_popd(self.directory):
             if is_local_filename(f.url):
                 url_local_filename = get_local_filename(f.url)
@@ -97,6 +98,7 @@ class Workspace():
                         f.url = pjoin(self.baseurl, url_local_filename)
                         return self.download_file(f, recursion_count + 1)
                     raise Exception("Cannot retrieve non-existant local file %s" % (url_local_filename))
+                log.debug("url_local_filename_abs=%s\tself.directory=%s" % (abspath(url_local_filename), self.directory))
                 if abspath(url_local_filename).startswith(self.directory):
                     log.debug("Present in the directory, nothing to do")
                     f.local_filename = url_local_filename

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -82,7 +82,7 @@ class Workspace():
         Returns:
             The local filename of the downloaded file
         """
-        return self.download_file(OcrdFile(None, url=url, **kwargs)).local_filename
+        return abspath(self.download_file(OcrdFile(None, url=url, **kwargs)).local_filename)
 
     def download_file(self, f, recursion_count=0):
         """

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -85,18 +85,18 @@ class Workspace():
         """
         return abspath(self.download_file(OcrdFile(None, url=url, **kwargs)).local_filename)
 
-    def download_file(self, f, recursion_count=0):
+    def download_file(self, f, _recursion_count=0):
         """
         Download a :py:mod:`ocrd.model.ocrd_file.OcrdFile` to the workspace.
         """
-        log.debug('Workspace.download_file(%s, recursion_count=%s', f, recursion_count)
+        log.debug('Workspace.download_file(%s, _recursion_count=%s', f, _recursion_count)
         with pushd_popd(self.directory):
             if is_local_filename(f.url):
                 url_local_filename = get_local_filename(f.url)
                 if not exists(url_local_filename):
-                    if self.baseurl and recursion_count == 0:
+                    if self.baseurl and _recursion_count == 0:
                         f.url = pjoin(self.baseurl, url_local_filename)
-                        return self.download_file(f, recursion_count + 1)
+                        return self.download_file(f, _recursion_count + 1)
                     raise Exception("Cannot retrieve non-existant local file %s" % (url_local_filename))
                 log.debug("url_local_filename_abs=%s\tself.directory=%s" % (abspath(url_local_filename), self.directory))
                 if abspath(url_local_filename).startswith(self.directory):
@@ -119,20 +119,20 @@ class Workspace():
         Remove a file from the workspace.
 
         Arguments:
-            ID (string): ID of the file to delete
+            ID (string|OcrdFile): ID of the file to delete or the file itself
             force (boolean): Whether to delete from disk as well
         """
         log.debug('Deleting mets:file %s', ID)
-        mets_file = self.mets.remove_file(ID)
+        ocrd_file = self.mets.remove_file(ID)
         if force:
-            if not mets_file:
+            if not ocrd_file:
                 raise Exception("File '%s' not found" % ID)
-            if not mets_file.local_filename:
-                raise Exception("File not locally available %s" % mets_file)
+            if not ocrd_file.local_filename:
+                raise Exception("File not locally available %s" % ocrd_file)
             with pushd_popd(self.directory):
-                log.info("rm %s [cwd=%s]", mets_file.local_filename, self.directory)
-                unlink(mets_file.local_filename)
-        return mets_file
+                log.info("rm %s [cwd=%s]", ocrd_file.local_filename, self.directory)
+                unlink(ocrd_file.local_filename)
+        return ocrd_file
 
     def remove_file_group(self, USE, recursive=False, force=False):
         """

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -83,7 +83,9 @@ class Workspace():
         Returns:
             The local filename of the downloaded file
         """
-        return self.download_file(OcrdFile(None, url=url, **kwargs)).local_filename
+        f = OcrdFile(None, url=url, **kwargs)
+        f = self.download_file(f)
+        return f.local_filename
 
 
     def download_file(self, f, _recursion_count=0):
@@ -102,10 +104,10 @@ class Workspace():
                 if _recursion_count >= 1:
                     raise Exception("Already tried prepending baseurl '%s'. Cannot retrieve '%s'" % (self.baseurl, f.url))
                 log.debug("First run of resolver.download_to_directory(%s) failed, try prepending baseurl '%s': %s", f.url, self.baseurl, e)
-                # XXX FIXME HACK
                 f.url = '%s/%s' % (self.baseurl, f.url)
                 f.url = self.download_file(f, _recursion_count + 1).local_filename
-                f.local_filename = f.url
+            # XXX FIXME HACK
+            f.local_filename = f.url
             return f
 
     def remove_file(self, ID, force=False):

--- a/ocrd/ocrd/workspace_bagger.py
+++ b/ocrd/ocrd/workspace_bagger.py
@@ -65,10 +65,9 @@ class WorkspaceBagger():
             for f in mets.find_files():
                 log.info("Resolving %s (%s)", f.url, ocrd_manifestation_depth)
                 if is_local_filename(f.url):
-                    f.url = abspath(f.url)
-                # XXX cannot happen because chdir above
-                #  elif is_local_filename(join(workspace.directory, 'data', f.url)):
-                #      f.url = abspath(join(workspace.directory, 'data', f.url))
+                    # FIXME No abspath! No!
+                    #  f.url = abspath(f.url)
+                    pass
                 elif ocrd_manifestation_depth != 'full':
                     self._log_or_raise("Not fetching non-local files, skipping %s" % f.url)
                     continue

--- a/ocrd/ocrd/workspace_bagger.py
+++ b/ocrd/ocrd/workspace_bagger.py
@@ -10,7 +10,15 @@ import sys
 from pkg_resources import get_distribution
 from bagit import Bag, make_manifests  # pylint: disable=no-name-in-module
 
-from ocrd_utils import VERSION, getLogger, abspath, is_local_filename, unzip_file_to_dir
+from ocrd_utils import (
+    pushd_popd,
+    getLogger,
+    abspath,
+    is_local_filename,
+    unzip_file_to_dir,
+
+    VERSION,
+)
 from ocrd_validators.constants import BAGIT_TXT, TMP_BAGIT_PREFIX, OCRD_BAGIT_PROFILE_URL
 
 from .workspace import Workspace
@@ -43,9 +51,8 @@ class WorkspaceBagger():
             # Remove temporary bagdir
             rmtree(bagdir)
 
-    def _log_or_raise(self, msg, oldpwd):
+    def _log_or_raise(self, msg):
         if self.strict:
-            chdir(oldpwd)
             raise(Exception(msg))
         else:
             log.info(msg)
@@ -54,36 +61,34 @@ class WorkspaceBagger():
         mets = workspace.mets
 
         # TODO allow filtering by fileGrp@USE and such
-        oldpwd = getcwd()
-        chdir(workspace.directory)
-        for f in mets.find_files():
-            log.info("Resolving %s (%s)", f.url, ocrd_manifestation_depth)
-            if is_local_filename(f.url):
-                f.url = abspath(f.url)
-            # XXX cannot happen because chdir above
-            #  elif is_local_filename(join(workspace.directory, 'data', f.url)):
-            #      f.url = abspath(join(workspace.directory, 'data', f.url))
-            elif ocrd_manifestation_depth != 'full':
-                self._log_or_raise("Not fetching non-local files, skipping %s" % f.url, oldpwd)
-                continue
-            elif not f.url.startswith('http'):
-                self._log_or_raise("Not an http URL: %s" % f.url, oldpwd)
-                continue
-            log.info("Resolved %s", f.url)
+        with pushd_popd(workspace.directory):
+            for f in mets.find_files():
+                log.info("Resolving %s (%s)", f.url, ocrd_manifestation_depth)
+                if is_local_filename(f.url):
+                    f.url = abspath(f.url)
+                # XXX cannot happen because chdir above
+                #  elif is_local_filename(join(workspace.directory, 'data', f.url)):
+                #      f.url = abspath(join(workspace.directory, 'data', f.url))
+                elif ocrd_manifestation_depth != 'full':
+                    self._log_or_raise("Not fetching non-local files, skipping %s" % f.url)
+                    continue
+                elif not f.url.startswith('http'):
+                    self._log_or_raise("Not an http URL: %s" % f.url)
+                    continue
+                log.info("Resolved %s", f.url)
 
-            file_grp_dir = join(bagdir, 'data', f.fileGrp)
-            if not isdir(file_grp_dir):
-                makedirs(file_grp_dir)
-            self.resolver.download_to_directory(file_grp_dir, f.url, basename="%s%s" % (f.ID, f.extension))
-            f.url = join(f.fileGrp, f.ID)
+                file_grp_dir = join(bagdir, 'data', f.fileGrp)
+                if not isdir(file_grp_dir):
+                    makedirs(file_grp_dir)
+                self.resolver.download_to_directory(file_grp_dir, f.url, basename="%s%s" % (f.ID, f.extension))
+                f.url = join(f.fileGrp, f.ID)
 
-        # save mets.xml
-        with open(join(bagdir, 'data', ocrd_mets), 'wb') as f:
-            f.write(workspace.mets.to_xml())
+            # save mets.xml
+            with open(join(bagdir, 'data', ocrd_mets), 'wb') as f:
+                f.write(workspace.mets.to_xml())
 
-        chdir(bagdir)
-        total_bytes, total_files = make_manifests('data', processes, algorithms=['sha512'])
-        chdir(oldpwd)
+            chdir(bagdir)
+            total_bytes, total_files = make_manifests('data', processes, algorithms=['sha512'])
         return total_bytes, total_files
 
     def _set_bag_info(self, bag, total_bytes, total_files, ocrd_identifier, ocrd_manifestation_depth, ocrd_base_version_checksum):

--- a/ocrd/ocrd/workspace_bagger.py
+++ b/ocrd/ocrd/workspace_bagger.py
@@ -13,7 +13,6 @@ from bagit import Bag, make_manifests  # pylint: disable=no-name-in-module
 from ocrd_utils import (
     pushd_popd,
     getLogger,
-    abspath,
     is_local_filename,
     unzip_file_to_dir,
 
@@ -65,8 +64,7 @@ class WorkspaceBagger():
             for f in mets.find_files():
                 log.info("Resolving %s (%s)", f.url, ocrd_manifestation_depth)
                 if is_local_filename(f.url):
-                    # FIXME No abspath! No!
-                    #  f.url = abspath(f.url)
+                    # nothing to do then
                     pass
                 elif ocrd_manifestation_depth != 'full':
                     self._log_or_raise("Not fetching non-local files, skipping %s" % f.url)

--- a/ocrd_modelfactory/ocrd_modelfactory/__init__.py
+++ b/ocrd_modelfactory/ocrd_modelfactory/__init__.py
@@ -53,7 +53,7 @@ def page_from_image(input_file):
             imageWidth=exif.width,
             imageHeight=exif.height,
             # XXX brittle
-            imageFilename=input_file.url if input_file.url is not None else 'file://' + input_file.local_filename
+            imageFilename=input_file.url if input_file.url is not None else input_file.local_filename
         )
     )
 

--- a/ocrd_modelfactory/ocrd_modelfactory/__init__.py
+++ b/ocrd_modelfactory/ocrd_modelfactory/__init__.py
@@ -64,7 +64,9 @@ def page_from_file(input_file):
     Arguments:
         * input_file (OcrdFile):
     """
-    #  print("PARSING PARSING '%s'" % input_file)
+    #  from os import getcwd
+    #  from os.path import exists
+    #  print(">>>>>> cwd='%s' local_filename=%s exists=%s" %(getcwd(), input_file.local_filename, exists(input_file.local_filename)))
     if input_file.mimetype.startswith('image'):
         return page_from_image(input_file)
     if input_file.mimetype == MIMETYPE_PAGE:

--- a/ocrd_modelfactory/ocrd_modelfactory/__init__.py
+++ b/ocrd_modelfactory/ocrd_modelfactory/__init__.py
@@ -4,6 +4,7 @@ Factory methods to create models for data, files, URLs.
 
 """
 from datetime import datetime
+from pathlib import Path
 
 from PIL import Image
 
@@ -39,8 +40,10 @@ def page_from_image(input_file):
     Arguments:
         * input_file (OcrdFile):
     """
-    if input_file.local_filename is None:
-        raise Exception("input_file must have 'local_filename' property")
+    if not input_file.local_filename:
+        raise ValueError("input_file must have 'local_filename' property")
+    if not Path(input_file.local_filename).exists():
+        raise FileNotFoundError("File not found: '%s' (%s)" % (input_file.local_filename, input_file))
     exif = exif_from_filename(input_file.local_filename)
     now = datetime.now()
     return PcGtsType(
@@ -64,11 +67,12 @@ def page_from_file(input_file):
     Arguments:
         * input_file (OcrdFile):
     """
-    #  from os import getcwd
-    #  from os.path import exists
-    #  print(">>>>>> cwd='%s' local_filename=%s exists=%s" %(getcwd(), input_file.local_filename, exists(input_file.local_filename)))
+    if not input_file.local_filename:
+        raise ValueError("input_file must have 'local_filename' property")
+    if not Path(input_file.local_filename).exists():
+        raise FileNotFoundError("File not found: '%s' (%s)" % (input_file.local_filename, input_file))
     if input_file.mimetype.startswith('image'):
         return page_from_image(input_file)
     if input_file.mimetype == MIMETYPE_PAGE:
         return parse(input_file.local_filename, silence=True)
-    raise Exception("Unsupported mimetype '%s'" % input_file.mimetype)
+    raise ValueError("Unsupported mimetype '%s'" % input_file.mimetype)

--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -1,7 +1,6 @@
 """
 API to ``mets:file``
 """
-import os
 from os.path import splitext, basename
 
 from ocrd_utils import is_local_filename, get_local_filename
@@ -66,8 +65,8 @@ class OcrdFile():
 
     @property
     def extension(self):
-        basename, ext = splitext(self.basename)
-        if basename.endswith('.tar'):
+        _basename, ext = splitext(self.basename)
+        if _basename.endswith('.tar'):
             ext = ".tar" + ext
         return ext
 

--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -2,6 +2,7 @@
 API to ``mets:file``
 """
 import os
+from os.path import splitext, basename
 
 from ocrd_utils import is_local_filename, get_local_filename
 
@@ -61,11 +62,11 @@ class OcrdFile():
         """
         Get the ``os.path.basename`` of the local file, if any.
         """
-        return os.path.basename(self.local_filename if self.local_filename else self.url)
+        return basename(self.local_filename if self.local_filename else self.url)
 
     @property
     def extension(self):
-        basename, ext = os.path.splitext(self.basename)
+        basename, ext = splitext(self.basename)
         if basename.endswith('.tar'):
             ext = ".tar" + ext
         return ext

--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -17,7 +17,7 @@ class OcrdFile():
     #  def create(mimetype, ID, url, local_filename):
     #      el_fileGrp.SubElement('file')
 
-    def __init__(self, el, mimetype=None, instance=None, local_filename=None, mets=None):
+    def __init__(self, el, mimetype=None, instance=None, local_filename=None, mets=None, url=None):
         """
         Args:
             el (LxmlElement):
@@ -34,12 +34,12 @@ class OcrdFile():
         self._instance = instance
         self.mets = mets
 
+        if url:
+            self.url = url
+
         if not(local_filename):
             if self.url and is_local_filename(self.url):
                 self.local_filename = get_local_filename(self.url)
-
-        #  if baseurl and not local_filename and '://' not in self.url:
-        #      self.local_filename = '%s/%s' % (baseurl, self.url)
 
     def __str__(self):
         """
@@ -61,7 +61,7 @@ class OcrdFile():
         """
         Get the ``os.path.basename`` of the local file, if any.
         """
-        return os.path.basename(self.local_filename)
+        return os.path.basename(self.local_filename if self.local_filename else self.url)
 
     @property
     def extension(self):
@@ -138,7 +138,10 @@ class OcrdFile():
         """
         The ``USE`` attribute of the containing ``mets:fileGrp``
         """
-        return self._el.getparent().get('USE')
+        parent = self._el.getparent()
+        if parent is not None:
+            return self._el.getparent().get('USE')
+        return 'TEMP'
 
     @property
     def url(self):

--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -3,6 +3,8 @@ API to ``mets:file``
 """
 import os
 
+from ocrd_utils import is_local_filename, get_local_filename
+
 from .ocrd_xml_base import ET
 from .constants import NAMESPACES as NS, TAG_METS_FLOCAT, TAG_METS_FILE
 
@@ -32,12 +34,9 @@ class OcrdFile():
         self._instance = instance
         self.mets = mets
 
-        if self.url:
-            if not self.url.startswith('http://') and \
-                not self.url.startswith('https://'):
-                self.local_filename = self.url
-            if self.url.startswith('file://'):
-                self.local_filename = self.url[len('file://'):]
+        if not(local_filename):
+            if self.url and is_local_filename(self.url):
+                self.local_filename = get_local_filename(self.url)
 
         #  if baseurl and not local_filename and '://' not in self.url:
         #      self.local_filename = '%s/%s' % (baseurl, self.url)

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -3,7 +3,7 @@ API to METS
 """
 from datetime import datetime
 
-from ocrd_utils import getLogger, VERSION
+from ocrd_utils import is_local_filename, getLogger, VERSION
 
 from .constants import (
     NAMESPACES as NS,
@@ -124,7 +124,7 @@ class OcrdMets(OcrdXmlDocument):
             pageId (string) : ID of physical page manifested by matching files
             url (string) : @xlink:href of mets:Flocat of mets:file
             mimetype (string) : MIMETYPE of matching files
-            local (boolean) : Whether to restrict results to local files, i.e. file://-URL
+            local (boolean) : Whether to restrict results to local files
 
         Return:
             List of files.
@@ -154,10 +154,9 @@ class OcrdMets(OcrdXmlDocument):
             if file_id not in self._file_by_id:
                 self._file_by_id[file_id] = OcrdFile(el, mets=self)
 
-            # If only local resources should be returned and file is neither a
-            # file:// URL nor a file path: skip the file
+            # If only local resources should be returned and file is not a file path: skip the file
             url = self._file_by_id[file_id].url
-            if local_only and not (url.startswith('file://') or '://' not in url):
+            if local_only and not is_local_filename(url):
                 continue
             ret.append(self._file_by_id[file_id])
         return ret

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -203,7 +203,11 @@ def coordinates_of_segment(segment, parent_image, parent_xywh):
 
 @contextlib.contextmanager
 def pushd_popd(newcwd=None):
-    oldcwd = getcwd()
+    try:
+        oldcwd = getcwd()
+    except FileNotFoundError as e:
+        # This happens when a directory is deleted before the context is exited
+        oldcwd = '/tmp'
     try:
         if newcwd:
             chdir(newcwd)

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -2,43 +2,43 @@
 Utility functions and constants usable in various circumstances.
 
 * ``coordinates_of_segment``, ``coordinates_for_segment``, ``rotate_coordinates``
-   
+
    These functions convert polygon outlines for PAGE elements on all hierarchy
    levels (page, region, line, word, glyph) between relative coordinates w.r.t.
    parent segment and absolute coordinates w.r.t. the top-level (source) image.
    This includes rotation and offset correction.
-   
+
 * ``polygon_mask``, ``image_from_polygon``, ``crop_image``
-   
+
    These functions combine PIL.Image with polygons or bboxes.
-   
+
 * ``xywh_from_points``, ``points_from_xywh``, ``polygon_from_points`` etc.
-   
+
    These functions have the syntax ``X_from_Y``, where ``X``/``Y`` can be
-   
+
     * ``bbox`` is a 4-tuple of integers x0, y0, x1, y1 of the bounding box (rectangle)
-      
+
       (used by PIL.Image)
     * ``points`` a string encoding a polygon: ``"0,0 100,0 100,100, 0,100"``
-      
+
       (used by PAGE-XML)
     * ``polygon`` is a list of 2-lists of integers x, y of points forming an (implicitly closed) polygon path: ``[[0,0], [100,0], [100,100], [0,100]]``
-      
+
       (used by opencv2 and higher-level coordinate functions in ocrd_utils)
     * ``xywh`` a dict with keys for x, y, width and height: ``{'x': 0, 'y': 0, 'w': 100, 'h': 100}``
-      
+
       (produced by tesserocr and image/coordinate recursion methods in ocrd.workspace)
     * ``x0y0x1y1`` is a 4-list of strings ``x0``, ``y0``, ``x1``, ``y1`` of the bounding box (rectangle)
-      
+
       (produced by tesserocr)
     * ``y0x0y1x1`` is the same as ``x0y0x1y1`` with positions of ``x`` and ``y`` in the list swapped
 
 * ``is_local_filename``, ``safe_filename``, ``abspath``
-   
+
    FS-related utilities
 
 * ``is_string``, ``membername``, ``concat_padded``
-   
+
    String and OOP utilities
 
 * ``MIMETYPE_PAGE``, ``EXT_TO_MIME``, ``VERSION``

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -3,14 +3,14 @@ Utility functions and constants usable in various circumstances.
 
 * ``coordinates_of_segment``, ``coordinates_for_segment``, ``rotate_coordinates``
 
-   These functions convert polygon outlines for PAGE elements on all hierarchy
-   levels (page, region, line, word, glyph) between relative coordinates w.r.t.
-   parent segment and absolute coordinates w.r.t. the top-level (source) image.
-   This includes rotation and offset correction.
+    These functions convert polygon outlines for PAGE elements on all hierarchy
+    levels (page, region, line, word, glyph) between relative coordinates w.r.t.
+    parent segment and absolute coordinates w.r.t. the top-level (source) image.
+    This includes rotation and offset correction.
 
 * ``polygon_mask``, ``image_from_polygon``, ``crop_image``
 
-   These functions combine PIL.Image with polygons or bboxes.
+    These functions combine PIL.Image with polygons or bboxes.
 
 * ``xywh_from_points``, ``points_from_xywh``, ``polygon_from_points`` etc.
 
@@ -35,15 +35,19 @@ Utility functions and constants usable in various circumstances.
 
 * ``is_local_filename``, ``safe_filename``, ``abspath``
 
-   FS-related utilities
+    FS-related utilities
 
 * ``is_string``, ``membername``, ``concat_padded``
 
-   String and OOP utilities
+    String and OOP utilities
 
 * ``MIMETYPE_PAGE``, ``EXT_TO_MIME``, ``VERSION``
 
-   Constants
+    Constants
+
+* ``logging``, ``setOverrideLogLevel``, ``getLevelName``, ``getLogger``, ``initLogging``
+
+    Exports of ocrd_utils.logging
 """
 
 __all__ = [
@@ -55,7 +59,9 @@ __all__ = [
     'coordinates_of_segment',
     'concat_padded',
     'crop_image',
+    'getLevelName',
     'getLogger',
+    'initLogging',
     'is_local_filename',
     'is_string',
     'logging',
@@ -73,6 +79,7 @@ __all__ = [
     'polygon_mask',
     'rotate_coordinates',
     'safe_filename',
+    'setOverrideLogLevel',
     'unzip_file_to_dir',
     'xywh_from_bbox',
     'xywh_from_points',
@@ -96,7 +103,7 @@ import numpy as np
 from PIL import Image, ImageStat, ImageDraw
 
 import logging
-from .logging import getLogger
+from .logging import * # pylint: disable=wildcard-import
 from .constants import *  # pylint: disable=wildcard-import
 
 LOG = getLogger('ocrd_utils')

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -37,7 +37,7 @@ Utility functions and constants usable in various circumstances.
 
     FS-related utilities
 
-* ``is_string``, ``membername``, ``concat_padded``
+* ``is_string``, ``membername``, ``concat_padded``, ``nth_url_segment``, ``remove_non_path_from_url``
 
     String and OOP utilities
 
@@ -64,6 +64,8 @@ __all__ = [
     'initLogging',
     'is_local_filename',
     'is_string',
+    'nth_url_segment',
+    'remove_non_path_from_url',
     'logging',
     'membername',
     'image_from_polygon',
@@ -95,6 +97,7 @@ import re
 import sys
 import logging
 import os
+import re
 from os import getcwd, chdir
 from os.path import isfile, abspath as os_abspath
 from zipfile import ZipFile
@@ -226,6 +229,29 @@ def concat_padded(base, *args):
         else:
             ret = "%s_%04i"  % (ret, n + 1)
     return ret
+
+def remove_non_path_from_url(url):
+    """
+    Remove everything from URL after path.
+    """
+    url = url.split('?', 1)[0]    # query
+    url = url.split('#', 1)[0]    # fragment identifier
+    url = re.sub(r"/+$", "", url) # trailing slashes
+    return url
+
+def nth_url_segment(url, n=-1):
+    """
+    Return the last /-delimited segment of a URL-like string
+
+    Arguments:
+        url (string):
+        n (integer): index of segment, default: -1
+    """
+    segments = remove_non_path_from_url(url).split('/')
+    try:
+        return segments[n]
+    except IndexError:
+        return ''
 
 def crop_image(image, box=None):
     """"Crop an image to a rectangle, filling with background.

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -41,7 +41,7 @@ Utility functions and constants usable in various circumstances.
 
     String and OOP utilities
 
-* ``MIMETYPE_PAGE``, ``EXT_TO_MIME``, ``VERSION``
+* ``MIMETYPE_PAGE``, ``EXT_TO_MIME``, ``MIME_TO_EXT``, ``VERSION``
 
     Constants
 
@@ -87,6 +87,7 @@ __all__ = [
     'VERSION',
     'MIMETYPE_PAGE',
     'EXT_TO_MIME',
+    'MIME_TO_EXT',
 ]
 
 import io

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -33,7 +33,7 @@ Utility functions and constants usable in various circumstances.
       (produced by tesserocr)
     * ``y0x0y1x1`` is the same as ``x0y0x1y1`` with positions of ``x`` and ``y`` in the list swapped
 
-* ``is_local_filename``, ``safe_filename``, ``abspath``
+* ``is_local_filename``, ``safe_filename``, ``abspath``, ``get_local_filename``
 
     FS-related utilities
 
@@ -247,6 +247,30 @@ def crop_image(image, box=None):
     new_image.paste(image, (-xywh['x'], -xywh['y']))
     return new_image
 
+def get_local_filename(url, start=None):
+    """
+    Return local filename, optionally relative to ``start``
+
+    Arguments:
+        url (string): filename or URL
+        start (string): Base path to remove from filename. Raise an exception if not a prefix of url
+    """
+    if url.startswith('https://') or url.startswith('http:'):
+        raise Exception("Can't determine local filename of http(s) URL")
+    if url.startswith('file://'):
+        url = url[len('file://'):]
+    # Goobi/Kitodo produces those, they are always absolute
+    if url.startswith('file:/'):
+        url = url[len('file:'):]
+    if start:
+        if not url.startswith(start):
+            raise Exception("Cannot remove prefix %s from url %s" % (start, url))
+        if not start.endswith('/'):
+            start += '/'
+        url = url[len(start):]
+    return url
+
+
 def image_from_polygon(image, polygon):
     """"Mask an image with a polygon.
 
@@ -273,11 +297,7 @@ def is_local_filename(url):
     """
     Whether a url is a local filename.
     """
-    if url.startswith('file://'):
-        return True
-    if isfile(url):
-        return True
-    return False
+    return url.startswith('file:/') or not('://' in url)
 
 def is_string(val):
     """

--- a/ocrd_utils/ocrd_utils/constants.py
+++ b/ocrd_utils/ocrd_utils/constants.py
@@ -27,6 +27,7 @@ MIME_TO_EXT = {
     'image/tiff': '.tif',
     'image/png': '.png',
     'image/jpg': '.jpg',
+    'image/jpeg': '.jpg',
     MIMETYPE_PAGE: '.xml',
     'application/alto+xml': '.xml',
 }

--- a/ocrd_utils/ocrd_utils/constants.py
+++ b/ocrd_utils/ocrd_utils/constants.py
@@ -7,6 +7,7 @@ __all__ = [
     'VERSION',
     'MIMETYPE_PAGE',
     'EXT_TO_MIME',
+    'MIME_TO_EXT'
 ]
 
 VERSION = get_distribution('ocrd_utils').version
@@ -20,4 +21,12 @@ EXT_TO_MIME = {
     '.jpg': 'image/jpg',
     '.jpeg': 'image/jpg',
     '.xml': MIMETYPE_PAGE
+}
+
+MIME_TO_EXT = {
+    'image/tiff': '.tif',
+    'image/png': '.png',
+    'image/jpg': '.jpg',
+    MIMETYPE_PAGE: '.xml',
+    'application/alto+xml': '.xml',
 }

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -22,6 +22,7 @@ __all__ = [
     'logging',
     'getLogger',
     'getLevelName',
+    'initLogging',
     'setOverrideLogLevel'
 ]
 

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -3,7 +3,7 @@ Validating a workspace.
 """
 import re
 
-from ocrd_utils import getLogger, MIMETYPE_PAGE, pushd_popd
+from ocrd_utils import getLogger, MIMETYPE_PAGE, pushd_popd, is_local_filename
 from ocrd_modelfactory import page_from_file
 
 from .constants import FILE_GROUP_CATEGORIES, FILE_GROUP_PREFIX
@@ -37,13 +37,13 @@ class WorkspaceValidator():
         self.skip = skip if skip else []
         log.debug('resolver=%s mets_url=%s src_dir=%s', resolver, mets_url, src_dir)
         self.resolver = resolver
+        if mets_url is None and src_dir is not None:
+            mets_url = '%s/mets.xml' % src_dir
         self.mets_url = mets_url
         self.download = download
         self.page_strictness = page_strictness
 
         self.src_dir = src_dir
-        if mets_url is None and src_dir is not None:
-            mets_url = '%s/mets.xml' % src_dir
         self.workspace = None
         self.mets = None
 
@@ -71,22 +71,23 @@ class WorkspaceValidator():
         """
         try:
             self._resolve_workspace()
-            with pushd_popd(self.workspace.directory):
-                if 'mets_unique_identifier' not in self.skip:
-                    self._validate_mets_unique_identifier()
-                if 'mets_file_group_names' not in self.skip:
-                    self._validate_mets_file_group_names()
-                if 'mets_files' not in self.skip:
-                    self._validate_mets_files()
-                if 'pixel_density' not in self.skip:
-                    self._validate_pixel_density()
-                if 'dimension' not in self.skip:
-                    self._validate_dimension()
-                if 'page' not in self.skip:
-                    self._validate_page()
         except Exception as e: # pylint: disable=broad-except
+            log.warning("Failed to instantiate workspace: %s", e)
             self.report.add_error("Failed to instantiate workspace: %s" % e)
-            #  raise e
+            return self.report
+        with pushd_popd(self.workspace.directory):
+            if 'mets_unique_identifier' not in self.skip:
+                self._validate_mets_unique_identifier()
+            if 'mets_file_group_names' not in self.skip:
+                self._validate_mets_file_group_names()
+            if 'mets_files' not in self.skip:
+                self._validate_mets_files()
+            if 'pixel_density' not in self.skip:
+                self._validate_pixel_density()
+            if 'dimension' not in self.skip:
+                self._validate_dimension()
+            if 'page' not in self.skip:
+                self._validate_page()
         return self.report
 
     def _resolve_workspace(self):
@@ -94,7 +95,7 @@ class WorkspaceValidator():
         Clone workspace from mets_url unless workspace was provided.
         """
         if self.workspace is None:
-            self.workspace = self.resolver.workspace_from_url(self.mets_url, baseurl=self.src_dir, download=self.download)
+            self.workspace = self.resolver.workspace_from_url(self.mets_url, src_baseurl=self.src_dir, download=self.download)
             self.mets = self.workspace.mets
 
     def _validate_mets_unique_identifier(self):

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -5,6 +5,7 @@ import re
 
 from ocrd_utils import (
     getLogger,
+    is_local_filename,
     pushd_popd,
     MIMETYPE_PAGE,
 )
@@ -113,7 +114,7 @@ class WorkspaceValidator():
         See `spec <https://ocr-d.github.io/mets#pixel-density-of-images-must-be-explicit-and-high-enough>`_.
         """
         for f in [f for f in self.mets.find_files() if f.mimetype.startswith('image/')]:
-            if not f.local_filename and not self.download:
+            if not is_local_filename(f.url) and not self.download:
                 self.report.add_notice("Won't download remote image <%s>" % f.url)
                 continue
             exif = self.workspace.resolve_image_exif(f.url)

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -3,7 +3,11 @@ Validating a workspace.
 """
 import re
 
-from ocrd_utils import getLogger, MIMETYPE_PAGE
+from ocrd_utils import (
+    getLogger,
+    pushd_popd,
+    MIMETYPE_PAGE,
+)
 from .constants import FILE_GROUP_CATEGORIES, FILE_GROUP_PREFIX
 from .report import ValidationReport
 from .page_validator import PageValidator
@@ -69,16 +73,17 @@ class WorkspaceValidator():
         """
         try:
             self._resolve_workspace()
-            if 'mets_unique_identifier' not in self.skip:
-                self._validate_mets_unique_identifier()
-            if 'mets_file_group_names' not in self.skip:
-                self._validate_mets_file_group_names()
-            if 'mets_files' not in self.skip:
-                self._validate_mets_files()
-            if 'pixel_density' not in self.skip:
-                self._validate_pixel_density()
-            if 'page' not in self.skip:
-                self._validate_page()
+            with pushd_popd(self.workspace.directory):
+                if 'mets_unique_identifier' not in self.skip:
+                    self._validate_mets_unique_identifier()
+                if 'mets_file_group_names' not in self.skip:
+                    self._validate_mets_file_group_names()
+                if 'mets_files' not in self.skip:
+                    self._validate_mets_files()
+                if 'pixel_density' not in self.skip:
+                    self._validate_pixel_density()
+                if 'page' not in self.skip:
+                    self._validate_page()
         except Exception as e: # pylint: disable=broad-except
             self.report.add_error("Failed to instantiate workspace: %s" % e)
             #  raise e

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ sphinx
 codecov >= 2.0.15
 recommonmark >= 0.5.0
 docstr-coverage
+pylint

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,10 +1,10 @@
 # pylint: disable=unused-import
 
-import os
+from os.path import dirname, realpath
 import sys
 from unittest import TestCase, skip, main
 
-from .assets import assets
+from .assets import assets, copy_of_directory
 
 #  import traceback
 #  import warnings
@@ -14,4 +14,4 @@ from .assets import assets
 #      log.write(warnings.formatwarning(message, category, filename, lineno, line))
 #  warnings.showwarning = warn_with_traceback
 
-sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../ocrd')
+sys.path.append(dirname(realpath(__file__)) + '/../ocrd')

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 
 from tests.base import TestCase, main, assets # pylint: disable=import-error, no-name-in-module
 
-from ocrd_utils.logging import initLogging
+from ocrd_utils import initLogging
 from ocrd.cli.workspace import workspace_cli
 from ocrd.resolver import Resolver
 

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -155,12 +155,14 @@ class TestCli(TestCase):
         Test removal of filegrp
         """
         with TemporaryDirectory() as tempdir:
-            copytree(assets.path_to('SBB0000F29300010000/data'), join(tempdir, 'ws'))
+            wsdir = join(tempdir, 'ws')
+            copytree(assets.path_to('SBB0000F29300010000/data'), wsdir)
             file_group = 'OCR-D-GT-PAGE'
             file_path = join(tempdir, 'ws', file_group, 'FILE_0002_FULLTEXT.xml')
             self.assertTrue(exists(file_path))
 
-            workspace = self.resolver.workspace_from_url(join(tempdir, 'ws', 'mets.xml'))
+            workspace = self.resolver.workspace_from_url(join(wsdir, 'mets.xml'))
+            self.assertEqual(workspace.directory, wsdir)
 
             with self.assertRaisesRegex(Exception, "not empty"):
                 workspace.remove_file_group(file_group)

--- a/tests/model/test_ocrd_file.py
+++ b/tests/model/test_ocrd_file.py
@@ -17,6 +17,11 @@ class TestOcrdFile(TestCase):
         f.url = 'http://bar'
         self.assertEqual(f.url, 'http://bar')
 
+    def test_constructor_url(self):
+        f = OcrdFile(None, url="foo/bar")
+        self.assertEqual(f.url, 'foo/bar')
+        self.assertEqual(f.local_filename, 'foo/bar')
+
     def test_set_id_none(self):
         f = OcrdFile(None)
         f.ID = 'foo12'
@@ -27,6 +32,10 @@ class TestOcrdFile(TestCase):
     def test_basename(self):
         f = OcrdFile(None, local_filename='/tmp/foo/bar/foo.bar')
         self.assertEqual(f.basename, 'foo.bar')
+
+    def test_basename_from_url(self):
+        f = OcrdFile(None, url="http://foo.bar/quux")
+        self.assertEqual(f.basename, 'quux')
 
     def test_extension(self):
         f = OcrdFile(None, local_filename='/tmp/foo/bar/foo.bar')
@@ -43,6 +52,10 @@ class TestOcrdFile(TestCase):
     def test_basename_without_extension_tar(self):
         f = OcrdFile(None, local_filename='/tmp/foo/bar/foo.tar.gz')
         self.assertEqual(f.basename_without_extension, 'foo')
+
+    def test_fileGrp_wo_parent(self):
+        f = OcrdFile(None)
+        self.assertEqual(f.fileGrp, 'TEMP')
 
 if __name__ == '__main__':
     main()

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -4,8 +4,11 @@ from shutil import copytree
 from os.path import join
 from tests.base import TestCase, main, assets
 
-from ocrd_utils import VERSION, MIMETYPE_PAGE
-from ocrd_utils.logging import initLogging
+from ocrd_utils import (
+    initLogging,
+    VERSION,
+    MIMETYPE_PAGE
+)
 from ocrd_models import OcrdMets
 
 # pylint: disable=protected-access,deprecated-method,too-many-public-methods

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -1,8 +1,6 @@
 from datetime import datetime
-from tempfile import TemporaryDirectory
-from shutil import copytree
 from os.path import join
-from tests.base import TestCase, main, assets
+from tests.base import TestCase, main, assets, copy_of_directory
 
 from ocrd_utils import (
     initLogging,
@@ -155,17 +153,16 @@ class TestOcrdMets(TestCase):
         """
         Test removal of filegrp
         """
-        with TemporaryDirectory() as tempdir:
-            copytree(assets.path_to('SBB0000F29300010000/data'), join(tempdir, 'ws'))
-            mets = OcrdMets(filename=join(tempdir, 'ws', 'mets.xml'))
+        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
+            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
             self.assertEqual(len(mets.file_groups), 17)
             self.assertEqual(len(mets.find_files()), 35)
-            print()
-            before = sorted([x.ID for x in mets.find_files()])
+            #  print()
+            #  before = sorted([x.ID for x in mets.find_files()])
             with self.assertRaisesRegex(Exception, "not empty"):
                 mets.remove_file_group('OCR-D-GT-ALTO')
             mets.remove_file_group('OCR-D-GT-PAGE', recursive=True)
-            print([x for x in before if x not in sorted([x.ID for x in mets.find_files()])])
+            #  print([x for x in before if x not in sorted([x.ID for x in mets.find_files()])])
             self.assertEqual(len(mets.file_groups), 16)
             self.assertEqual(len(mets.find_files()), 33)
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -9,7 +9,7 @@ from tests.base import TestCase, assets, main # pylint: disable=import-error, no
 
 from ocrd import Processor
 from ocrd.decorators import ocrd_cli_options, ocrd_loglevel, ocrd_cli_wrap_processor
-from ocrd_utils.logging import setOverrideLogLevel, initLogging
+from ocrd_utils import setOverrideLogLevel, initLogging
 
 @click.command()
 @ocrd_cli_options

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -70,10 +70,11 @@ class TestDecorators(TestCase):
         result = self.runner.invoke(cli_dummy_processor, ['--version'])
         self.assertEqual(result.exit_code, 0)
 
-    def test_processor_non_existing_mets(self):
-        result = self.runner.invoke(cli_dummy_processor, ['--mets', 'file:///does/not/exist.xml'])
-        self.assertIn('File does not exist: file:///does/not/exist.xml', result.output)
-        self.assertEqual(result.exit_code, 1)
+    # XXX cannot be tested in this way because logging is reused and not part of output
+    #  def test_processor_non_existing_mets(self):
+    #      result = self.runner.invoke(cli_dummy_processor, ['--mets', 'file:///does/not/exist.xml'])
+    #      #  self.assertIn('File does not exist: file:///does/not/exist.xml', result.output)
+    #      self.assertEqual(result.exit_code, 1)
 
     def test_processor_run(self):
         with TemporaryDirectory() as tempdir:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,10 +1,10 @@
-import os
 import logging
 from tempfile import TemporaryDirectory
 
 from tests.base import TestCase, main
 
 from ocrd_utils import (
+    pushd_popd,
     getLevelName,
     setOverrideLogLevel,
     initLogging,
@@ -40,13 +40,11 @@ class TestLogging2(TestCase):
         self.assertEqual(getLevelName('OFF'), logging.CRITICAL)
 
     def test_configfile(self):
-        previous_dir = os.getcwd()
         with TemporaryDirectory() as tempdir:
-            os.chdir(tempdir)
-            with open('ocrd_logging.py', 'w') as f:
-                f.write('print("this is mighty dangerous")')
-            initLogging()
-        os.chdir(previous_dir)
+            with pushd_popd(tempdir):
+                with open('ocrd_logging.py', 'w') as f:
+                    f.write('print("this is mighty dangerous")')
+                initLogging()
 
 if __name__ == '__main__':
     main()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 
 from tests.base import TestCase, main
 
-from ocrd_utils.logging import (
+from ocrd_utils import (
     getLevelName,
     setOverrideLogLevel,
     initLogging,

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -34,12 +34,16 @@ class TestModelFactory(TestCase):
         self.assertEqual(p.get_Page().imageWidth, 1457)
 
     def test_page_from_file_no_local_filename(self):
-        with self.assertRaisesRegex(Exception, "input_file must have 'local_filename' property"):
+        with self.assertRaisesRegex(ValueError, "input_file must have 'local_filename' property"):
             page_from_file(OcrdFile(None, mimetype='image/tiff'))
 
+    def test_page_from_file_no_existe(self):
+        with self.assertRaisesRegex(FileNotFoundError, "File not found: 'no-existe'"):
+            page_from_file(OcrdFile(None, local_filename='no-existe', mimetype='foo/bar'))
+
     def test_page_from_file_unsupported_mimetype(self):
-        with self.assertRaisesRegex(Exception, "Unsupported mimetype"):
-            page_from_file(OcrdFile(None, mimetype='foo/bar'))
+        with self.assertRaisesRegex(ValueError, "Unsupported mimetype"):
+            page_from_file(OcrdFile(None, local_filename=__file__, mimetype='foo/bar'))
 
 if __name__ == '__main__':
     main()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,4 +1,4 @@
-from os import makedirs, walk
+from os import makedirs
 from os.path import join, exists
 from shutil import copytree, rmtree
 from re import sub
@@ -7,15 +7,12 @@ from tempfile import TemporaryDirectory
 from tests.base import TestCase, assets, main
 
 from ocrd.resolver import Resolver
-from ocrd.workspace import Workspace
 from ocrd_utils import pushd_popd
 #  setOverrideLogLevel('DEBUG')
-
 
 TMP_FOLDER = '/tmp/test-core-resolver'
 METS_HEROLD = assets.url_of('SBB0000F29300010000/data/mets.xml')
 FOLDER_KANT = assets.path_to('kant_aufklaerung_1784')
-TEST_ZIP = assets.path_to('test.ocrd.zip')
 
 # pylint: disable=redundant-unittest-assert, broad-except, deprecated-method, too-many-public-methods
 
@@ -141,78 +138,6 @@ class TestResolver(TestCase):
         tmp_dir = join(TMP_FOLDER, 'target')
         fn = self.resolver.download_to_directory(tmp_dir, 'file://' + join(self.folder, 'data/mets.xml'), subdir='baz')
         self.assertEqual(fn, join(tmp_dir, 'baz', 'mets.xml'))
-
-    def test_workspace_add_file(self):
-        with TemporaryDirectory() as tempdir:
-            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
-            fpath = join(tempdir, 'ID1.tif')
-            ws1.add_file(
-                'GRP',
-                ID='ID1',
-                mimetype='image/tiff',
-                content='CONTENT',
-                local_filename=fpath
-            )
-            f = ws1.mets.find_files()[0]
-            self.assertEqual(f.ID, 'ID1')
-            self.assertEqual(f.mimetype, 'image/tiff')
-            self.assertEqual(f.url, fpath)
-            self.assertEqual(f.local_filename, fpath)
-            self.assertTrue(exists(fpath))
-
-    def test_workspace_add_file_basename_no_content(self):
-        with TemporaryDirectory() as tempdir:
-            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
-            ws1.add_file('GRP', ID='ID1', mimetype='image/tiff')
-            f = ws1.mets.find_files()[0]
-            self.assertEqual(f.url, '')
-
-    def test_workspace_add_file_binary_content(self):
-        with TemporaryDirectory() as tempdir:
-            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
-            fpath = join(tempdir, 'subdir', 'ID1.tif')
-            ws1.add_file('GRP', ID='ID1', content=b'CONTENT', local_filename=fpath, url='http://foo/bar')
-            self.assertTrue(exists(fpath))
-
-    def test_workspacec_add_file_content_wo_local_filename(self):
-        with TemporaryDirectory() as tempdir:
-            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
-            with self.assertRaisesRegex(Exception, "'content' was set but no 'local_filename'"):
-                ws1.add_file('GRP', ID='ID1', content=b'CONTENT')
-
-
-    def test_workspace_str(self):
-        with TemporaryDirectory() as tempdir:
-            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
-            ws1.save_mets()
-            ws1.reload_mets()
-            self.assertEqual(str(ws1), 'Workspace[directory=%s, file_groups=[], files=[]]' % tempdir)
-
-    def test_workspace_backup(self):
-        with TemporaryDirectory() as tempdir:
-            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
-            ws1.automatic_backup = True
-            ws1.save_mets()
-            ws1.reload_mets()
-            self.assertEqual(str(ws1), 'Workspace[directory=%s, file_groups=[], files=[]]' % tempdir)
-
-    def test_227_1(self):
-        def find_recursive(root):
-            ret = []
-            for _, _, f in walk(root):
-                for file in f:
-                    ret.append(file)
-            return ret
-        with TemporaryDirectory() as wsdir:
-            with open(assets.path_to('SBB0000F29300010000/data/mets_one_file.xml'), 'r') as f_in:
-                with open(join(wsdir, 'mets.xml'), 'w') as f_out:
-                    f_out.write(f_in.read())
-            self.assertEqual(len(find_recursive(wsdir)), 1)
-            ws1 = Workspace(self.resolver, wsdir)
-            for file in ws1.mets.find_files():
-                ws1.download_file(file)
-            self.assertEqual(len(find_recursive(wsdir)), 2)
-            self.assertTrue(exists(join(wsdir, 'OCR-D-IMG/FILE_0005_IMAGE.tif')))
 
 if __name__ == '__main__':
     main()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,4 +1,4 @@
-import os
+from os import makedirs, walk
 from os.path import join, exists
 from shutil import copytree, rmtree
 from re import sub
@@ -8,7 +8,7 @@ from tests.base import TestCase, assets, main
 
 from ocrd.resolver import Resolver
 from ocrd.workspace import Workspace
-#  from ocrd_utils.logging import setOverrideLogLevel
+from ocrd_utils import pushd_popd
 #  setOverrideLogLevel('DEBUG')
 
 
@@ -16,7 +16,6 @@ TMP_FOLDER = '/tmp/test-core-resolver'
 METS_HEROLD = assets.url_of('SBB0000F29300010000/data/mets.xml')
 FOLDER_KANT = assets.path_to('kant_aufklaerung_1784')
 TEST_ZIP = assets.path_to('test.ocrd.zip')
-oldpwd = os.getcwd()
 
 # pylint: disable=redundant-unittest-assert, broad-except, deprecated-method, too-many-public-methods
 
@@ -27,7 +26,7 @@ class TestResolver(TestCase):
         self.folder = join(TMP_FOLDER, 'kant_aufklaerung_1784')
         if exists(TMP_FOLDER):
             rmtree(TMP_FOLDER)
-            os.makedirs(TMP_FOLDER)
+            makedirs(TMP_FOLDER)
         copytree(FOLDER_KANT, self.folder)
 
     def test_workspace_from_url_bad(self):
@@ -62,9 +61,8 @@ class TestResolver(TestCase):
 
     def test_workspace_from_url_rel_dir(self):
         with TemporaryDirectory() as dst_dir:
-            os.chdir(FOLDER_KANT)
-            self.resolver.workspace_from_url(None, baseurl='data', dst_dir='../../../../../../../../../../../../../../../../'+dst_dir[1:])
-            os.chdir(oldpwd)
+            with pushd_popd(FOLDER_KANT):
+                self.resolver.workspace_from_url(None, baseurl='data', dst_dir='../../../../../../../../../../../../../../../../'+dst_dir[1:])
 
     def test_workspace_from_url(self):
         workspace = self.resolver.workspace_from_url(METS_HEROLD)
@@ -201,7 +199,7 @@ class TestResolver(TestCase):
     def test_227_1(self):
         def find_recursive(root):
             ret = []
-            for _, _, f in os.walk(root):
+            for _, _, f in walk(root):
                 for file in f:
                     ret.append(file)
             return ret

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -41,7 +41,7 @@ class TestResolver(TestCase):
         with TemporaryDirectory() as dst_dir:
             dst_mets = Path(dst_dir, 'mets.xml')
             dst_mets.write_text('CONTENT')
-            with self.assertRaisesRegex(Exception, "File already exists and 'overwrite' not set: %s" % dst_mets):
+            with self.assertRaisesRegex(FileExistsError, "File already exists and if_exists == 'raise': %s" % dst_mets):
                 self.resolver.workspace_from_url(
                         'https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xml',
                         dst_dir=dst_dir)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -78,31 +78,34 @@ class TestResolver(TestCase):
         self.assertEqual(f.ID, 'FILE_0001_IMAGE')
         #  print(f)
 
+    # pylint: disable=protected-access
     def test_resolve_image(self):
         workspace = self.resolver.workspace_from_url(METS_HEROLD)
         input_files = workspace.mets.find_files(fileGrp='OCR-D-IMG')
         f = input_files[0]
         print(f.url)
-        img_pil1 = workspace.resolve_image_as_pil(f.url)
+        img_pil1 = workspace._resolve_image_as_pil(f.url)
         self.assertEqual(img_pil1.size, (2875, 3749))
-        img_pil2 = workspace.resolve_image_as_pil(f.url, [[0, 0], [1, 1]])
+        img_pil2 = workspace._resolve_image_as_pil(f.url, [[0, 0], [1, 1]])
         self.assertEqual(img_pil2.size, (1, 1))
-        img_pil2 = workspace.resolve_image_as_pil(f.url, [[0, 0], [1, 1]])
+        img_pil2 = workspace._resolve_image_as_pil(f.url, [[0, 0], [1, 1]])
 
+    # pylint: disable=protected-access
     def test_resolve_image_grayscale(self):
         img_url = assets.url_of('kant_aufklaerung_1784-binarized/data/OCR-D-IMG-NRM/OCR-D-IMG-NRM_0017')
         workspace = self.resolver.workspace_from_url(METS_HEROLD)
-        img_pil1 = workspace.resolve_image_as_pil(img_url)
+        img_pil1 = workspace._resolve_image_as_pil(img_url)
         self.assertEqual(img_pil1.size, (1457, 2083))
-        img_pil2 = workspace.resolve_image_as_pil(img_url, [[0, 0], [1, 1]])
+        img_pil2 = workspace._resolve_image_as_pil(img_url, [[0, 0], [1, 1]])
         self.assertEqual(img_pil2.size, (1, 1))
 
+    # pylint: disable=protected-access
     def test_resolve_image_bitonal(self):
         img_url = assets.url_of('kant_aufklaerung_1784-binarized/data/OCR-D-IMG-1BIT/OCR-D-IMG-1BIT_0017')
         workspace = self.resolver.workspace_from_url(METS_HEROLD)
-        img_pil1 = workspace.resolve_image_as_pil(img_url)
+        img_pil1 = workspace._resolve_image_as_pil(img_url)
         self.assertEqual(img_pil1.size, (1457, 2083))
-        img_pil2 = workspace.resolve_image_as_pil(img_url, [[0, 0], [1, 1]])
+        img_pil2 = workspace._resolve_image_as_pil(img_url, [[0, 0], [1, 1]])
         self.assertEqual(img_pil2.size, (1, 1))
 
     def test_workspace_from_nothing(self):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,5 +1,5 @@
 from os import makedirs
-from os.path import join, exists
+from os.path import join, exists, isdir
 from re import sub
 from tempfile import TemporaryDirectory
 
@@ -19,6 +19,8 @@ class TestResolver(TestCase):
 
     def setUp(self):
         self.resolver = Resolver()
+        if not isdir(TMP_FOLDER):
+            makedirs(TMP_FOLDER)
 
     def test_workspace_from_url_bad(self):
         with self.assertRaisesRegex(Exception, "Must pass mets_url and/or baseurl"):
@@ -102,6 +104,12 @@ class TestResolver(TestCase):
         ws1 = self.resolver.workspace_from_nothing(None)
         self.assertIsNotNone(ws1.mets)
 
+    def test_workspace_from_nothing_makedirs(self):
+        with TemporaryDirectory() as tempdir:
+            non_existant_dir = join(tempdir, 'target')
+            ws1 = self.resolver.workspace_from_nothing(non_existant_dir)
+            self.assertEqual(ws1.directory, non_existant_dir)
+
     def test_workspace_from_nothing_noclobber(self):
         with TemporaryDirectory() as tempdir:
             ws2 = self.resolver.workspace_from_nothing(tempdir)
@@ -120,21 +128,21 @@ class TestResolver(TestCase):
 
     def test_download_to_directory_default(self):
         with copy_of_directory(FOLDER_KANT) as dst:
-            tmp_dir = join(TMP_FOLDER, 'target')
-            fn = self.resolver.download_to_directory(tmp_dir, 'file://' + join(dst, 'data/mets.xml'))
-            self.assertEqual(fn, join(tmp_dir, 'file%s.data.mets.xml' % sub(r'[/_\.\-]', '.', dst)))
+            dst_subdir = join(dst, 'target')
+            fn = self.resolver.download_to_directory(dst_subdir, 'file://' + join(dst, 'data/mets.xml'))
+            self.assertEqual(fn, join(dst_subdir, 'file%s.data.mets.xml' % sub(r'[/_\.\-]', '.', dst)))
 
     def test_download_to_directory_basename(self):
         with copy_of_directory(FOLDER_KANT) as dst:
-            tmp_dir = join(TMP_FOLDER, 'target')
-            fn = self.resolver.download_to_directory(tmp_dir, 'file://' + join(dst, 'data/mets.xml'), basename='foo')
-            self.assertEqual(fn, join(tmp_dir, 'foo'))
+            dst_subdir = join(dst, 'target')
+            fn = self.resolver.download_to_directory(dst_subdir, 'file://' + join(dst, 'data/mets.xml'), basename='foo')
+            self.assertEqual(fn, join(dst_subdir, 'foo'))
 
     def test_download_to_directory_subdir(self):
         with copy_of_directory(FOLDER_KANT) as dst:
-            tmp_dir = join(TMP_FOLDER, 'target')
-            fn = self.resolver.download_to_directory(tmp_dir, 'file://' + join(dst, 'data/mets.xml'), subdir='baz')
-            self.assertEqual(fn, join(tmp_dir, 'baz', 'mets.xml'))
+            dst_subdir = join(dst, 'target')
+            fn = self.resolver.download_to_directory(dst_subdir, 'file://' + join(dst, 'data/mets.xml'), subdir='baz')
+            self.assertEqual(fn, join(dst_subdir, 'baz', 'mets.xml'))
 
 if __name__ == '__main__':
     main()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -214,7 +214,7 @@ class TestResolver(TestCase):
             for file in ws1.mets.find_files():
                 ws1.download_file(file)
             self.assertEqual(len(find_recursive(wsdir)), 2)
-            self.assertTrue(exists(join(wsdir, 'OCR-D-IMG/FILE_0005_IMAGE')))
+            self.assertTrue(exists(join(wsdir, 'OCR-D-IMG/FILE_0005_IMAGE.tif')))
 
 if __name__ == '__main__':
     main()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -76,6 +76,7 @@ class TestResolver(TestCase):
         #  print(image_file)
         f = workspace.download_file(image_file)
         self.assertEqual(f.ID, 'FILE_0001_IMAGE')
+        self.assertEqual(f.local_filename, 'OCR-D-IMG/FILE_0001_IMAGE')
         #  print(f)
 
     # pylint: disable=protected-access

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from ocrd_utils import (
 
     concat_padded,
     is_local_filename,
+    get_local_filename,
     is_string,
     membername,
 
@@ -33,9 +34,6 @@ class TestUtils(TestCase):
 
     def test_abspath(self):
         self.assertEqual(abspath('file:///'), '/')
-
-    def test_is_local_filename(self):
-        self.assertEqual(is_local_filename('file:///'), True)
 
     def test_points_from_xywh(self):
         self.assertEqual(
@@ -133,6 +131,21 @@ class TestUtils(TestCase):
         with pushd_popd('/tmp'):
             self.assertEqual(getcwd(), '/tmp')
         self.assertEqual(getcwd(), cwd)
+
+    def test_is_local_filename(self):
+        self.assertTrue(is_local_filename('/foo/bar'))
+        self.assertTrue(is_local_filename('file:///foo/bar'))
+        self.assertTrue(is_local_filename('file:/foo/bar'))
+        self.assertTrue(is_local_filename('foo/bar'))
+        self.assertFalse(is_local_filename('bad-scheme://foo/bar'))
+
+    def test_local_filename(self):
+        self.assertEqual(get_local_filename('/foo/bar'), '/foo/bar')
+        self.assertEqual(get_local_filename('file:///foo/bar'), '/foo/bar')
+        self.assertEqual(get_local_filename('file:/foo/bar'), '/foo/bar')
+        self.assertEqual(get_local_filename('/foo/bar', '/foo/'), 'bar')
+        self.assertEqual(get_local_filename('/foo/bar', '/foo'), 'bar')
+        self.assertEqual(get_local_filename('foo/bar', 'foo'), 'bar')
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,9 @@ from ocrd_utils import (
     is_string,
     membername,
 
+    nth_url_segment,
+    remove_non_path_from_url,
+
     points_from_bbox,
     points_from_x0y0x1y1,
     points_from_xywh,
@@ -147,6 +150,23 @@ class TestUtils(TestCase):
         self.assertEqual(get_local_filename('/foo/bar', '/foo'), 'bar')
         self.assertEqual(get_local_filename('foo/bar', 'foo'), 'bar')
 
+    def test_remove_non_path_from_url(self):
+        self.assertEqual(remove_non_path_from_url('https://foo/bar'), 'https://foo/bar')
+        self.assertEqual(remove_non_path_from_url('https://foo//?bar#frag'), 'https://foo')
+        self.assertEqual(remove_non_path_from_url('/path/to/foo#frag'), '/path/to/foo')
+
+    def test_nth_url_segment(self):
+        self.assertEqual(nth_url_segment(''), '')
+        self.assertEqual(nth_url_segment('foo'), 'foo')
+        self.assertEqual(nth_url_segment('foo', n=-1), 'foo')
+        self.assertEqual(nth_url_segment('foo', n=-2), '')
+        self.assertEqual(nth_url_segment('foo/bar', n=-2), 'foo')
+        self.assertEqual(nth_url_segment('/baz/bar', n=-2), 'baz')
+        self.assertEqual(nth_url_segment('foo/'), 'foo')
+        self.assertEqual(nth_url_segment('foo//?bar#frag'), 'foo')
+        self.assertEqual(nth_url_segment('/path/to/foo#frag'), 'foo')
+        self.assertEqual(nth_url_segment('/path/to/foo#frag', n=-2), 'to')
+        self.assertEqual(nth_url_segment('https://server/foo?xyz=zyx'), 'foo')
 
 if __name__ == '__main__':
     main()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -78,25 +78,25 @@ class TestWorkspace(TestCase):
             ws1.reload_mets()
             self.assertEqual(str(ws1), 'Workspace[directory=%s, baseurl=None, file_groups=[], files=[]]' % tempdir)
 
-    def test_download_url(self):
+    def test_download_url0(self):
         with TemporaryDirectory() as directory:
             ws1 = self.resolver.workspace_from_nothing(directory)
             fn = ws1.download_url(abspath(__file__))
             self.assertEqual(fn, join('TEMP', basename(__file__)))
 
     def test_download_url_without_baseurl(self):
-        with TemporaryDirectory() as tempdir:
-            dst_mets = join(tempdir, 'mets.xml')
+        with TemporaryDirectory() as dst_dir:
+            dst_mets = join(dst_dir, 'mets.xml')
             copyfile(SRC_METS, dst_mets)
             ws1 = self.resolver.workspace_from_url(dst_mets)
-            with self.assertRaisesRegex(Exception, "Cannot retrieve non-existant local file %s" % join(tempdir, SAMPLE_FILE_URL)):
+            with self.assertRaisesRegex(Exception, "Already tried prepending baseurl '%s'" % dst_dir):
                 ws1.download_url(SAMPLE_FILE_URL)
 
     def test_download_url_with_baseurl(self):
         with TemporaryDirectory() as tempdir:
             dst_mets = join(tempdir, 'mets.xml')
             copyfile(SRC_METS, dst_mets)
-            ws1 = self.resolver.workspace_from_url(dst_mets, baseurl=dirname(SRC_METS))
+            ws1 = self.resolver.workspace_from_url(dst_mets, src_baseurl=dirname(SRC_METS))
             f = Path(ws1.download_url(SAMPLE_FILE_URL))
             self.assertEqual(f, Path('TEMP', SAMPLE_FILE_ID))
             self.assertTrue(Path(ws1.directory, f).exists())
@@ -121,7 +121,7 @@ class TestWorkspace(TestCase):
 
     #  def test_remove(self):
     #      with TemporaryDirectory() as tempdir:
-    #          dst_dir = 
+    #          dst_dir =
     #          ws1 = self.resolver.workspace_from_url(SRC_METS, dst_dir=dst_dir)
     #          res = ws1.download_url(SAMPLE_FILE_URL)
     #          print('>>>>>> %s' % res)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -85,11 +85,11 @@ class TestWorkspace(TestCase):
             self.assertEqual(fn, join('TEMP', basename(__file__)))
 
     def test_download_url_without_baseurl(self):
-        with TemporaryDirectory() as dst_dir:
-            dst_mets = join(dst_dir, 'mets.xml')
+        with TemporaryDirectory() as tempdir:
+            dst_mets = join(tempdir, 'mets.xml')
             copyfile(SRC_METS, dst_mets)
             ws1 = self.resolver.workspace_from_url(dst_mets)
-            with self.assertRaisesRegex(Exception, "Already tried prepending baseurl '%s'" % dst_dir)
+            with self.assertRaisesRegex(Exception, "Already tried prepending baseurl '%s'" % tempdir):
                 ws1.download_url(SAMPLE_FILE_URL)
 
     def test_download_url_with_baseurl(self):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,5 +1,5 @@
 from os import makedirs, walk
-from os.path import join, exists
+from os.path import join, exists, abspath, basename
 from shutil import copytree, rmtree
 from tempfile import TemporaryDirectory
 
@@ -74,6 +74,12 @@ class TestWorkspace(TestCase):
             ws1.save_mets()
             ws1.reload_mets()
             self.assertEqual(str(ws1), 'Workspace[directory=%s, file_groups=[], files=[]]' % tempdir)
+
+    def test_download_url(self):
+        with TemporaryDirectory() as tempdir:
+            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
+            fn = ws1.download_url(abspath(__file__))
+            self.assertEqual(fn, join(ws1.directory, 'TEMP', basename(__file__)))
 
     def test_227_1(self):
         def find_recursive(root):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -13,9 +13,10 @@ from ocrd.workspace import Workspace
 
 TMP_FOLDER = '/tmp/test-core-workspace'
 SRC_METS = assets.path_to('kant_aufklaerung_1784/data/mets.xml')
-SAMPLE_FILE_SUBDIR = 'OCR-D-IMG'
-SAMPLE_FILE_BASENAME = 'INPUT_0017'
-SAMPLE_FILE_URL = join(SAMPLE_FILE_SUBDIR, SAMPLE_FILE_BASENAME)
+
+SAMPLE_FILE_FILEGRP = 'OCR-D-IMG'
+SAMPLE_FILE_ID = 'INPUT_0017'
+SAMPLE_FILE_URL = join(SAMPLE_FILE_FILEGRP, SAMPLE_FILE_ID)
 
 class TestWorkspace(TestCase):
 
@@ -97,7 +98,7 @@ class TestWorkspace(TestCase):
             ws1 = self.resolver.workspace_from_url(dst_mets, baseurl=dirname(SRC_METS))
             fn = ws1.download_url(SAMPLE_FILE_URL)
             self.assertTrue(exists(fn))
-            self.assertEqual(fn, join(ws1.directory, 'TEMP', SAMPLE_FILE_BASENAME))
+            self.assertEqual(fn, join(ws1.directory, 'TEMP', SAMPLE_FILE_ID))
 
     def test_227_1(self):
         def find_recursive(root):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,97 @@
+from os import makedirs, walk
+from os.path import join, exists
+from shutil import copytree, rmtree
+from tempfile import TemporaryDirectory
+
+from tests.base import TestCase, assets, main
+
+from ocrd.resolver import Resolver
+from ocrd.workspace import Workspace
+
+TMP_FOLDER = '/tmp/test-core-workspace'
+FOLDER_KANT = assets.path_to('kant_aufklaerung_1784')
+
+class TestWorkspace(TestCase):
+
+    def setUp(self):
+        self.resolver = Resolver()
+        self.folder = join(TMP_FOLDER, 'kant_aufklaerung_1784')
+        if exists(TMP_FOLDER):
+            rmtree(TMP_FOLDER)
+            makedirs(TMP_FOLDER)
+        copytree(FOLDER_KANT, self.folder)
+
+    def test_workspace_add_file(self):
+        with TemporaryDirectory() as tempdir:
+            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
+            fpath = join(tempdir, 'ID1.tif')
+            ws1.add_file(
+                'GRP',
+                ID='ID1',
+                mimetype='image/tiff',
+                content='CONTENT',
+                local_filename=fpath
+            )
+            f = ws1.mets.find_files()[0]
+            self.assertEqual(f.ID, 'ID1')
+            self.assertEqual(f.mimetype, 'image/tiff')
+            self.assertEqual(f.url, fpath)
+            self.assertEqual(f.local_filename, fpath)
+            self.assertTrue(exists(fpath))
+
+    def test_workspace_add_file_basename_no_content(self):
+        with TemporaryDirectory() as tempdir:
+            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
+            ws1.add_file('GRP', ID='ID1', mimetype='image/tiff')
+            f = ws1.mets.find_files()[0]
+            self.assertEqual(f.url, '')
+
+    def test_workspace_add_file_binary_content(self):
+        with TemporaryDirectory() as tempdir:
+            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
+            fpath = join(tempdir, 'subdir', 'ID1.tif')
+            ws1.add_file('GRP', ID='ID1', content=b'CONTENT', local_filename=fpath, url='http://foo/bar')
+            self.assertTrue(exists(fpath))
+
+    def test_workspacec_add_file_content_wo_local_filename(self):
+        with TemporaryDirectory() as tempdir:
+            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
+            with self.assertRaisesRegex(Exception, "'content' was set but no 'local_filename'"):
+                ws1.add_file('GRP', ID='ID1', content=b'CONTENT')
+
+
+    def test_workspace_str(self):
+        with TemporaryDirectory() as tempdir:
+            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
+            ws1.save_mets()
+            ws1.reload_mets()
+            self.assertEqual(str(ws1), 'Workspace[directory=%s, file_groups=[], files=[]]' % tempdir)
+
+    def test_workspace_backup(self):
+        with TemporaryDirectory() as tempdir:
+            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
+            ws1.automatic_backup = True
+            ws1.save_mets()
+            ws1.reload_mets()
+            self.assertEqual(str(ws1), 'Workspace[directory=%s, file_groups=[], files=[]]' % tempdir)
+
+    def test_227_1(self):
+        def find_recursive(root):
+            ret = []
+            for _, _, f in walk(root):
+                for file in f:
+                    ret.append(file)
+            return ret
+        with TemporaryDirectory() as wsdir:
+            with open(assets.path_to('SBB0000F29300010000/data/mets_one_file.xml'), 'r') as f_in:
+                with open(join(wsdir, 'mets.xml'), 'w') as f_out:
+                    f_out.write(f_in.read())
+            self.assertEqual(len(find_recursive(wsdir)), 1)
+            ws1 = Workspace(self.resolver, wsdir)
+            for file in ws1.mets.find_files():
+                ws1.download_file(file)
+            self.assertEqual(len(find_recursive(wsdir)), 2)
+            self.assertTrue(exists(join(wsdir, 'OCR-D-IMG/FILE_0005_IMAGE.tif')))
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,6 +2,7 @@ from os import walk
 from os.path import join, exists, abspath, basename, dirname
 from tempfile import TemporaryDirectory
 from shutil import copyfile
+from pathlib import Path
 
 from tests.base import TestCase, assets, main
 
@@ -78,10 +79,10 @@ class TestWorkspace(TestCase):
             self.assertEqual(str(ws1), 'Workspace[directory=%s, baseurl=None, file_groups=[], files=[]]' % tempdir)
 
     def test_download_url(self):
-        with TemporaryDirectory() as tempdir:
-            ws1 = self.resolver.workspace_from_nothing(directory=tempdir)
+        with TemporaryDirectory() as directory:
+            ws1 = self.resolver.workspace_from_nothing(directory)
             fn = ws1.download_url(abspath(__file__))
-            self.assertEqual(fn, join(ws1.directory, 'TEMP', basename(__file__)))
+            self.assertEqual(fn, join('TEMP', basename(__file__)))
 
     def test_download_url_without_baseurl(self):
         with TemporaryDirectory() as tempdir:
@@ -96,9 +97,9 @@ class TestWorkspace(TestCase):
             dst_mets = join(tempdir, 'mets.xml')
             copyfile(SRC_METS, dst_mets)
             ws1 = self.resolver.workspace_from_url(dst_mets, baseurl=dirname(SRC_METS))
-            fn = ws1.download_url(SAMPLE_FILE_URL)
-            self.assertTrue(exists(fn))
-            self.assertEqual(fn, join(ws1.directory, 'TEMP', SAMPLE_FILE_ID))
+            f = Path(ws1.download_url(SAMPLE_FILE_URL))
+            self.assertEqual(f, Path('TEMP', SAMPLE_FILE_ID))
+            self.assertTrue(Path(ws1.directory, f).exists())
 
     def test_227_1(self):
         def find_recursive(root):
@@ -117,6 +118,18 @@ class TestWorkspace(TestCase):
                 ws1.download_file(file)
             self.assertEqual(len(find_recursive(wsdir)), 2)
             self.assertTrue(exists(join(wsdir, 'OCR-D-IMG/FILE_0005_IMAGE.tif')))
+
+    #  def test_remove(self):
+    #      with TemporaryDirectory() as tempdir:
+    #          dst_dir = 
+    #          ws1 = self.resolver.workspace_from_url(SRC_METS, dst_dir=dst_dir)
+    #          res = ws1.download_url(SAMPLE_FILE_URL)
+    #          print('>>>>>> %s' % res)
+    #          ocrd_file = ws1.remove_file(SAMPLE_FILE_ID)
+    #          print(ocrd_file)
+    #          import os
+    #          self.assertTrue(exists(join(ws1.directory, ocrd_file.local_filename)))
+    #          #  with copy_of_directory(FOLDER_KANT) as tempdir:
 
 if __name__ == '__main__':
     main()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -17,7 +17,7 @@ SRC_METS = assets.path_to('kant_aufklaerung_1784/data/mets.xml')
 
 SAMPLE_FILE_FILEGRP = 'OCR-D-IMG'
 SAMPLE_FILE_ID = 'INPUT_0017'
-SAMPLE_FILE_URL = join(SAMPLE_FILE_FILEGRP, SAMPLE_FILE_ID)
+SAMPLE_FILE_URL = join(SAMPLE_FILE_FILEGRP, '%s.tif' % SAMPLE_FILE_ID)
 
 class TestWorkspace(TestCase):
 
@@ -98,7 +98,7 @@ class TestWorkspace(TestCase):
             copyfile(SRC_METS, dst_mets)
             ws1 = self.resolver.workspace_from_url(dst_mets, src_baseurl=dirname(SRC_METS))
             f = Path(ws1.download_url(SAMPLE_FILE_URL))
-            self.assertEqual(f, Path('TEMP', SAMPLE_FILE_ID))
+            self.assertEqual(f, Path('TEMP', '%s.tif' % SAMPLE_FILE_ID))
             self.assertTrue(Path(ws1.directory, f).exists())
 
     def test_227_1(self):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -89,7 +89,7 @@ class TestWorkspace(TestCase):
             dst_mets = join(dst_dir, 'mets.xml')
             copyfile(SRC_METS, dst_mets)
             ws1 = self.resolver.workspace_from_url(dst_mets)
-            with self.assertRaisesRegex(Exception, "Already tried prepending baseurl '%s'" % dst_dir):
+            with self.assertRaisesRegex(Exception, "Already tried prepending baseurl '%s'" % dst_dir)
                 ws1.download_url(SAMPLE_FILE_URL)
 
     def test_download_url_with_baseurl(self):

--- a/tests/validator/test_ocrd_zip_validator.py
+++ b/tests/validator/test_ocrd_zip_validator.py
@@ -4,7 +4,7 @@ from tempfile import mkdtemp
 
 from tests.base import TestCase, main, assets # pylint: disable=import-error,no-name-in-module
 
-from bagit import BagValidationError # pylint: disable=no-name-in-module
+#  from bagit import BagValidationError # pylint: disable=no-name-in-module
 
 from ocrd_validators import OcrdZipValidator
 from ocrd.workspace import Workspace
@@ -25,7 +25,7 @@ class TestOcrdZipValidator(TestCase):
     def tearDown(self):
         rmtree(self.tempdir)
 
-    def test_validation(self):
+    def test_validation0(self):
         ocrdzip = self.bagger.bag(self.workspace, 'SBB0000F29300010000', ocrd_manifestation_depth='partial')
         report = OcrdZipValidator(self.resolver, ocrdzip).validate()
         self.assertEqual(report.is_valid, True)

--- a/tests/validator/test_page_validator.py
+++ b/tests/validator/test_page_validator.py
@@ -1,5 +1,3 @@
-from os import chdir
-
 from tests.base import TestCase, assets, main # pylint: disable=import-error,no-name-in-module
 from ocrd.resolver import Resolver
 from ocrd_validators import PageValidator

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -98,9 +98,9 @@ class TestWorkspaceValidator(TestCase):
         with TemporaryDirectory() as tempdir:
             workspace = self.resolver.workspace_from_nothing(directory=tempdir)
             workspace.mets.unique_identifier = 'foobar'
-            workspace.mets.add_file('OCR-D-GT-BIN', ID='file1', mimetype='image/png', pageId='page1', url='file://%s' % imgpath)
+            workspace.mets.add_file('OCR-D-GT-BIN', ID='file1', mimetype='image/png', pageId='page1', url=imgpath)
             workspace.save_mets()
-            report = WorkspaceValidator.validate(self.resolver, join(tempdir, 'mets.xml'), skip=[])
+            report = WorkspaceValidator.validate(self.resolver, join(tempdir, 'mets.xml'), skip=[], download=False)
             self.assertEqual(len(report.errors), 0)
             self.assertEqual(len(report.warnings), 0)
             self.assertEqual(len(report.notices), 0)
@@ -110,7 +110,7 @@ class TestWorkspaceValidator(TestCase):
         with TemporaryDirectory() as tempdir:
             workspace = self.resolver.workspace_from_nothing(directory=tempdir)
             workspace.mets.unique_identifier = 'foobar'
-            workspace.mets.add_file('OCR-D-GT-BIN', ID='file1', mimetype='image/png', pageId='page1', url='file://%s' % imgpath)
+            workspace.mets.add_file('OCR-D-GT-BIN', ID='file1', mimetype='image/png', pageId='page1', url=imgpath)
             workspace.save_mets()
             report = WorkspaceValidator.validate(self.resolver, join(tempdir, 'mets.xml'), skip=[], download=True)
             self.assertEqual(len(report.errors), 2)


### PR DESCRIPTION
I went through the code and tried to get rid of all the logic that was based on `file://` URLs and the complexities from supporting all sorts of URLs.

In particular, filenames will be resolved to relative paths from the workspace directory whereever possible. To achieve that, employ the `pushd_popd` context manager in all places where relative filenames can be expected.

Split workspace tests from resolver tests.

`Workspace.download_to_directory`'s  boolean `overwrite` argument replaced with an `if_exists` string, that can handle existing files as an exception (`"raise"`), skip them (`"skip"`, the default) or overwrite them (`"overwrite"`).

Fix #302 
Fix #272
Fix #248 
Fix #227
Fix #96 

Supersedes #266 
