### PR TITLE
allow parameter CLI arg to contain JSON strings, fix #239

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 Changed:
 
   * `-m/--mets` is not required anymore, #301
+  * `-p/--parameter` argument accepts raw JSON as well now, #239
 
 Fixed:
 

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -19,13 +19,19 @@ loglevel_option = click.option('-l', '--log-level', help="Log level",
 
 def _parse_json_string_or_file(ctx, param, value='{}'):    # pylint: disable=unused-argument
     ret = None
+    err = None
     try:
-        with open(value, 'r') as f:
-            ret = json.load(f)
-    except FileNotFoundError:
-        ret = json.loads(value.strip())
-    if not isinstance(ret, dict):
-        raise ValueError("JSON parameter '%s' is not a valid JSON object")
+        try:
+            with open(value, 'r') as f:
+                ret = json.load(f)
+        except FileNotFoundError:
+            ret = json.loads(value.strip())
+        if not isinstance(ret, dict):
+            err = ValueError("Not a valid JSON object: '%s' (parsed as '%s')" % (value, ret))
+    except json.decoder.JSONDecodeError as e:
+        err = ValueError("Error parsing '%s': %s" % (value, e))
+    if err:
+        raise err       # pylint: disable=raising-bad-type
     return ret
 
 parameter_option = click.option('-p', '--parameter',

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import click
@@ -15,6 +16,22 @@ def _set_root_logger_version(ctx, param, value):    # pylint: disable=unused-arg
 loglevel_option = click.option('-l', '--log-level', help="Log level",
                                type=click.Choice(['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']),
                                default=None, callback=_set_root_logger_version)
+
+def _parse_json_string_or_file(ctx, param, value='{}'):    # pylint: disable=unused-argument
+    ret = None
+    try:
+        with open(value, 'r') as f:
+            ret = json.load(f)
+    except FileNotFoundError:
+        ret = json.loads(value.strip())
+    if not isinstance(ret, dict):
+        raise ValueError("JSON parameter '%s' is not a valid JSON object")
+    return ret
+
+parameter_option = click.option('-p', '--parameter',
+                                help="Parameters, either JSON string or path to JSON file",
+                                default='{}',
+                                callback=_parse_json_string_or_file)
 
 def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_dir=None, dump_json=False, version=False, **kwargs):
     if dump_json:
@@ -63,7 +80,7 @@ def ocrd_cli_options(f):
         click.option('-I', '--input-file-grp', help='File group(s) used as input.', default='INPUT'),
         click.option('-O', '--output-file-grp', help='File group(s) used as output.', default='OUTPUT'),
         click.option('-g', '--page-id', help="ID(s) of the pages to process"),
-        click.option('-p', '--parameter', type=click.Path()),
+        parameter_option,
         click.option('-J', '--dump-json', help="Dump tool description as JSON and exit", is_flag=True, default=False),
         loglevel_option,
         click.option('-V', '--version', help="Show version", is_flag=True, default=False)

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -40,15 +40,6 @@ def run_processor(
         mets_url,
         working_dir
     )
-    if parameter is not None:
-        if not '://' in parameter:
-            fname = os.path.abspath(parameter)
-        else:
-            fname = workspace.download_url(parameter)
-        with open(fname, 'r') as param_json_file:
-            parameter = json.load(param_json_file)
-    else:
-        parameter = {}
     log.debug("Running processor %s", processorClass)
     processor = processorClass(
         workspace,

--- a/ocrd_validators/ocrd_validators/json_validator.py
+++ b/ocrd_validators/ocrd_validators/json_validator.py
@@ -74,5 +74,6 @@ class JsonValidator():
         report = ValidationReport()
         if not self.validator.is_valid(obj):
             for v in self.validator.iter_errors(obj):
+                #  print(">>>>>>>>> v='%s', obj='%s'" % (v, obj))
                 report.add_error("[%s] %s" % ('.'.join(str(vv) for vv in v.path), v.message))
         return report

--- a/tests/base.py
+++ b/tests/base.py
@@ -4,7 +4,7 @@ import os
 import sys
 from unittest import TestCase, skip, main
 
-from .assets import assets
+from .assets import assets, copy_of_directory
 
 #  import traceback
 #  import warnings

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -1,3 +1,5 @@
+import json
+
 from tempfile import TemporaryDirectory
 from os.path import join
 from tests.base import TestCase, assets, main # pylint: disable=import-error, no-name-in-module
@@ -47,26 +49,14 @@ class TestResolver(TestCase):
         with TemporaryDirectory() as tempdir:
             jsonpath = join(tempdir, 'params.json')
             with open(jsonpath, 'w') as f:
-                f.write('{}')
-            processor = run_processor(
-                DummyProcessor,
-                parameter=jsonpath,
-                resolver=self.resolver,
-                mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml')
-            )
-            self.assertEqual(len(processor.input_files), 35)
-
-    def test_parameter_url(self):
-        with TemporaryDirectory() as tempdir:
-            jsonpath = join(tempdir, 'params.json')
-            with open(jsonpath, 'w') as f:
-                f.write('{}')
-            processor = run_processor(
-                DummyProcessor,
-                parameter='file://%s' % jsonpath,
-                resolver=self.resolver,
-                mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml')
-            )
+                f.write('{"baz": "quux"}')
+            with open(jsonpath, 'r') as f:
+                processor = run_processor(
+                    DummyProcessor,
+                    parameter=json.load(f),
+                    resolver=self.resolver,
+                    mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml')
+                )
             self.assertEqual(len(processor.input_files), 35)
 
     def test_verify(self):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -90,7 +90,7 @@ class TestDecorators(TestCase):
         self.assertEqual(_parse_json_string_or_file(None, None, '{"foo": 32}'), {'foo': 32})
         self.assertEqual(_parse_json_string_or_file(None, None, '{"foo": 32}'), {'foo': 32})
         with TemporaryDirectory() as tempdir:
-            paramfile = Path(tempdir, '{}') # XXX yes, the file is called '{}'
+            paramfile = str(Path(tempdir, '{}')) # XXX yes, the file is called '{}'
             with open(paramfile, 'w') as f:
                 f.write('{"bar": 42}')
             self.assertEqual(_parse_json_string_or_file(None, None, paramfile), {'bar': 42})

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -7,7 +7,12 @@ from click.testing import CliRunner
 from tests.base import TestCase, assets, main, copy_of_directory # pylint: disable=import-error, no-name-in-module
 
 from ocrd import Processor
-from ocrd.decorators import ocrd_cli_options, ocrd_loglevel, ocrd_cli_wrap_processor
+from ocrd.decorators import (
+    ocrd_cli_options,
+    ocrd_loglevel,
+    ocrd_cli_wrap_processor,
+    _parse_json_string_or_file
+)    # pylint: disable=protected-access
 from ocrd_utils.logging import setOverrideLogLevel, initLogging
 from ocrd_utils import pushd_popd
 
@@ -83,12 +88,13 @@ class TestDecorators(TestCase):
                 result = self.runner.invoke(cli_dummy_processor, ['--mets', 'mets.xml'])
                 self.assertEqual(result.exit_code, 0)
 
-    def test_parameters(self):
-        from ocrd.decorators import _parse_json_string_or_file      # pylint: disable=protected-access
+    def test_parameters0(self):
         self.assertEqual(_parse_json_string_or_file(None, None), {})
         self.assertEqual(_parse_json_string_or_file(None, None, '{}'), {})
         self.assertEqual(_parse_json_string_or_file(None, None, '{"foo": 32}'), {'foo': 32})
         self.assertEqual(_parse_json_string_or_file(None, None, '{"foo": 32}'), {'foo': 32})
+
+    def test_parameter_file(self):
         with TemporaryDirectory() as tempdir:
             paramfile = str(Path(tempdir, '{}')) # XXX yes, the file is called '{}'
             with open(paramfile, 'w') as f:
@@ -96,6 +102,12 @@ class TestDecorators(TestCase):
             self.assertEqual(_parse_json_string_or_file(None, None, paramfile), {'bar': 42})
             with pushd_popd(tempdir):
                 self.assertEqual(_parse_json_string_or_file(None, None), {'bar': 42})
+
+    def test_parameters_invalid(self):
+        with self.assertRaisesRegex(ValueError, 'Not a valid JSON object'):
+            _parse_json_string_or_file(None, None, '[]')
+        with self.assertRaisesRegex(ValueError, 'Error parsing'):
+            _parse_json_string_or_file(None, None, '[}')
 
 
 if __name__ == '__main__':

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,23 +1,25 @@
-from os.path import join
-from shutil import copyfile
 from tempfile import TemporaryDirectory
+from pathlib import Path
 
 import click
 from click.testing import CliRunner
 
-from tests.base import TestCase, assets, main # pylint: disable=import-error, no-name-in-module
+from tests.base import TestCase, assets, main, copy_of_directory # pylint: disable=import-error, no-name-in-module
 
 from ocrd import Processor
 from ocrd.decorators import ocrd_cli_options, ocrd_loglevel, ocrd_cli_wrap_processor
 from ocrd_utils.logging import setOverrideLogLevel, initLogging
+from ocrd_utils import pushd_popd
 
 @click.command()
 @ocrd_cli_options
-def cli_with_ocrd_cli_options(*args, **kwargs): pass # pylint: disable=unused-argument, multiple-statements
+def cli_with_ocrd_cli_options(*args, **kwargs):      # pylint: disable=unused-argument
+    pass
 
 @click.command()
 @ocrd_loglevel
-def cli_with_ocrd_loglevel(*args, **kwargs): pass # pylint: disable=unused-argument, multiple-statements
+def cli_with_ocrd_loglevel(*args, **kwargs):         # pylint: disable=unused-argument
+    pass
 
 DUMMY_TOOL = {'executable': 'ocrd-test', 'steps': ['recognition/post-correction']}
 
@@ -76,11 +78,24 @@ class TestDecorators(TestCase):
         self.assertEqual(result.exit_code, 1)
 
     def test_processor_run(self):
+        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
+            with pushd_popd(tempdir):
+                result = self.runner.invoke(cli_dummy_processor, ['--mets', 'mets.xml'])
+                self.assertEqual(result.exit_code, 0)
+
+    def test_parameters(self):
+        from ocrd.decorators import _parse_json_string_or_file      # pylint: disable=protected-access
+        self.assertEqual(_parse_json_string_or_file(None, None), {})
+        self.assertEqual(_parse_json_string_or_file(None, None, '{}'), {})
+        self.assertEqual(_parse_json_string_or_file(None, None, '{"foo": 32}'), {'foo': 32})
+        self.assertEqual(_parse_json_string_or_file(None, None, '{"foo": 32}'), {'foo': 32})
         with TemporaryDirectory() as tempdir:
-            mets_path = join(tempdir, 'mets.xml')
-            copyfile(assets.path_to('SBB0000F29300010000/data/mets.xml'), mets_path)
-            result = self.runner.invoke(cli_dummy_processor, ['--mets', mets_path])
-            self.assertEqual(result.exit_code, 0)
+            paramfile = Path(tempdir, '{}') # XXX yes, the file is called '{}'
+            with open(paramfile, 'w') as f:
+                f.write('{"bar": 42}')
+            self.assertEqual(_parse_json_string_or_file(None, None, paramfile), {'bar': 42})
+            with pushd_popd(tempdir):
+                self.assertEqual(_parse_json_string_or_file(None, None), {'bar': 42})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These are now equivalent:

```sh
$ cat params.json
{"foo": 42}

$ ocrd-foo -p params.json
$ ocrd-foo -p '{"foo": 42}'
$ ocrd-foo -p <(echo '{"foo": 42}')
$ ocrd-foo -p '$(cat params.json)"
```

The second one is the new variant.

@mikegerber @bertsky 