### PR TITLE
Validate input group

### DIFF
--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -1,5 +1,3 @@
-import json
-import os
 from os.path import isfile
 
 import click
@@ -37,7 +35,7 @@ def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_d
     elif version:
         try:
             p = processorClass(workspace=None)
-        except e:
+        except Exception:
             pass
         print("Version %s, ocrd/core %s" % (p.version, OCRD_VERSION))
     elif mets is None:

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -14,6 +14,7 @@ from ocrd_utils import (
 from ocrd_utils import getLogger
 from .resolver import Resolver
 from .processor.base import run_processor
+from ocrd_validators import WorkspaceValidator
 
 def _set_root_logger_version(ctx, param, value):    # pylint: disable=unused-argument
     setOverrideLogLevel(value)
@@ -49,6 +50,9 @@ def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_d
             raise Exception(msg)
         resolver = Resolver()
         workspace = resolver.workspace_from_url(mets, working_dir)
+        with WorkspaceValidator.check_file_grp(workspace, kwargs['input_file_grp'], kwargs['output_file_grp']) as report:
+            if not report.is_valid:
+                raise Exception("Invalid input/output file grps:\n\t%s" % '\n\t'.join(report.errors))
         run_processor(processorClass, ocrd_tool, mets, workspace=workspace, **kwargs)
 
 def ocrd_loglevel(f):

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -52,9 +52,9 @@ def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_d
         workspace = resolver.workspace_from_url(mets, working_dir)
         # TODO once we implement 'overwrite' CLI option and mechanism, disable the
         # `output_file_grp_ check by setting to False-y value if 'overwrite' is set
-        with WorkspaceValidator.check_file_grp(workspace, kwargs['input_file_grp'], kwargs['output_file_grp']) as report:
-            if not report.is_valid:
-                raise Exception("Invalid input/output file grps:\n\t%s" % '\n\t'.join(report.errors))
+        report = WorkspaceValidator.check_file_grp(workspace, kwargs['input_file_grp'], kwargs['output_file_grp'])
+        if not report.is_valid:
+            raise Exception("Invalid input/output file grps:\n\t%s" % '\n\t'.join(report.errors))
         run_processor(processorClass, ocrd_tool, mets, workspace=workspace, **kwargs)
 
 def ocrd_loglevel(f):

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -50,6 +50,8 @@ def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_d
             raise Exception(msg)
         resolver = Resolver()
         workspace = resolver.workspace_from_url(mets, working_dir)
+        # TODO once we implement 'overwrite' CLI option and mechanism, disable the
+        # `output_file_grp_ check by setting to False-y value if 'overwrite' is set
         with WorkspaceValidator.check_file_grp(workspace, kwargs['input_file_grp'], kwargs['output_file_grp']) as report:
             if not report.is_valid:
                 raise Exception("Invalid input/output file grps:\n\t%s" % '\n\t'.join(report.errors))

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -95,7 +95,7 @@ def run_cli(
     log.debug("Running subprocess '%s'", ' '.join(args))
     return subprocess.call(args)
 
-class Processor(object):
+class Processor():
     """
     A processor runs an algorithm based on the workspace, the mets.xml in the
     workspace (and the input files defined therein) as well as optional

--- a/ocrd/ocrd/task_sequence.py
+++ b/ocrd/ocrd/task_sequence.py
@@ -80,17 +80,17 @@ def validate_tasks(tasks, workspace):
         task.validate()
         if task_idx == 0:
             # first task: check input/output file groups from METS
-            # TODO disable output_file_grp checks once CLI parameter 'overwrite' is implemented
+            # TODO disable output_file_grps checks once CLI parameter 'overwrite' is implemented
             WorkspaceValidator.check_file_grp(workspace, task.input_file_grps, task.output_file_grps, report)
         else:
             # check either existing fileGrp or output-file group of previous task matches current input_file_group
             prev_output_file_grps = workspace.mets.file_groups
-            for prev_task in tasks[0:task_idx - 1]:
-                prev_output_file_grps += prev_task.output_file_grp.split(',')
+            for prev_task in tasks[0:task_idx]:
+                prev_output_file_grps += prev_task.output_file_grps
             for input_file_grp in task.input_file_grps:
                 if not input_file_grp in prev_output_file_grps:
                     report.add_error("Input file group not contained in METS or produced by previous steps: %s" % input_file_grp)
-            # TODO disable output_file_grp checks once CLI parameter 'overwrite' is implemented
+            # TODO disable output_file_grps checks once CLI parameter 'overwrite' is implemented
             if len(prev_output_file_grps) != len(set(prev_output_file_grps)):
                 report.add_error("Output file group specified multiple times: %s" % 
                     [grp for grp, count in Counter(prev_output_file_grps).items() if count >= 2])

--- a/ocrd/ocrd/task_sequence.py
+++ b/ocrd/ocrd/task_sequence.py
@@ -2,11 +2,12 @@ import json
 from shlex import split as shlex_split
 from distutils.spawn import find_executable as which # pylint: disable=import-error,no-name-in-module
 from subprocess import run, PIPE
+from collections import Counter
 
 from ocrd_utils import getLogger, parse_json_string_or_file
 from ocrd.processor.base import run_cli
 from ocrd.resolver import Resolver
-from ocrd_validators import ParameterValidator
+from ocrd_validators import ParameterValidator, WorkspaceValidator, ValidationReport
 
 class ProcessorTask():
 
@@ -38,22 +39,29 @@ class ProcessorTask():
         self.input_file_grps = input_file_grps
         self.output_file_grps = output_file_grps
         self.parameter_path = parameter_path
+        self._ocrd_tool_json = None
+
+    @property
+    def ocrd_tool_json(self):
+        if self._ocrd_tool_json:
+            return self._ocrd_tool_json
+        result = run([self.executable, '--dump-json'], stdout=PIPE, check=True, universal_newlines=True)
+        self._ocrd_tool_json = json.loads(result.stdout)
+        return self._ocrd_tool_json
 
     def validate(self):
         if not which(self.executable):
             raise Exception("Executable not found in PATH: %s" % self.executable)
         if not self.input_file_grps:
             raise Exception("Task must have input file group")
-        result = run([self.executable, '--dump-json'], stdout=PIPE, check=True, universal_newlines=True)
-        ocrd_tool_json = json.loads(result.stdout)
         parameters = {}
         if self.parameter_path:
             parameters = parse_json_string_or_file(self.parameter_path)
-        param_validator = ParameterValidator(ocrd_tool_json)
+        param_validator = ParameterValidator(self.ocrd_tool_json)
         report = param_validator.validate(parameters)
         if not report.is_valid:
             raise Exception(report.errors)
-        if 'output_file_grp' in ocrd_tool_json and not self.output_file_grps:
+        if 'output_file_grp' in self.ocrd_tool_json and not self.output_file_grps:
             raise Exception("Processor requires output_file_grp but none was provided.")
         return True
 
@@ -66,24 +74,40 @@ class ProcessorTask():
             ret += ' -p %s' % self.parameter_path
         return ret
 
+def validate_tasks(tasks, workspace):
+    report = ValidationReport()
+    for task_idx, task in enumerate(tasks):
+        task.validate()
+        if task_idx == 0:
+            # first task: check input/output file groups from METS
+            # TODO disable output_file_grp checks once CLI parameter 'overwrite' is implemented
+            WorkspaceValidator.check_file_grp(workspace, task.input_file_grps, task.output_file_grps, report)
+        else:
+            # check either existing fileGrp or output-file group of previous task matches current input_file_group
+            prev_output_file_grps = workspace.mets.file_groups
+            for prev_task in tasks[0:task_idx - 1]:
+                prev_output_file_grps += prev_task.output_file_grp.split(',')
+            for input_file_grp in task.input_file_grps:
+                if not input_file_grp in prev_output_file_grps:
+                    report.add_error("Input file group not contained in METS or produced by previous steps: %s" % input_file_grp)
+            # TODO disable output_file_grp checks once CLI parameter 'overwrite' is implemented
+            if len(prev_output_file_grps) != len(set(prev_output_file_grps)):
+                report.add_error("Output file group specified multiple times: %s" % 
+                    [grp for grp, count in Counter(prev_output_file_grps).items() if count >= 2])
+    if not report.is_valid:
+        raise Exception("Invalid task sequence input/output file groups: %s" % report.errors)
+
+
 def run_tasks(mets, log_level, page_id, task_strs):
     resolver = Resolver()
     workspace = resolver.workspace_from_url(mets)
-    log = getLogger('ocrd.task_sequence')
+    log = getLogger('ocrd.task_sequence.run_tasks')
     tasks = [ProcessorTask.parse(task_str) for task_str in task_strs]
 
+    validate_tasks(tasks, workspace)
+
+    # Run the tasks
     for task in tasks:
-
-        task.validate()
-
-        # check input file groups are in mets
-        for input_file_grp in task.input_file_grps:
-            if not input_file_grp in workspace.mets.file_groups:
-                raise Exception("Unmet requirement: expected input file group not contained in mets: %s" % input_file_grp)
-
-        for output_file_grp in task.output_file_grps:
-            if output_file_grp in workspace.mets.file_groups:
-                raise Exception("Conflict: output file group already contained in mets: %s" % output_file_grp)
 
         log.info("Start processing task '%s'", task)
 
@@ -113,5 +137,4 @@ def run_tasks(mets, log_level, page_id, task_strs):
         for output_file_grp in task.output_file_grps:
             if not output_file_grp in workspace.mets.file_groups:
                 raise Exception("Invalid state: expected output file group not in mets: %s" % output_file_grp)
-
 

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -26,18 +26,20 @@ class WorkspaceValidator():
 
     @staticmethod
     @contextmanager
-    def check_file_grp(workspace, input_file_grp, output_file_grp):
+    def check_file_grp(workspace, input_file_grp=None, output_file_grp=None):
         """
-        Return a report on whether input_file_grp is/are in workspace.mets
+        Return a report on whether input_file_grp is/are in workspace.mets and output_file_grp is/are not.
         To be run before processing
         """
         report = ValidationReport()
-        for grp in input_file_grp.split(','):
-            if grp not in workspace.mets.file_groups:
-                report.add_error("Input fileGrp[@USE='%s'] not in METS!" % grp)
-        for grp in output_file_grp.split(','):
-            if grp in workspace.mets.file_groups:
-                report.add_error("Output fileGrp[@USE='%s'] already in METS!" % grp)
+        if input_file_grp:
+            for grp in input_file_grp.split(','):
+                if grp not in workspace.mets.file_groups:
+                    report.add_error("Input fileGrp[@USE='%s'] not in METS!" % grp)
+        if output_file_grp:
+            for grp in output_file_grp.split(','):
+                if grp in workspace.mets.file_groups:
+                    report.add_error("Output fileGrp[@USE='%s'] already in METS!" % grp)
         yield report
         return report
 

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -37,7 +37,6 @@ class WorkspaceValidator():
         if isinstance(output_file_grp, str):
             output_file_grp = output_file_grp.split(',')
 
-        print('hi')
         log.info("input_file_grp=%s output_file_grp=%s" % (input_file_grp, output_file_grp))
         print(input_file_grp)
         if input_file_grp:

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -33,12 +33,18 @@ class WorkspaceValidator():
         """
         if not report:
             report = ValidationReport()
+        if isinstance(input_file_grp, str):
+            input_file_grp = input_file_grp.split(',')
+        if isinstance(output_file_grp, str):
+            output_file_grp = output_file_grp.split(',')
+
+        log.info("input_file_grp=%s output_file_grp=%s" % (input_file_grp, output_file_grp))
         if input_file_grp:
-            for grp in input_file_grp.split(','):
+            for grp in input_file_grp:
                 if grp not in workspace.mets.file_groups:
                     report.add_error("Input fileGrp[@USE='%s'] not in METS!" % grp)
         if output_file_grp:
-            for grp in output_file_grp.split(','):
+            for grp in output_file_grp:
                 if grp in workspace.mets.file_groups:
                     report.add_error("Output fileGrp[@USE='%s'] already in METS!" % grp)
         yield report

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -26,12 +26,13 @@ class WorkspaceValidator():
 
     @staticmethod
     @contextmanager
-    def check_file_grp(workspace, input_file_grp=None, output_file_grp=None):
+    def check_file_grp(workspace, input_file_grp=None, output_file_grp=None, report=None):
         """
         Return a report on whether input_file_grp is/are in workspace.mets and output_file_grp is/are not.
         To be run before processing
         """
-        report = ValidationReport()
+        if not report:
+            report = ValidationReport()
         if input_file_grp:
             for grp in input_file_grp.split(','):
                 if grp not in workspace.mets.file_groups:

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -25,7 +25,6 @@ class WorkspaceValidator():
     """
 
     @staticmethod
-    @contextmanager
     def check_file_grp(workspace, input_file_grp=None, output_file_grp=None, report=None):
         """
         Return a report on whether input_file_grp is/are in workspace.mets and output_file_grp is/are not.
@@ -38,7 +37,9 @@ class WorkspaceValidator():
         if isinstance(output_file_grp, str):
             output_file_grp = output_file_grp.split(',')
 
+        print('hi')
         log.info("input_file_grp=%s output_file_grp=%s" % (input_file_grp, output_file_grp))
+        print(input_file_grp)
         if input_file_grp:
             for grp in input_file_grp:
                 if grp not in workspace.mets.file_groups:
@@ -47,7 +48,6 @@ class WorkspaceValidator():
             for grp in output_file_grp:
                 if grp in workspace.mets.file_groups:
                     report.add_error("Output fileGrp[@USE='%s'] already in METS!" % grp)
-        yield report
         return report
 
     def __init__(self, resolver, mets_url, src_dir=None, skip=None, download=False,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -92,7 +92,7 @@ class TestDecorators(TestCase):
     def test_processor_run(self):
         with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
             with pushd_popd(tempdir):
-                result = self.runner.invoke(cli_dummy_processor, ['-p', '{"foo": 42}', '--mets', 'mets.xml'])
+                result = self.runner.invoke(cli_dummy_processor, ['-p', '{"foo": 42}', '--mets', 'mets.xml', '-I', 'OCR-D-IMG'])
                 self.assertEqual(result.exit_code, 0)
 
 

--- a/tests/test_task_sequence.py
+++ b/tests/test_task_sequence.py
@@ -124,10 +124,14 @@ print('''%s''')
             workspace = resolver.workspace_from_url(assets.path_to('kant_aufklaerung_1784/data/mets.xml'), dst_dir=tempdir)
             params_path = Path(tempdir, 'params.json')
             params_path.write_text('{"param1": true}')
-            with self.assertRaisesRegex(Exception, 'Input file group not contained in METS or produced by previous steps: FOO'):
+            with self.assertRaisesRegex(Exception, "Input fileGrp.@USE='IN'. not in METS!"):
                 validate_tasks([ProcessorTask.parse(x) for x in [
-                    'sample-processor-required-param -I IN -O OUT -p %s' % params_path,
-                    'sample-processor-required-param -I FOO -O OUT -p %s' % params_path
+                    'sample-processor-required-param -I IN -O OUT1 -p %s' % params_path,
+                ]], workspace)
+            with self.assertRaisesRegex(Exception, "Input file group not contained in METS or produced by previous steps: FOO'"):
+                validate_tasks([ProcessorTask.parse(x) for x in [
+                    'sample-processor-required-param -I OCR-D-IMG -O OUT1 -p %s' % params_path,
+                    'sample-processor-required-param -I FOO -O OUT2 -p %s' % params_path
                 ]], workspace)
 
 if __name__ == '__main__':

--- a/tests/test_task_sequence.py
+++ b/tests/test_task_sequence.py
@@ -124,15 +124,18 @@ print('''%s''')
             workspace = resolver.workspace_from_url(assets.path_to('kant_aufklaerung_1784/data/mets.xml'), dst_dir=tempdir)
             params_path = Path(tempdir, 'params.json')
             params_path.write_text('{"param1": true}')
-            with self.assertRaisesRegex(Exception, "Input fileGrp.@USE='IN'. not in METS!"):
-                validate_tasks([ProcessorTask.parse(x) for x in [
-                    'sample-processor-required-param -I IN -O OUT1 -p %s' % params_path,
-                ]], workspace)
+
             with self.assertRaisesRegex(Exception, "Input file group not contained in METS or produced by previous steps: FOO'"):
                 validate_tasks([ProcessorTask.parse(x) for x in [
                     'sample-processor-required-param -I OCR-D-IMG -O OUT1 -p %s' % params_path,
                     'sample-processor-required-param -I FOO -O OUT2 -p %s' % params_path
                 ]], workspace)
+
+            with self.assertRaisesRegex(Exception, "Input fileGrp.@USE='IN'. not in METS!"):
+                validate_tasks([ProcessorTask.parse(x) for x in [
+                    'sample-processor-required-param -I IN -O OUT1 -p %s' % params_path,
+                ]], workspace)
+
 
 if __name__ == '__main__':
     main()

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -29,6 +29,12 @@ class TestWorkspaceValidator(TestCase):
             self.assertFalse(report.is_valid)
             self.assertEqual(len(report.errors), 1)
             self.assertEqual(report.errors[0], "Input fileGrp[@USE='FOO'] not in METS!")
+        with WorkspaceValidator.check_file_grp(workspace, 'OCR-D-IMG,FOO', None) as report:
+            self.assertFalse(report.is_valid)
+            self.assertEqual(len(report.errors), 1)
+            self.assertEqual(report.errors[0], "Input fileGrp[@USE='FOO'] not in METS!")
+        with WorkspaceValidator.check_file_grp(workspace, None, '') as report:
+            self.assertTrue(report.is_valid)
 
     def test_simple(self):
         report = WorkspaceValidator.validate(self.resolver, assets.url_of('SBB0000F29300010000/data/mets_one_file.xml'), download=True)

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -1,5 +1,5 @@
 import os
-from tempfile import TemporaryDirectory, mkdtemp
+from tempfile import TemporaryDirectory
 from os.path import join
 from shutil import copytree
 
@@ -14,6 +14,21 @@ class TestWorkspaceValidator(TestCase):
 
     def setUp(self):
         self.resolver = Resolver()
+
+    def test_check_file_grp(self):
+        workspace = self.resolver.workspace_from_url(assets.url_of('SBB0000F29300010000/data/mets.xml'))
+        with WorkspaceValidator.check_file_grp(workspace, 'foo', 'bar') as report:
+            self.assertFalse(report.is_valid)
+            self.assertEqual(len(report.errors), 1)
+            self.assertEqual(report.errors[0], "Input fileGrp[@USE='foo'] not in METS!")
+        with WorkspaceValidator.check_file_grp(workspace, 'OCR-D-IMG', 'OCR-D-IMG-BIN') as report:
+            self.assertFalse(report.is_valid)
+            self.assertEqual(len(report.errors), 1)
+            self.assertEqual(report.errors[0], "Output fileGrp[@USE='OCR-D-IMG-BIN'] already in METS!")
+        with WorkspaceValidator.check_file_grp(workspace, 'OCR-D-IMG,FOO', 'FOO') as report:
+            self.assertFalse(report.is_valid)
+            self.assertEqual(len(report.errors), 1)
+            self.assertEqual(report.errors[0], "Input fileGrp[@USE='FOO'] not in METS!")
 
     def test_simple(self):
         report = WorkspaceValidator.validate(self.resolver, assets.url_of('SBB0000F29300010000/data/mets_one_file.xml'), download=True)

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -17,24 +17,24 @@ class TestWorkspaceValidator(TestCase):
 
     def test_check_file_grp(self):
         workspace = self.resolver.workspace_from_url(assets.url_of('SBB0000F29300010000/data/mets.xml'))
-        with WorkspaceValidator.check_file_grp(workspace, 'foo', 'bar') as report:
-            self.assertFalse(report.is_valid)
-            self.assertEqual(len(report.errors), 1)
-            self.assertEqual(report.errors[0], "Input fileGrp[@USE='foo'] not in METS!")
-        with WorkspaceValidator.check_file_grp(workspace, 'OCR-D-IMG', 'OCR-D-IMG-BIN') as report:
-            self.assertFalse(report.is_valid)
-            self.assertEqual(len(report.errors), 1)
-            self.assertEqual(report.errors[0], "Output fileGrp[@USE='OCR-D-IMG-BIN'] already in METS!")
-        with WorkspaceValidator.check_file_grp(workspace, 'OCR-D-IMG,FOO', 'FOO') as report:
-            self.assertFalse(report.is_valid)
-            self.assertEqual(len(report.errors), 1)
-            self.assertEqual(report.errors[0], "Input fileGrp[@USE='FOO'] not in METS!")
-        with WorkspaceValidator.check_file_grp(workspace, 'OCR-D-IMG,FOO', None) as report:
-            self.assertFalse(report.is_valid)
-            self.assertEqual(len(report.errors), 1)
-            self.assertEqual(report.errors[0], "Input fileGrp[@USE='FOO'] not in METS!")
-        with WorkspaceValidator.check_file_grp(workspace, None, '') as report:
-            self.assertTrue(report.is_valid)
+        report = WorkspaceValidator.check_file_grp(workspace, 'foo', 'bar')
+        self.assertFalse(report.is_valid)
+        self.assertEqual(len(report.errors), 1)
+        self.assertEqual(report.errors[0], "Input fileGrp[@USE='foo'] not in METS!")
+        report = WorkspaceValidator.check_file_grp(workspace, 'OCR-D-IMG', 'OCR-D-IMG-BIN')
+        self.assertFalse(report.is_valid)
+        self.assertEqual(len(report.errors), 1)
+        self.assertEqual(report.errors[0], "Output fileGrp[@USE='OCR-D-IMG-BIN'] already in METS!")
+        report = WorkspaceValidator.check_file_grp(workspace, 'OCR-D-IMG,FOO', 'FOO')
+        self.assertFalse(report.is_valid)
+        self.assertEqual(len(report.errors), 1)
+        self.assertEqual(report.errors[0], "Input fileGrp[@USE='FOO'] not in METS!")
+        report = WorkspaceValidator.check_file_grp(workspace, 'OCR-D-IMG,FOO', None)
+        self.assertFalse(report.is_valid)
+        self.assertEqual(len(report.errors), 1)
+        self.assertEqual(report.errors[0], "Input fileGrp[@USE='FOO'] not in METS!")
+        report = WorkspaceValidator.check_file_grp(workspace, None, '')
+        self.assertTrue(report.is_valid)
 
     def test_simple(self):
         report = WorkspaceValidator.validate(self.resolver, assets.url_of('SBB0000F29300010000/data/mets_one_file.xml'), download=True)


### PR DESCRIPTION
Adds a static method `check_file_grp` to WorkspaceValidator which is called before run_processor when wrapping processors and will fail if
- input file groups are NOT in mets
- output file groups ARE in mets