### PR TITLE
workspace bagger: update PAGE imageFilenames, #176

### DIFF
--- a/ocrd/ocrd/workspace_bagger.py
+++ b/ocrd/ocrd/workspace_bagger.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from os import makedirs, chdir, walk, getcwd
+from os import makedirs, chdir, walk
 from os.path import join, isdir, basename, exists, relpath
 from shutil import make_archive, rmtree, copyfile, move
 from tempfile import mkdtemp
@@ -16,9 +16,12 @@ from ocrd_utils import (
     is_local_filename,
     unzip_file_to_dir,
 
+    MIMETYPE_PAGE,
     VERSION,
 )
 from ocrd_validators.constants import BAGIT_TXT, TMP_BAGIT_PREFIX, OCRD_BAGIT_PROFILE_URL
+from ocrd_modelfactory import page_from_file
+from ocrd_models.ocrd_page import to_xml
 
 from .workspace import Workspace
 
@@ -58,9 +61,11 @@ class WorkspaceBagger():
 
     def _bag_mets_files(self, workspace, bagdir, ocrd_manifestation_depth, ocrd_mets, processes):
         mets = workspace.mets
+        changed_urls = {}
 
         # TODO allow filtering by fileGrp@USE and such
         with pushd_popd(workspace.directory):
+            # URLs of the files before changing
             for f in mets.find_files():
                 log.info("Resolving %s (%s)", f.url, ocrd_manifestation_depth)
                 if is_local_filename(f.url):
@@ -77,15 +82,40 @@ class WorkspaceBagger():
                 file_grp_dir = join(bagdir, 'data', f.fileGrp)
                 if not isdir(file_grp_dir):
                     makedirs(file_grp_dir)
-                self.resolver.download_to_directory(file_grp_dir, f.url, basename="%s%s" % (f.ID, f.extension))
-                f.url = join(f.fileGrp, f.ID + f.extension)
+
+                _basename = "%s%s" % (f.ID, f.extension)
+                _relpath = join(f.fileGrp, _basename)
+                self.resolver.download_to_directory(file_grp_dir, f.url, basename=_basename)
+                changed_urls[f.url] = _relpath
+                f.url = _relpath
 
             # save mets.xml
             with open(join(bagdir, 'data', ocrd_mets), 'wb') as f:
                 f.write(workspace.mets.to_xml())
 
+        # Walk through bagged workspace and fix the PAGE
+        # Page/@imageFilename and
+        # AlternativeImage/@filename
+        bag_workspace = Workspace(self.resolver, directory=join(bagdir, 'data'))
+        with pushd_popd(bag_workspace.directory):
+            for page_file in bag_workspace.mets.find_files(mimetype=MIMETYPE_PAGE):
+                pcgts = page_from_file(page_file)
+                changed = False
+                #  page_doc.set(imageFileName
+            #  for old, new in changed_urls:
+                for old, new in changed_urls.items():
+                    if pcgts.get_Page().imageFilename == old:
+                        pcgts.get_Page().imageFilename = new
+                        changed = True
+                    # TODO replace AlternativeImage, recursively...
+                if changed:
+                    with open(page_file.url, 'w') as out:
+                        out.write(to_xml(pcgts))
+                    #  log.info("Replace %s -> %s in %s" % (old, new, page_file))
+
             chdir(bagdir)
             total_bytes, total_files = make_manifests('data', processes, algorithms=['sha512'])
+            log.info("New vs. old: %s" % changed_urls)
         return total_bytes, total_files
 
     def _set_bag_info(self, bag, total_bytes, total_files, ocrd_identifier, ocrd_manifestation_depth, ocrd_base_version_checksum):


### PR DESCRIPTION
After bagging the files, walk through the PAGE files and replace outdated `@imageFilename`