### PR TITLE
improve handling of rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [1.0.0b19] - 2019-09-10
+
+* image_from_page: allow filtering by feature (@comment), #294
+
 ## [1.0.0b18] - 2019-09-06
 
 Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* image_from_page etc: allow filling with background or transparency
+
 ## [1.0.0b19] - 2019-09-10
 
-* image_from_page: allow filtering by feature (@comment), #294
+* image_from_page etc: allow filtering by feature (@comments), #294
 
 ## [1.0.0b18] - 2019-09-06
 
@@ -25,7 +27,7 @@ Fixed:
   * Processor: `chdir` to workspace directory on init so relative files resolve properly
   * typos in docstrings
   * README: 'module' -> 'package'
-  * workspace.image_from_page: logic with rotation/angle
+  * workspace.image_from_page etc: logic with rotation/angle
   * Adapted test suite to OCR-D/assets now with file extensions
 
 Added:

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -343,7 +343,9 @@ class Workspace():
         if (border and
             not 'cropped' in page_xywh['features'] and
             not 'cropped' in feature_filter.split(',')):
-            log.debug('Cropping to border')
+            log.debug("Cropping %s for page '%s' to border", 
+                      "AlternativeImage" if alternative_image else
+                      "image", page_id)
             # get polygon outline of page border:
             page_polygon = np.array(polygon_from_points(page_points))
             # create a mask from the page polygon:

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -249,43 +249,46 @@ class Workspace():
         ]
         return Image.fromarray(region_cut)
 
-    def image_from_page(self, page, page_id, fill='transparent', feature_selector='', feature_filter=''):
+    def image_from_page(self, page, page_id,
+                        fill='background', transparency=False,
+                        feature_selector='', feature_filter=''):
         """Extract a Page image from the workspace.
-
+        
         Given a PageType object, ``page``, extract its PIL.Image from
         AlternativeImage if it exists. Otherwise extract the PIL.Image
         from imageFilename. Also crop it if a Border exists, and rotate
         it if an @orientation exists. Otherwise just return it.
-
+        
         If ``feature_selector`` and/or ``feature_filter`` is given, then
         select/filter among imageFilename and all AlternativeImages the
         last which contains all of the selected but none of the filtered
         features (i.e. @comments classes), or raise an error.
-
+        
         If the chosen image does not have "cropped", but a Border exists,
         then crop it (unless "cropped" is also being filtered). And if the
         chosen image does not have "deskewed", but an @orientation exists,
         then rotate it (unless "deskewed" is also being filtered).
-
+        
         Cropping uses a polygon mask (not just the rectangle). Areas outside
         the polygon (regardless of cropping and deskewing) will be filled
         according to ``fill``:
         - if ``background`` (the default), then fill with the median color
           of the image;
-        - if ``white``, then fill with white;
-        - if ``transparent``, then add a transparency channel which is
-          fully opaque before cropping and rotating (thus only the exposed
-          areas will be transparent afterwards).
-
+        - if ``white``, then fill with white.
+        Moreover, ``transparency`` is true, then add an alpha channel which
+        is fully opaque before cropping and rotating (thus only the exposed
+        areas will be transparent afterwards, for those that can interpret
+        alpha channels).
+        
         (Required and produced features need not be in the same order, so
         ``feature_selector`` is merely a mask specifying Boolean AND, and
         ``feature_filter`` is merely a mask specifying Boolean OR.)
-
+        
         If the resulting page image is larger than the bounding box of
         ``page``, then in the returned bounding box, reduce the offset by
         half the width/height difference (so consumers being passed this
         image and offset will still crop relative to the original center).
-
+        
         Return a tuple:
          * the extracted image,
          * a dictionary with the absolute coordinates of the page's
@@ -295,7 +298,7 @@ class Workspace():
          * an OcrdExif instance associated with the original image.
         (The first two can be used to annotate a new AlternativeImage,
          or pass down with ``image_from_segment``.)
-
+        
         Example:
          * get a raw (colored) but already deskewed and cropped image:
            ``page_image, page_xywh, page_image_info = workspace.image_from_page(
@@ -358,7 +361,8 @@ class Workspace():
             # get polygon outline of page border:
             page_polygon = np.array(polygon_from_points(page_points))
             # create a mask from the page polygon:
-            page_image = image_from_polygon(page_image, page_polygon, fill=fill)
+            page_image = image_from_polygon(page_image, page_polygon,
+                                            fill=fill, transparency=transparency)
             # recrop into page rectangle:
             page_image = crop_image(page_image,
                                     box=(page_xywh['x'],
@@ -373,17 +377,15 @@ class Workspace():
             log.info("Rotating %s for page '%s' by %.2f°",
                      "AlternativeImage" if alternative_image else
                      "image", page_id, page_xywh['angle'])
-            if fill == 'transparent':
-                if page_image.mode in ['RGB', 'L']:
-                    # ensure no information is lost by adding transparency channel
-                    # initialized to fully opaque (so cropping and rotation will
-                    # expose areas as transparent):
-                    page_image.putalpha(255)
-                background = 0
-            elif fill == 'background':
+            if fill == 'background':
                 background = ImageStat.Stat(page_image).median[0]
             else:
                 background = 'white'
+            if transparency and page_image.mode in ['RGB', 'L']:
+                # ensure no information is lost by adding transparency channel
+                # initialized to fully opaque (so cropping and rotation will
+                # expose areas as transparent):
+                page_image.putalpha(255)
             page_image = page_image.rotate(page_xywh['angle'],
                                            expand=True,
                                            #resample=Image.BILINEAR,
@@ -406,49 +408,52 @@ class Workspace():
         page_image.format = 'PNG' # workaround for tesserocr#194
         return page_image, page_xywh, page_image_info
 
-    def image_from_segment(self, segment, parent_image, parent_xywh, fill='transparent', feature_selector='', feature_filter=''):
+    def image_from_segment(self, segment, parent_image, parent_xywh,
+                           fill='background', transparency=False,
+                           feature_selector='', feature_filter=''):
         """Extract a segment image from its parent's image.
