### PR TITLE
add python3-venv dependency to deps-ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ PIP_INSTALL = pip install
 
 # Dependencies for deployment in an ubuntu/debian linux
 deps-ubuntu:
-	apt-get install -y python3 python3-pip
+	apt-get install -y python3 python3-pip python3-venv
 
 # Install test python deps via pip
 deps-test:


### PR DESCRIPTION
perhaps also (for modules still using the old spec) `python3-virtualenv`?