### PR TITLE
Update Pillow to 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Fixed:
 
   * Add `dimension` to workspace validation skip list, #329
   * Update ocrd-tool.json schema to spec 3.3.0 (no output_file_grp, no syntax restriction on content-type)
+  * Update Pillow to 6.2.0
 
 ## [1.0.0] - 2019-10-18
 

--- a/ocrd_utils/requirements.txt
+++ b/ocrd_utils/requirements.txt
@@ -1,2 +1,2 @@
-Pillow == 5.4.1
+Pillow >= 6.2.0
 numpy >= 1.17.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -124,6 +124,7 @@ class TestUtils(TestCase):
             5.4.1 no
             6.0.0 yes
             6.1.0 yes
+            6.2.0 no
         """
         for _ in range(0, 10):
             pil_image = Image.open(assets.path_to('grenzboten-test/data/OCR-D-IMG-BIN/p179470.tif'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,12 +119,14 @@ class TestUtils(TestCase):
 
         Run the same code multiple times to make segfaults more probable
 
-        Should fail persistently:
-            5.3.1 no
-            5.4.1 no
-            6.0.0 yes
-            6.1.0 yes
-            6.2.0 no
+        Test is failing due to segfaults in Pillow versions:
+            6.0.0
+            6.1.0
+
+        Test succeeds in Pillow versions:
+            5.3.1
+            5.4.1
+            6.2.0
         """
         for _ in range(0, 10):
             pil_image = Image.open(assets.path_to('grenzboten-test/data/OCR-D-IMG-BIN/p179470.tif'))


### PR DESCRIPTION
I cannot reproduce the segfaults in 6.2.0 that were plaguing 6.0.0 and 6.1.0.

Tested by running `test_pil_version` a few thousand times, which consistently fails in >= 6.0.0 < 6.2.0 but not in 6.2.0

Can someone confirm this please?

It's also highly advisable to update because of https://nvd.nist.gov/vuln/detail/CVE-2019-16865