-
+        
         Given a PIL.Image of the parent, ``parent_image``, with its
         absolute coordinates, ``parent_xywh``, and a PAGE segment
         (TextRegionType / TextLineType / WordType / GlyphType) object
         which is logically contained in it, ``segment``, extract its
         PIL.Image from AlternativeImage if it exists. Otherwise produce
         an image via cropping from ``parent_image``.
-
+        
         If ``feature_selector`` and/or ``feature_filter`` is given, then
         select/filter among the cropped ``parent_image`` and the available
         AlternativeImages the last which contains all of the selected but none
         of the filtered features (i.e. @comments classes), or raise an error.
-
+        
         If the chosen AlternativeImage does not have "deskewed", but
         an @orientation exists, then rotate it (unless "deskewed" is
         also being filtered).
-
+        
         Regardless, respect any orientation angle annotated for the parent
         (from parent-level deskewing) by rotating the image, and compensating
         the segment coordinates in an inverse transformation (i.e. translation
         to center, passive rotation, re-translation).
-
+        
         Cropping uses a polygon mask (not just the rectangle). Areas outside
         the polygon (regardless of cropping and deskewing) will be filled
         according to ``fill``:
         - if ``background`` (the default), then fill with the median color
           of the image;
-        - if ``white``, then fill with white;
-        - if ``transparent``, then add a transparency channel which is
-          fully opaque before cropping and rotating (thus only the exposed
-          areas will be transparent afterwards).
+        - if ``white``, then fill with white.
+        Moreover, if ``transparency`` is true, then add an alpha channel which
+        is fully opaque before cropping and rotating (thus only the exposed
+        areas will be transparent afterwards, for those that can interpret
+        alpha channels).
         
         (Required and produced features need not be in the same order, so
         ``feature_selector`` is merely a mask specifying Boolean AND, and
         ``feature_filter`` is merely a mask specifying Boolean OR.)
-
+        
         If the resulting segment image is larger than the bounding box of
         ``segment``, then in the returned bounding box, reduce the offset by
         half the width/height difference (so consumers being passed this
         image and offset will still crop relative to the original center).
-
+        
         Return a tuple:
          * the extracted image,
          * a dictionary with the absolute coordinates of the segment's
@@ -456,7 +461,7 @@ class Workspace():
            (features, i.e. of all operations that lead up to this result).
         (These can be used to create a new AlternativeImage, or pass down
          for calls on lower hierarchy levels.)
