### PR TITLE
have save_mets use UTF-8 encoding for byte-serialization…

### DIFF
--- a/ocrd_models/ocrd_models/utils.py
+++ b/ocrd_models/ocrd_models/utils.py
@@ -16,4 +16,5 @@ def xmllint_format(xml):
     """
     parser = ET.XMLParser(resolve_entities=False, strip_cdata=False, remove_blank_text=True)
     document = ET.fromstring(xml, parser)
-    return ('%s\n%s' % ('<?xml version="1.0" encoding="UTF-8"?>', ET.tostring(document, pretty_print=True).decode('utf-8'))).encode('utf-8')
+    return ('%s\n%s' % ('<?xml version="1.0" encoding="UTF-8"?>',
+                        ET.tostring(document, pretty_print=True, encoding='UTF-8').decode('utf-8'))).encode('utf-8')


### PR DESCRIPTION
…to avoid HTML-encoding non-ASCII codepoints.

Fixes #326