### PR TITLE
Improve param validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 Changed:
 
-  * `ocrd process` uses the ocrd-tool.json of the tools to check whether output file group necessary, #296
+  * `ocrd process`: Use the ocrd-tool.json of the tools to check whether output file group necessary, #296
+  * `ocrd process`: Validate parameters when validating a task
   * Dockerfile: Revert to Ubuntu 18.04 for LTS compatibility, #344
+  * Parameter validation: Raise exception for unknown parameters
+  * `ocrd ocrd-tool validate`: Raise exception for unknown keys in JSON
 
 ## [2.0.0] - 2019-11-05
 

--- a/ocrd_validators/ocrd_validators/parameter_validator.py
+++ b/ocrd_validators/ocrd_validators/parameter_validator.py
@@ -43,5 +43,6 @@ class ParameterValidator(JsonValidator):
         super(ParameterValidator, self).__init__({
             "type": "object",
             "required": required,
+            "additionalProperties": False,
             "properties": p
         }, DefaultValidatingDraft4Validator)

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -7,7 +7,16 @@ from tests.base import TestCase, assets, main # pylint: disable=import-error, no
 from ocrd.resolver import Resolver
 from ocrd.processor.base import Processor, run_processor, run_cli
 
-DUMMY_TOOL = {'executable': 'ocrd-test', 'steps': ['recognition/post-correction']}
+DUMMY_TOOL = {
+    'executable': 'ocrd-test',
+    'steps': ['recognition/post-correction'],
+    'parameters': {
+        'baz': {
+            'type': 'string',
+            'default': 'bla'
+        }
+    }
+}
 
 class DummyProcessor(Processor):
 

--- a/tests/test_task_sequence.py
+++ b/tests/test_task_sequence.py
@@ -30,6 +30,12 @@ SAMPLE_OCRD_TOOL_JSON_WITHOUT_OUTPUT_FILE_GRP = json.loads(SAMPLE_OCRD_TOOL_JSON
 del SAMPLE_OCRD_TOOL_JSON_WITHOUT_OUTPUT_FILE_GRP['output_file_grp']
 SAMPLE_OCRD_TOOL_JSON_WITHOUT_OUTPUT_FILE_GRP = json.dumps(SAMPLE_OCRD_TOOL_JSON_WITHOUT_OUTPUT_FILE_GRP)
 
+SAMPLE_NAME_REQUIRED_PARAM = 'ocrd-sample-processor-required-param'
+SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM = json.loads(SAMPLE_OCRD_TOOL_JSON)
+del SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM['parameters']['param1']['default']
+SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM['parameters']['param1']['required'] = True
+SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM = json.dumps(SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM)
+
 class TestTaskSequence(TestCase):
 
     def tearDown(self):
@@ -50,6 +56,13 @@ print('''%s''')
 #!/usr/bin/env python
 print('''%s''')
         """ % SAMPLE_OCRD_TOOL_JSON_WITHOUT_OUTPUT_FILE_GRP)
+        p.chmod(0o777)
+
+        p = Path(self.tempdir, SAMPLE_NAME_REQUIRED_PARAM)
+        p.write_text("""\
+#!/usr/bin/env python
+print('''%s''')
+        """ % SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM)
         p.chmod(0o777)
 
         os.environ['PATH'] = os.pathsep.join([self.tempdir, os.environ['PATH']])
@@ -98,6 +111,10 @@ print('''%s''')
         with self.assertRaisesRegex(Exception, 'Executable not found in '):
             task.validate()
 
+    def test_required_param(self):
+        task = ProcessorTask.parse('sample-processor-required-param -I IN -O OUT')
+        with self.assertRaisesRegex(Exception, "'param1' is a required property"):
+            task.validate()
 
 if __name__ == '__main__':
     main()

--- a/tests/validator/test_ocrd_tool_validator.py
+++ b/tests/validator/test_ocrd_tool_validator.py
@@ -23,10 +23,25 @@ skeleton = '''
 
 class TestOcrdToolValidator(TestCase):
 
-    def test_something(self):
-        report = OcrdToolValidator.validate(json.loads(skeleton))
-        #  print(report.to_xml())
+    def setUp(self):
+        self.ocrd_tool = json.loads(skeleton)
+
+    def test_smoke(self):
+        report = OcrdToolValidator.validate(self.ocrd_tool)
         self.assertEqual(report.is_valid, True)
+
+    def test_additional_props(self):
+        self.ocrd_tool['not-allowed'] = 'YUP'
+        report = OcrdToolValidator.validate(self.ocrd_tool)
+        self.assertFalse(report.is_valid)
+        self.assertIn("Additional properties are not allowed ('not-allowed' was unexpected)", report.errors[0])
+
+    def test_additional_props_in_tool(self):
+        # XXX 'parameter' is the wrong key, should be 'parameters'
+        self.ocrd_tool['tools']['ocrd-xyz']['parameter'] = {}
+        report = OcrdToolValidator.validate(self.ocrd_tool)
+        self.assertFalse(report.is_valid)
+        self.assertIn("Additional properties are not allowed ('parameter' was unexpected)", report.errors[0])
 
     def test_file_param_ok(self):
         ocrd_tool = json.loads(skeleton)

--- a/tests/validator/test_parameter_validator.py
+++ b/tests/validator/test_parameter_validator.py
@@ -3,6 +3,13 @@ from ocrd_validators import ParameterValidator
 
 class TestParameterValidator(TestCase):
 
+    def test_extraneous(self):
+        validator = ParameterValidator({"parameters": {}})
+        obj = {"foo": 42}
+        report = validator.validate(obj)
+        self.assertFalse(report.is_valid)
+        self.assertIn("Additional properties are not allowed ('foo' was unexpected)", report.errors[0])
+
     def test_missing_required(self):
         validator = ParameterValidator({
             "parameters": {


### PR DESCRIPTION
* [x] Unspecified keys in all objects of the ocrd-tool.json should raise a validation error
* [x] Unspecified parameters should raise a validation error
* [x] Parameters should be validated before executing a processor
* [x] Parameters of all processors should be validated before executing a task sequence