-
+        
         Example:
          * get a raw (colored) but already deskewed and cropped image:
            ``image, xywh = workspace.image_from_segment(region,
@@ -483,7 +488,8 @@ class Workspace():
         # get polygon outline of segment relative to parent image:
         segment_polygon = coordinates_of_segment(segment, parent_image, parent_xywh)
         # create a mask from the segment polygon:
-        segment_image = image_from_polygon(parent_image, segment_polygon, fill=fill)
+        segment_image = image_from_polygon(parent_image, segment_polygon,
+                                           fill=fill, transparency=transparency)
         # recrop into segment rectangle:
         segment_image = crop_image(segment_image,
                                    box=(segment_xywh['x'] - parent_xywh['x'],
@@ -531,17 +537,15 @@ class Workspace():
             log.info("Rotating %s for segment '%s' by %.2f°",
                      "AlternativeImage" if alternative_image else
                      "image", segment.id, segment_xywh['angle'])
-            if fill == 'transparent':
-                if segment_image.mode in ['RGB', 'L']:
-                    # ensure no information is lost by adding transparency channel
-                    # initialized to fully opaque (so cropping and rotation will
-                    # expose areas as transparent):
-                    segment_image.putalpha(255)
-                background = 0
-            elif fill == 'background':
+            if fill == 'background':
                 background = ImageStat.Stat(segment_image).median[0]
             else:
                 background = 'white'
+            if transparency and segment_image.mode in ['RGB', 'L']:
+                # ensure no information is lost by adding transparency channel
+                # initialized to fully opaque (so cropping and rotation will
+                # expose areas as transparent):
+                segment_image.putalpha(255)
             segment_image = segment_image.rotate(segment_xywh['angle'],
                                                  expand=True,
                                                  #resample=Image.BILINEAR,

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -314,6 +314,7 @@ class Workspace():
         # initialize AlternativeImage@comments classes as empty:
         page_xywh['features'] = ''
 
+        alternative_image = None
         alternative_images = page.get_AlternativeImage()
         if alternative_images:
             # (e.g. from page-level cropping, binarization, deskewing or despeckling)
@@ -479,6 +480,7 @@ class Workspace():
         # initialize AlternativeImage@comments classes from parent:
         segment_xywh['features'] = parent_xywh['features'] + ',cropped'
 
+        alternative_image = None
         alternative_images = segment.get_AlternativeImage()
         if alternative_images:
             # (e.g. from segment-level cropping, binarization, deskewing or despeckling)

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -271,6 +271,9 @@ def crop_image(image, box=None):
     # (It should be invalid in PAGE-XML to extend beyond parents.)
     if not box:
         box = (0, 0, image.width, image.height)
+    elif box[0] < 0 or box[1] < 0 or box[2] > image.width or box[3] > image.height:
+        LOG.error('crop coordinates (%s) exceed image (%dx%d)',
+                  str(box), image.width, image.height)
     xywh = xywh_from_bbox(*box)
     background = ImageStat.Stat(image).median[0]
     new_image = Image.new(image.mode, (xywh['w'], xywh['h']),
@@ -446,7 +449,7 @@ def polygon_mask(image, coordinates):
     mask = Image.new('L', image.size, 0)
     if isinstance(coordinates, np.ndarray):
         coordinates = list(map(tuple, coordinates))
-    ImageDraw.Draw(mask).polygon(coordinates, outline=1, fill=255)
+    ImageDraw.Draw(mask).polygon(coordinates, outline=255, fill=255)
     return mask
 
 def rotate_coordinates(polygon, angle, orig=np.array([0, 0])):

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -320,7 +320,12 @@ def image_from_polygon(image, polygon):
     # background = np.median(array, axis=[0, 1], keepdims=True)
     # array = np.broadcast_to(background.astype(np.uint8), array.shape)
     background = ImageStat.Stat(image).median[0]
-    new_image = Image.new('L', image.size, background)
+    new_image = Image.new(image.mode, image.size, background)
+    if image.mode in ['RGB', 'L']:
+        # ensure no information is lost by adding transparency
+        # (so we do not have to rely on background estimation):
+        image.putalpha(mask)
+        return image
     new_image.paste(image, mask=mask)
     return new_image
 

--- a/ocrd_utils/setup.py
+++ b/ocrd_utils/setup.py
@@ -5,7 +5,7 @@ install_requires = open('requirements.txt').read().split('\n')
 
 setup(
     name='ocrd_utils',
-    version='1.0.0b18',
+    version='1.0.0b19',
     description='OCR-D framework - shared code, helpers, constants',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Workspace.image_from_*: when rotation is necessary, do not always fill with white; instead, determine the background color by median, and only use white for binary images; moreover, add a transparency 
 channel if the input mode allows it