### PR TITLE
PAGE validator: coordinate self-validity and mutual consistency

### DIFF
--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -48,16 +48,18 @@ def workspace_cli(ctx, directory, mets_basename, backup):
 @pass_workspace
 @click.option('-a', '--download', is_flag=True, help="Download all files")
 @click.option('-s', '--skip', help="Tests to skip", default=[], multiple=True, type=click.Choice(['imagefilename', 'dimension', 'mets_unique_identifier', 'mets_file_group_names', 'mets_files', 'pixel_density', 'page', 'url']))
-@click.option('--page-strictness', help="How strict to check PAGE consistency", type=click.Choice(['strict', 'lax', 'fix', 'off']), default='strict')
+@click.option('--page-strictness', help="How strict to check PAGE multi-level textequiv consistency", type=click.Choice(['strict', 'lax', 'fix', 'off']), default='strict')
+@click.option('--page-discipline', help="How fierce to check PAGE multi-level coordinate consistency", type=click.Choice(['poly', 'baseline', 'both', 'off']), default='poly')
 @click.argument('mets_url')
-def validate_workspace(ctx, mets_url, download, skip, page_strictness):
+def validate_workspace(ctx, mets_url, download, skip, page_strictness, page_discipline):
     report = WorkspaceValidator.validate(
         ctx.resolver,
         mets_url,
         src_dir=ctx.directory,
         skip=skip,
         download=download,
-        page_strictness=page_strictness
+        page_strictness=page_strictness,
+        page_discipline=page_discipline
     )
     print(report.to_xml())
     if not report.is_valid:

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -48,10 +48,10 @@ def workspace_cli(ctx, directory, mets_basename, backup):
 @pass_workspace
 @click.option('-a', '--download', is_flag=True, help="Download all files")
 @click.option('-s', '--skip', help="Tests to skip", default=[], multiple=True, type=click.Choice(['imagefilename', 'dimension', 'mets_unique_identifier', 'mets_file_group_names', 'mets_files', 'pixel_density', 'page', 'url']))
-@click.option('--page-strictness', help="How strict to check PAGE multi-level textequiv consistency", type=click.Choice(['strict', 'lax', 'fix', 'off']), default='strict')
-@click.option('--page-discipline', help="How fierce to check PAGE multi-level coordinate consistency", type=click.Choice(['poly', 'baseline', 'both', 'off']), default='poly')
+@click.option('--page-textequiv-consistency', '--page-strictness', help="How strict to check PAGE multi-level textequiv consistency", type=click.Choice(['strict', 'lax', 'fix', 'off']), default='strict')
+@click.option('--page-coordinate-consistency', help="How fierce to check PAGE multi-level coordinate consistency", type=click.Choice(['poly', 'baseline', 'both', 'off']), default='poly')
 @click.argument('mets_url')
