### PR TITLE
Install latest Python packages pip, wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ deps-test:
 
 # (Re)install the tool
 install: spec
+	$(PIP) install -U "pip>=19.0.0" wheel
 	for mod in $(BUILD_ORDER);do (cd $$mod ; $(PIP_INSTALL) .);done
 
 # Uninstall the tool

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -28,7 +28,7 @@ class TestOcrdMets(TestCase):
         self.assertEqual(mets.unique_identifier, 'foo', 'Right identifier after change')
         as_string = mets.to_xml().decode('utf-8')
         self.assertIn('ocrd/core v%s' % VERSION, as_string)
-        self.assertIn('CREATEDATE="%d-%d-%02dT' % (
+        self.assertIn('CREATEDATE="%04u-%02u-%02uT' % (
             datetime.now().year,
             datetime.now().month,
             datetime.now().day,


### PR DESCRIPTION
wheel is required for builds.

pip is already available, but typically too old.
pip 19.0 or newer is required for manylinux2010 platform tag support.
pip 19.3 or newer is required for manylinux2014 platform tag support.
Installation of tensorflow==2.0.0 for example requires manylinux2010.

Signed-off-by: Stefan Weil <sw@weilnetz.de>