-def validate_workspace(ctx, mets_url, download, skip, page_strictness, page_discipline):
+def validate_workspace(ctx, mets_url, download, skip, page_strictness, page_coordinate_consistency):
     report = WorkspaceValidator.validate(
         ctx.resolver,
         mets_url,
@@ -59,7 +59,7 @@ def validate_workspace(ctx, mets_url, download, skip, page_strictness, page_disc
         skip=skip,
         download=download,
         page_strictness=page_strictness,
-        page_discipline=page_discipline
+        page_coordinate_consistency=page_coordinate_consistency
     )
     print(report.to_xml())
     if not report.is_valid:

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -62,6 +62,10 @@ Utility functions and constants usable in various circumstances.
 * ``logging``, ``setOverrideLogLevel``, ``getLevelName``, ``getLogger``, ``initLogging``
 
     Exports of ocrd_utils.logging
+
+* ``deprecated_alias``
+
+    Decorator to mark a kwarg as deprecated
 """
 
 __all__ = [
@@ -75,6 +79,7 @@ __all__ = [
     'coordinates_of_segment',
     'concat_padded',
     'crop_image',
+    'deprecated_alias',
     'getLevelName',
     'getLogger',
     'initLogging',
@@ -129,6 +134,7 @@ from PIL import Image, ImageStat, ImageDraw, ImageChops
 
 from .logging import * # pylint: disable=wildcard-import
 from .constants import *  # pylint: disable=wildcard-import
+from .deprecate import deprecated_alias
 
 LOG = getLogger('ocrd_utils')
 

--- a/ocrd_utils/ocrd_utils/deprecate.py
+++ b/ocrd_utils/ocrd_utils/deprecate.py
@@ -1,0 +1,29 @@
+import functools
+import warnings
+
+"""
+https://stackoverflow.com/questions/49802412/how-to-implement-deprecation-in-python-with-argument-alias
+by user2357112 supports Monica
+"""
+
+def deprecated_alias(**aliases):
+    """
+    Deprecate a kwarg in favor of another kwarg
+    """
+    def deco(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            rename_kwargs(f.__name__, kwargs, aliases)
+            return f(*args, **kwargs)
+        return wrapper
+    return deco
+
+def rename_kwargs(func_name, kwargs, aliases):
+    for alias, new in aliases.items():
+        if alias in kwargs:
+            if new in kwargs:
+                raise TypeError('{} received both {} and {}'.format(
+                    func_name, alias, new))
+            warnings.warn('{} is deprecated; use {}'.format(alias, new),
+                          DeprecationWarning)
+            kwargs[new] = kwargs.pop(alias)

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -89,6 +89,8 @@ def initLogging():
     #  logging.getLogger('ocrd.resolver.download_to_directory').setLevel(logging.INFO)
     #  logging.getLogger('ocrd.resolver.add_files_to_mets').setLevel(logging.INFO)
     logging.getLogger('PIL').setLevel(logging.INFO)
+    # To cut back on the `Self-intersection at or near point` INFO messages
+    logging.getLogger('shapely.geos').setLevel(logging.ERROR)
 
     # Allow overriding
 

--- a/ocrd_validators/ocrd_validators/page_validator.py
+++ b/ocrd_validators/ocrd_validators/page_validator.py
@@ -58,7 +58,7 @@ _HIERARCHY = [
     (GlyphType,      None,             None), # pylint: disable=bad-whitespace
 ]
 
-class TextequivConsistencyError(Exception):
+class ConsistencyError(Exception):
     """
     Exception representing a consistency error in textual transcription across levels of a PAGE-XML.
     (Element text strings must be the concatenation of their children's text strings, joined by white space.)
@@ -66,7 +66,7 @@ class TextequivConsistencyError(Exception):
 
     def __init__(self, tag, ID, file_id, actual, expected):
         """
-        Construct a new TextequivConsistencyError.
+        Construct a new ConsistencyError.
 
         Arguments:
             tag (string): Level of the inconsistent element (parent)
@@ -81,7 +81,7 @@ class TextequivConsistencyError(Exception):
         self.file_id = file_id
         self.actual = actual
         self.expected = expected
-        super(TextequivConsistencyError, self).__init__(
+        super(ConsistencyError, self).__init__(
             "INCONSISTENCY in %s ID '%s' of file '%s': text results '%s' != concatenated '%s'" % (
                 tag, ID, file_id, actual, expected))
 
@@ -231,7 +231,7 @@ def validate_consistency(node, strictness, strategy, check_baseline, check_coord
                 elif (strictness == 'strict' # or 'lax' but...
                       or not compare_without_whitespace(concatenated, text_results)):
                     log.debug("Inconsistent text of %s %s", tag, node_id)
-                    report.add_error(TextequivConsistencyError(tag, node_id, file_id,
+                    report.add_error(ConsistencyError(tag, node_id, file_id,
                                                       text_results, concatenated))
     return consistent
 

--- a/ocrd_validators/ocrd_validators/page_validator.py
+++ b/ocrd_validators/ocrd_validators/page_validator.py
@@ -2,35 +2,66 @@
 API for validating `OcrdPage <../ocrd_models/ocrd_models.ocrd_page.html>`_.
 """
 import re
+from shapely.geometry import Polygon, LineString
 
-from ocrd_utils import getLogger
+from ocrd_utils import getLogger, polygon_from_points
 from ocrd_models.ocrd_page import parse
 from ocrd_modelfactory import page_from_file
 
 from ocrd_models.ocrd_page import (
     PcGtsType,
     PageType,
-    TextEquivType,
     TextRegionType,
     TextLineType,
     WordType,
     GlyphType,
+    TextEquivType
 )
+from ocrd_models.ocrd_page_generateds import RegionType
 from .report import ValidationReport
 
 log = getLogger('ocrd.page_validator')
 
 _HIERARCHY = [
-    (PageType,       'Page',       'get_TextRegion', None), # pylint: disable=bad-whitespace
-    (TextRegionType, 'TextRegion', 'get_TextLine',   '\n'), # pylint: disable=bad-whitespace
-    (TextLineType,   'TextLine',   'get_Word',       ' '),  # pylint: disable=bad-whitespace
-    (WordType,       'Word',       'get_Glyph',      ''),   # pylint: disable=bad-whitespace
-    (GlyphType,      'Glyph',      None,             None), # pylint: disable=bad-whitespace
+    # page can contain different types of regions
+    (PageType,       'get_AdvertRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_ChartRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_ChemRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_GraphicRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_GraphicRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_LineDrawingRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_MathsRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_MusicRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_NoiseRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_SeparatorRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_TableRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_TextRegion', None), # pylint: disable=bad-whitespace
+    (PageType,       'get_UnknownRegion', None), # pylint: disable=bad-whitespace
+    # all regions can be recursive
+    (RegionType,     'get_AdvertRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_ChartRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_ChemRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_GraphicRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_GraphicRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_LineDrawingRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_MathsRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_MusicRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_NoiseRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_SeparatorRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_TableRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_TextRegion', None), # pylint: disable=bad-whitespace
+    (RegionType,     'get_UnknownRegion', None), # pylint: disable=bad-whitespace
+    # only TextRegion can contain TextLine
+    (TextRegionType, 'get_TextLine',   '\n'), # pylint: disable=bad-whitespace
+    (TextLineType,   'get_Word',       ' '),  # pylint: disable=bad-whitespace
+    (WordType,       'get_Glyph',      ''),   # pylint: disable=bad-whitespace
+    (GlyphType,      None,             None), # pylint: disable=bad-whitespace
 ]
 
 class ConsistencyError(Exception):
     """
-    Exception representing a consistency error in transcription level of a PAGE-XML.
+    Exception representing a consistency error in textual transcription across levels of a PAGE-XML.
+    (Element text strings must be the concatenation of their children's text strings, joined by white space.)
     """
 
     def __init__(self, tag, ID, actual, expected):
@@ -38,63 +69,175 @@ class ConsistencyError(Exception):
         Construct a new ConsistencyError.
 
         Arguments:
-            tag (string): Level of the inconsistent element
-            ID (string): ``ID`` of the inconsistent element
-            actual (string):
-            expected (string):
+            tag (string): Level of the inconsistent element (parent)
+            ID (string): ``ID`` of the inconsistent element (parent)
+            actual (string): Value of parent's TextEquiv[0]/Unicode
+            expected (string): Concatenated values of children's
+                               TextEquiv[0]/Unicode, joined by white-space
         """
         self.tag = tag
         self.ID = ID
         self.actual = actual
         self.expected = expected
-        super(ConsistencyError, self).__init__("INCONSISTENCY in %s ID '%s': text results '%s' != concatenated '%s'" % (tag, ID, actual, expected))
+        super(ConsistencyError, self).__init__(
+            "INCONSISTENCY in %s ID '%s': text results '%s' != concatenated '%s'" % (
+                tag, ID, actual, expected))
 
+class CoordinateConsistencyError(Exception):
+    """
+    Exception representing a consistency error in coordinate confinement across levels of a PAGE-XML.
+    (Element coordinate polygons must be properly contained in their parents' coordinate polygons.)
+    """
+
+    def __init__(self, tag, ID, outer, inner):
+        """
+        Construct a new CoordinateConsistencyError.
+
+        Arguments:
+            tag (string): Level of the offending element (child)
+            ID (string): ``ID`` of the offending element (child)
+            outer (string): Coordinate points of the parent
+            inner (string): Coordinate points of the child
+        """
+        self.tag = tag
+        self.ID = ID
+        self.outer = outer
+        self.inner = inner
+        super(CoordinateConsistencyError, self).__init__(
+            "INCONSISTENCY in %s ID '%s': coords '%s' not within parent coords '%s'" % (
+                tag, ID, inner, outer))
+
+class CoordinateValidityError(Exception):
+    """
+    Exception representing a validity error of an element's coordinates in PAGE-XML.
+    (Element coordinate polygons must have at least 3 points, and must not
+     self-intersect or be non-contiguous or be negative.)
+    """
+
+    def __init__(self, tag, ID, points):
+        """
+        Construct a new CoordinateValidityError.
+
+        Arguments:
+            tag (string): Level of the offending element (child)
+            ID (string): ``ID`` of the offending element (child)
+            points (string): Coordinate points
+        """
+        self.tag = tag
+        self.ID = ID
+        self.points = points
+        super(CoordinateValidityError, self).__init__(
+            "INVALIDITY in %s ID '%s': coords '%s'" % (
+                tag, ID, points))
+        
 def compare_without_whitespace(a, b):
     """
     Compare two strings, ignoring all whitespace.
     """
     return re.sub('\\s+', '', a) == re.sub('\\s+', '', b)
 
-def handle_inconsistencies(node, strictness, strategy, report):
+def validate_consistency(node, strictness, strategy, check_baseline, check_coords, report):
     """
-    Check whether the text results on an element is consistent with its child element text results.
+    Check whether the text results on an element is consistent with its child element text results,
+    and whether the coordinates of an element are fully within its parent element coordinates.
     """
     if isinstance(node, PcGtsType):
-        node = node.get_Page()
+        # top-level (start recursion)
+        node_id = node.get_pcGtsId()
+        node = node.get_Page() # has no .id
     elif isinstance(node, GlyphType):
-        return report
+        # terminal level (end recursion)
+        return True
+    else:
+        node_id = node.id
+    tag = node.original_tagname_
+    log.debug("Validating %s %s", tag, node_id)
+    consistent = True
+    if check_coords or check_baseline:
+        if isinstance(node, PageType):
+            parent = node.get_Border()
+        else:
+            parent = node
+        if parent:
+            parent_points = parent.get_Coords().points
+            node_poly = Polygon(polygon_from_points(parent_points))
+            if (not node_poly.is_valid
+                or node_poly.is_empty
+                or node_poly.bounds[0] < 0
+                or node_poly.bounds[1] < 0
+                or node_poly.length < 4):
+                report.add_error(CoordinateValidityError(tag, node_id, parent_points))
+                log.info("Invalid coords of %s %s", tag, node_id)
+                consistent = False
+        else:
+            node_poly = None
+    for class_, getter, concatenate_with in _HIERARCHY:
+        if not isinstance(node, class_):
+            continue
+        children = getattr(node, getter)()
+        for child in children:
+            consistent = (validate_consistency(child, strictness, strategy,
+                                               check_baseline, check_coords,
+                                               report)
+                          and consistent)
+            if check_coords and node_poly:
+                child_tag = child.original_tagname_
+                child_points = child.get_Coords().points
+                child_poly = Polygon(polygon_from_points(child_points))
+                if (not child_poly.is_valid
+                    or child_poly.is_empty
+                    or child_poly.bounds[0] < 0
+                    or child_poly.bounds[1] < 0
+                    or child_poly.length < 4):
+                    report.add_error(CoordinateValidityError(child_tag, child.id, child_points))
+                    log.info("Invalid coords of %s %s", child_tag, child.id)
+                    consistent = False
+                elif not child_poly.within(node_poly):
+                    # TODO: automatic repair?
+                    report.add_error(CoordinateConsistencyError(tag, child.id,
+                                                                parent_points,
+                                                                child_points))
+                    log.info("Inconsistent coords of %s %s", child_tag, child.id)
+                    consistent = False
+        if isinstance(node, TextLineType) and check_baseline and node.get_Baseline():
+            baseline_points = node.get_Baseline().points
+            baseline_line = LineString(polygon_from_points(baseline_points))
+            if (not baseline_line.is_valid
+                or baseline_line.is_empty
+                or baseline_line.bounds[0] < 0
+                or baseline_line.bounds[1] < 0
+                or baseline_line.length < 4):
+                report.add_error(CoordinateValidityError("Baseline", node_id, baseline_points))
+                log.info("Invalid coords of baseline in %s", node_id)
+                consistent = False
+            elif not baseline_line.within(node_poly):
+                report.add_error(CoordinateConsistencyError("Baseline", node_id,
+                                                            parent_points,
+                                                            baseline_points))
+                log.info("Inconsistent coords of baseline in %s %s", tag, node_id)
+                consistent = False
+        if concatenate_with is not None and strictness != 'off':
+            # validate textual consistency of node with children
+            concatenated = concatenate(children, concatenate_with, strategy)
+            text_results = get_text(node, strategy)
+            if concatenated and text_results and concatenated != text_results:
+                consistent = False
+                if strictness == 'fix':
+                    log.info("Repaired text of %s %s", tag, node_id)
+                    set_text(node, concatenated, strategy)
+                elif (strictness == 'strict' # or 'lax' but...
+                      or not compare_without_whitespace(concatenated, text_results)):
+                    log.info("Inconsistent text of %s %s", tag, node_id)
+                    report.add_error(ConsistencyError(tag, node_id,
+                                                      text_results,
+                                                      concatenated))
+    return consistent
 
-    _, tag, getter, concatenate_with = [x for x in _HIERARCHY if isinstance(node, x[0])][0]
-    children_are_consistent = True
-    children = getattr(node, getter)()
-    for child in children:
-        errors_before = len(report.errors)
-        handle_inconsistencies(child, strictness, strategy, report)
-        if len(report.errors) > errors_before:
-            children_are_consistent = False
-    if concatenate_with is not None:
-        concatenated_children = concatenate_children(node, concatenate_with, strategy)
-        text_results = get_text(node, strategy)
-        if concatenated_children and text_results and concatenated_children != text_results:
-            if strictness == 'fix':
-                set_text(node, concatenated_children, strategy)
-                #  if children_are_consistent:
-                #  else:
-                #      # TODO fix text results recursively
-                #      report.add_warning("Fixing inconsistencies recursively not implemented")
-            elif strictness == 'lax':
-                if not compare_without_whitespace(concatenated_children, text_results):
-                    report.add_error(ConsistencyError(tag, node.id, text_results, concatenated_children))
-            else:
-                report.add_error(ConsistencyError(tag, node.id, text_results, concatenated_children))
-    return report
-
-def concatenate_children(node, concatenate_with, strategy):
+def concatenate(nodes, concatenate_with, strategy):
     """
-    Concatenate children of node according to https://ocr-d.github.io/page#consistency-of-text-results-on-different-levels
+    Concatenate nodes textually according to https://ocr-d.github.io/page#consistency-of-text-results-on-different-levels
     """
-    _, _, getter, concatenate_with = [x for x in _HIERARCHY if isinstance(node, x[0])][0]
-    tokens = [get_text(x, strategy) for x in getattr(node, getter)()]
+    tokens = [get_text(node, strategy) for node in nodes]
     return concatenate_with.join(tokens).strip()
 
 def get_text(node, strategy):
@@ -136,7 +279,9 @@ class PageValidator():
     """
 
     @staticmethod
-    def validate(filename=None, ocrd_page=None, ocrd_file=None, strictness='strict', strategy='index1'):
+    def validate(filename=None, ocrd_page=None, ocrd_file=None,
+                 strictness='strict', strategy='index1',
+                 check_baseline=True, check_coords=True):
         """
         Validates a PAGE file for consistency by filename, OcrdFile or passing OcrdPage directly.
 
@@ -146,39 +291,25 @@ class PageValidator():
             ocrd_file (OcrdFile): OcrdFile instance wrapping OcrdPage
             strictness (string): 'strict', 'lax', 'fix' or 'off'
             strategy (string): Currently only 'index1'
+            check_baseline (bool): whether Baseline must be fully within TextLine/Coords
+            check_coords (bool): whether *Region/TextLine/Word/Glyph must each be fully
+                                 contained within Border/*Region/TextLine/Word, resp.
 
         Returns:
             report (:class:`ValidationReport`) Report on the validity
         """
         if ocrd_page:
-            validator = PageValidator(ocrd_page, strictness, strategy)
+            page = ocrd_page
         elif ocrd_file:
-            validator = PageValidator(page_from_file(ocrd_file), strictness, strategy)
+            page = page_from_file(ocrd_file)
         elif filename:
-            validator = PageValidator(parse(filename, silence=True), strictness, strategy)
+            page = parse(filename, silence=True)
         else:
             raise Exception("At least one of ocrd_page, ocrd_file or filename must be set")
-        return validator._validate() # pylint: disable=protected-access
-
-    def __init__(self, page, strictness, strategy):
-        """
-        Arguments:
-            page (OcrdPage): The OcrdPage to validate
-        """
         if strategy not in ('index1'):
             raise Exception("Element selection strategy %s not implemented" % strategy)
         if strictness not in ('strict', 'lax', 'fix', 'off'):
             raise Exception("Strictness level %s not implemented" % strictness)
-        self.report = ValidationReport()
-        self.page = page
-        self.strictness = strictness
-        self.strategy = strategy
-
-    def _validate(self):
-        """
-        Do the actual validation
-        """
-        if self.strictness == 'off':
-            return self.report
-        handle_inconsistencies(self.page, self.strictness, self.strategy, self.report)
-        return self.report
+        report = ValidationReport()
+        validate_consistency(page, strictness, strategy, check_baseline, check_coords, report)
+        return report

--- a/ocrd_validators/ocrd_validators/page_validator.py
+++ b/ocrd_validators/ocrd_validators/page_validator.py
@@ -58,7 +58,7 @@ _HIERARCHY = [
     (GlyphType,      None,             None), # pylint: disable=bad-whitespace
 ]
 
-class ConsistencyError(Exception):
+class TextequivConsistencyError(Exception):
     """
     Exception representing a consistency error in textual transcription across levels of a PAGE-XML.
     (Element text strings must be the concatenation of their children's text strings, joined by white space.)
@@ -66,7 +66,7 @@ class ConsistencyError(Exception):
 
     def __init__(self, tag, ID, file_id, actual, expected):
         """
-        Construct a new ConsistencyError.
+        Construct a new TextequivConsistencyError.
 
         Arguments:
             tag (string): Level of the inconsistent element (parent)
@@ -81,7 +81,7 @@ class ConsistencyError(Exception):
         self.file_id = file_id
         self.actual = actual
         self.expected = expected
-        super(ConsistencyError, self).__init__(
+        super(TextequivConsistencyError, self).__init__(
             "INCONSISTENCY in %s ID '%s' of file '%s': text results '%s' != concatenated '%s'" % (
                 tag, ID, file_id, actual, expected))
 
@@ -231,7 +231,7 @@ def validate_consistency(node, strictness, strategy, check_baseline, check_coord
                 elif (strictness == 'strict' # or 'lax' but...
                       or not compare_without_whitespace(concatenated, text_results)):
                     log.debug("Inconsistent text of %s %s", tag, node_id)
-                    report.add_error(ConsistencyError(tag, node_id, file_id,
+                    report.add_error(TextequivConsistencyError(tag, node_id, file_id,
                                                       text_results, concatenated))
     return consistent
 

--- a/ocrd_validators/ocrd_validators/page_validator.py
+++ b/ocrd_validators/ocrd_validators/page_validator.py
@@ -172,7 +172,7 @@ def validate_consistency(node, strictness, strategy, check_baseline, check_coord
                 or node_poly.bounds[1] < 0
                 or node_poly.length < 4):
                 report.add_error(CoordinateValidityError(tag, node_id, file_id, parent_points))
-                log.info("Invalid coords of %s %s", tag, node_id)
+                log.debug("Invalid coords of %s %s", tag, node_id)
                 consistent = False
         else:
             node_poly = None
@@ -195,13 +195,13 @@ def validate_consistency(node, strictness, strategy, check_baseline, check_coord
                     or child_poly.bounds[1] < 0
                     or child_poly.length < 4):
                     report.add_error(CoordinateValidityError(child_tag, child.id, file_id, child_points))
-                    log.info("Invalid coords of %s %s", child_tag, child.id)
+                    log.debug("Invalid coords of %s %s", child_tag, child.id)
                     consistent = False
                 elif not child_poly.within(node_poly):
                     # TODO: automatic repair?
                     report.add_error(CoordinateConsistencyError(tag, child.id, file_id,
                                                                 parent_points, child_points))
-                    log.info("Inconsistent coords of %s %s", child_tag, child.id)
+                    log.debug("Inconsistent coords of %s %s", child_tag, child.id)
                     consistent = False
         if isinstance(node, TextLineType) and check_baseline and node.get_Baseline():
             baseline_points = node.get_Baseline().points
@@ -212,12 +212,12 @@ def validate_consistency(node, strictness, strategy, check_baseline, check_coord
                 or baseline_line.bounds[1] < 0
                 or baseline_line.length < 4):
                 report.add_error(CoordinateValidityError("Baseline", node_id, file_id, baseline_points))
-                log.info("Invalid coords of baseline in %s", node_id)
+                log.debug("Invalid coords of baseline in %s", node_id)
                 consistent = False
             elif not baseline_line.within(node_poly):
                 report.add_error(CoordinateConsistencyError("Baseline", node_id, file_id,
                                                             parent_points, baseline_points))
-                log.info("Inconsistent coords of baseline in %s %s", tag, node_id)
+                log.debug("Inconsistent coords of baseline in %s %s", tag, node_id)
                 consistent = False
         if concatenate_with is not None and strictness != 'off':
             # validate textual consistency of node with children
@@ -226,11 +226,11 @@ def validate_consistency(node, strictness, strategy, check_baseline, check_coord
             if concatenated and text_results and concatenated != text_results:
                 consistent = False
                 if strictness == 'fix':
-                    log.info("Repaired text of %s %s", tag, node_id)
+                    log.debug("Repaired text of %s %s", tag, node_id)
                     set_text(node, concatenated, strategy)
                 elif (strictness == 'strict' # or 'lax' but...
                       or not compare_without_whitespace(concatenated, text_results)):
-                    log.info("Inconsistent text of %s %s", tag, node_id)
+                    log.debug("Inconsistent text of %s %s", tag, node_id)
                     report.add_error(ConsistencyError(tag, node_id, file_id,
                                                       text_results, concatenated))
     return consistent

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -22,7 +22,8 @@ class WorkspaceValidator():
     Validates an OCR-D/METS workspace against the specs.
     """
 
-    def __init__(self, resolver, mets_url, src_dir=None, skip=None, download=False, page_strictness='strict'):
+    def __init__(self, resolver, mets_url, src_dir=None, skip=None, download=False,
+                 page_strictness='strict', page_discipline='poly'):
         """
         Construct a new WorkspaceValidator.
 
@@ -33,6 +34,7 @@ class WorkspaceValidator():
             skip (list):
             download (boolean):
             page_strictness ("strict"|"lax"|"fix"|"off"):
+            page_discipline ("poly"|"baseline"|"both"|"off"):
         """
         self.report = ValidationReport()
         self.skip = skip if skip else []
@@ -43,6 +45,7 @@ class WorkspaceValidator():
         self.mets_url = mets_url
         self.download = download
         self.page_strictness = page_strictness
+        self.page_discipline = page_discipline
 
         self.src_dir = src_dir
         self.workspace = None
@@ -205,5 +208,8 @@ class WorkspaceValidator():
         """
         for ocrd_file in self.mets.find_files(mimetype=MIMETYPE_PAGE, local_only=True):
             self.workspace.download_file(ocrd_file)
-            page_report = PageValidator.validate(ocrd_file=ocrd_file, strictness=self.page_strictness)
+            page_report = PageValidator.validate(ocrd_file=ocrd_file,
+                                                 strictness=self.page_strictness,
+                                                 check_coords=self.page_discipline in ['poly', 'both'],
+                                                 check_baseline=self.page_discipline in ['baseline', 'both'])
             self.report.merge_report(page_report)

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -23,7 +23,7 @@ class WorkspaceValidator():
     """
 
     def __init__(self, resolver, mets_url, src_dir=None, skip=None, download=False,
-                 page_strictness='strict', page_discipline='poly'):
+                 page_strictness='strict', page_coordinate_consistency='poly'):
         """
         Construct a new WorkspaceValidator.
 
@@ -34,7 +34,7 @@ class WorkspaceValidator():
             skip (list):
             download (boolean):
             page_strictness ("strict"|"lax"|"fix"|"off"):
-            page_discipline ("poly"|"baseline"|"both"|"off"):
+            page_coordinate_consistency ("poly"|"baseline"|"both"|"off"):
         """
         self.report = ValidationReport()
         self.skip = skip if skip else []
@@ -45,7 +45,7 @@ class WorkspaceValidator():
         self.mets_url = mets_url
         self.download = download
         self.page_strictness = page_strictness
-        self.page_discipline = page_discipline
+        self.page_coordinate_consistency = page_coordinate_consistency
 
         self.src_dir = src_dir
         self.workspace = None
@@ -210,6 +210,6 @@ class WorkspaceValidator():
             self.workspace.download_file(ocrd_file)
             page_report = PageValidator.validate(ocrd_file=ocrd_file,
                                                  strictness=self.page_strictness,
-                                                 check_coords=self.page_discipline in ['poly', 'both'],
-                                                 check_baseline=self.page_discipline in ['baseline', 'both'])
+                                                 check_coords=self.page_coordinate_consistency in ['poly', 'both'],
+                                                 check_baseline=self.page_coordinate_consistency in ['baseline', 'both'])
             self.report.merge_report(page_report)

--- a/ocrd_validators/requirements.txt
+++ b/ocrd_validators/requirements.txt
@@ -3,3 +3,4 @@ bagit_profile >= 1.3.0
 click >=7
 jsonschema
 pyyaml
+shapely

--- a/tests/model/test_exif.py
+++ b/tests/model/test_exif.py
@@ -37,7 +37,7 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.photometricInterpretation, '1')
 
     def test_png2(self):
-        exif = OcrdExif(Image.open(assets.path_to('scribo-test/data/OCR-D-IMG-BIN-SAUVOLA/OCR-D-IMG-orig_sauvola_png.jpg')))
+        exif = OcrdExif(Image.open(assets.path_to('scribo-test/data/OCR-D-IMG-BIN-SAUVOLA/OCR-D-SEG-PAGE-SAUVOLA-orig_tiff-BIN_sauvola.png')))
         self.assertEqual(exif.width, 2097)
         self.assertEqual(exif.height, 3062)
         self.assertEqual(exif.xResolution, 1)

--- a/tests/validator/test_page_validator.py
+++ b/tests/validator/test_page_validator.py
@@ -15,17 +15,20 @@ class TestPageValidator(TestCase):
     def test_validate_err(self):
         with self.assertRaisesRegex(Exception, 'At least one of ocrd_page, ocrd_file or filename must be set'):
             PageValidator.validate()
-        with self.assertRaisesRegex(Exception, 'Element selection strategy best not implemented'):
+        with self.assertRaisesRegex(Exception, 'page_textequiv_strategy best not implemented'):
+            PageValidator.validate(filename=FAULTY_GLYPH_PAGE_FILENAME, page_textequiv_strategy='best')
+        # test with deprecated name
+        with self.assertRaisesRegex(Exception, 'page_textequiv_strategy best not implemented'):
             PageValidator.validate(filename=FAULTY_GLYPH_PAGE_FILENAME, strategy='best')
-        with self.assertRaisesRegex(Exception, 'Strictness level superstrictest not implemented'):
-            PageValidator.validate(filename=FAULTY_GLYPH_PAGE_FILENAME, strictness='superstrictest', strategy='index1')
+        with self.assertRaisesRegex(Exception, 'page_textequiv_consistency level superstrictest not implemented'):
+            PageValidator.validate(filename=FAULTY_GLYPH_PAGE_FILENAME, page_textequiv_consistency='superstrictest', strategy='index1')
 
     def test_validate_filename(self):
         report = PageValidator.validate(filename=FAULTY_GLYPH_PAGE_FILENAME)
         self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 17, '17 textequiv consistency errors')
 
     def test_validate_filename_off(self):
-        report = PageValidator.validate(filename=FAULTY_GLYPH_PAGE_FILENAME, strictness='off')
+        report = PageValidator.validate(filename=FAULTY_GLYPH_PAGE_FILENAME, page_textequiv_consistency='off')
         self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 0, '0 textequiv consistency errors')
 
     def test_validate_ocrd_file(self):

--- a/tests/validator/test_page_validator.py
+++ b/tests/validator/test_page_validator.py
@@ -1,7 +1,7 @@
 from tests.base import TestCase, assets, main # pylint: disable=import-error,no-name-in-module
 from ocrd.resolver import Resolver
 from ocrd_validators import PageValidator
-from ocrd_validators.page_validator import get_text, set_text, TextequivConsistencyError
+from ocrd_validators.page_validator import get_text, set_text, ConsistencyError
 from ocrd_models.ocrd_page import parse, TextEquivType
 from ocrd_utils import pushd_popd
 
@@ -22,11 +22,11 @@ class TestPageValidator(TestCase):
 
     def test_validate_filename(self):
         report = PageValidator.validate(filename=FAULTY_GLYPH_PAGE_FILENAME)
-        self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 17, '17 textequiv consistency errors')
+        self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 17, '17 textequiv consistency errors')
 
     def test_validate_filename_off(self):
         report = PageValidator.validate(filename=FAULTY_GLYPH_PAGE_FILENAME, strictness='off')
-        self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 0, '0 textequiv consistency errors')
+        self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 0, '0 textequiv consistency errors')
 
     def test_validate_ocrd_file(self):
         resolver = Resolver()
@@ -34,7 +34,7 @@ class TestPageValidator(TestCase):
         with pushd_popd(workspace.directory):
             ocrd_file = workspace.mets.find_files(ID="FAULTY_GLYPHS_FILE")[0]
             report = PageValidator.validate(ocrd_file=ocrd_file)
-            self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 17, '17 textequiv consistency errors')
+            self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 17, '17 textequiv consistency errors')
 
     def test_validate_lax(self):
         ocrd_page = parse(assets.path_to('kant_aufklaerung_1784/data/OCR-D-GT-PAGE/PAGE_0020_PAGE.xml'), silence=True)
@@ -43,14 +43,14 @@ class TestPageValidator(TestCase):
         ocrd_page.get_Page().get_TextRegion()[0].get_TextLine()[0].get_Word()[1].get_TextEquiv()[0].set_Unicode('FOO')
 
         report = PageValidator.validate(ocrd_page=ocrd_page)
-        self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 26, '26 textequiv consistency errors - strict')
+        self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 26, '26 textequiv consistency errors - strict')
         report = PageValidator.validate(ocrd_page=ocrd_page, strictness='lax')
-        self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 1, '1 textequiv consistency errors - lax')
+        self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 1, '1 textequiv consistency errors - lax')
 
     def test_validate_multi_textequiv_index1(self):
         ocrd_page = parse(assets.path_to('kant_aufklaerung_1784/data/OCR-D-GT-PAGE/PAGE_0020_PAGE.xml'), silence=True)
         report = PageValidator.validate(ocrd_page=ocrd_page)
-        self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 25, '25 textequiv consistency errors - strict')
+        self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 25, '25 textequiv consistency errors - strict')
 
         word = ocrd_page.get_Page().get_TextRegion()[0].get_TextLine()[0].get_Word()[1]
 
@@ -69,7 +69,7 @@ class TestPageValidator(TestCase):
     def test_validate_multi_textequiv(self):
         ocrd_page = parse(assets.path_to('kant_aufklaerung_1784/data/OCR-D-GT-PAGE/PAGE_0020_PAGE.xml'), silence=True)
         report = PageValidator.validate(ocrd_page=ocrd_page)
-        self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 25, '25 textequiv consistency errors - strict')
+        self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 25, '25 textequiv consistency errors - strict')
 
         word = ocrd_page.get_Page().get_TextRegion()[0].get_TextLine()[0].get_Word()[1]
 
@@ -88,10 +88,10 @@ class TestPageValidator(TestCase):
     def test_fix(self):
         ocrd_page = parse(FAULTY_GLYPH_PAGE_FILENAME, silence=True)
         report = PageValidator.validate(ocrd_page=ocrd_page)
-        self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 17, '17 textequiv consistency errors')
+        self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 17, '17 textequiv consistency errors')
         PageValidator.validate(ocrd_page=ocrd_page, strictness='fix')
         report = PageValidator.validate(ocrd_page=ocrd_page)
-        self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 0, 'no more textequiv consistency errors')
+        self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 0, 'no more textequiv consistency errors')
 
 if __name__ == '__main__':
     main()

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -6,6 +6,7 @@ from shutil import copytree
 from ocrd_utils import pushd_popd
 from ocrd.resolver import Resolver
 from ocrd_validators import WorkspaceValidator
+from ocrd_validators.page_validator import TextequivConsistencyError
 
 from tests.base import TestCase, assets, main # pylint: disable=import-error,no-name-in-module
 
@@ -162,7 +163,8 @@ class TestWorkspaceValidator(TestCase):
             skip=['imagefilename'],
             download=True,
         )
-        self.assertEqual(len(report.errors), 42)
+        print(report.errors)
+        self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 42, '42 textequiv consistency errors')
 
     def test_imagefilename(self):
         report = WorkspaceValidator.validate(

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -6,7 +6,7 @@ from shutil import copytree
 from ocrd_utils import pushd_popd
 from ocrd.resolver import Resolver
 from ocrd_validators import WorkspaceValidator
-from ocrd_validators.page_validator import TextequivConsistencyError
+from ocrd_validators.page_validator import ConsistencyError
 
 from tests.base import TestCase, assets, main # pylint: disable=import-error,no-name-in-module
 
@@ -164,7 +164,7 @@ class TestWorkspaceValidator(TestCase):
             download=True,
         )
         print(report.errors)
-        self.assertEqual(len([e for e in report.errors if isinstance(e, TextequivConsistencyError)]), 42, '42 textequiv consistency errors')
+        self.assertEqual(len([e for e in report.errors if isinstance(e, ConsistencyError)]), 42, '42 textequiv consistency errors')
 
     def test_imagefilename(self):
         report = WorkspaceValidator.validate(


### PR DESCRIPTION
- improve recursive validation of multi-level textequiv consistency:
  * regions (e.g. Table) may contain regions (e.g. Text)
  * 'fix' recursively by going bottom-up
  * better reports, more logging
  * simplify
- add recursive validation of multi-level coordinate consistency:
  * add all region types, also consider Baseline
  * introduce 2 more error cases into ValidationReport:
    - CoordinateValidityException (self-intersecting, non-contiguous,
      too short or negative path)
    - CoordinateConsistencyException (child extends beyond parent)
  * introduce 2 new parameters:
    - check_coords (valid paths and consistent child/parent relations
      within the normal hierarchy)
    - check_baseline (the same only for TextLine.Coords vs Baseline)
  * expose them as 1 new CLI parameter `--page-discipline` (analoguous to
    `--page-strictness` for text) as enum:
    - poly (only check_coords)
    - baseline (only check_baseline)
    - both
    - off
  * use shapely.geometry for checks
  * handle PAGE ideosyncrasies (no Coords or ID at PageType / Baseline)
  * try to be efficient (re-use Polygon objects)
- remove unnecessary/redundant instantiation and method from PageValidator