### PR TITLE
PNG with DPI have no tag, fix #395

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_exif.py
+++ b/ocrd_models/ocrd_models/ocrd_exif.py
@@ -41,6 +41,8 @@ class OcrdExif():
             self.yResolution = int(img.info['dpi'][1])
             if img.format == 'TIFF':
                 self.resolutionUnit = 'cm' if img.tag.get(296) == 3 else 'inches'
+            else:    
+                self.resolutionUnit = 'inches'
         elif img.format == 'JPEG' and 'jfif_density' in img.info:
             self.xResolution = img.info['jfif_density'][0]
             self.yResolution = img.info['jfif_density'][1]

--- a/ocrd_models/ocrd_models/ocrd_exif.py
+++ b/ocrd_models/ocrd_models/ocrd_exif.py
@@ -39,7 +39,8 @@ class OcrdExif():
         if img.format in ('TIFF', 'PNG') and 'dpi' in img.info:
             self.xResolution = int(img.info['dpi'][0])
             self.yResolution = int(img.info['dpi'][1])
-            self.resolutionUnit = 'cm' if img.tag.get(296) == 3 else 'inches'
+            if img.format == 'TIFF':
+                self.resolutionUnit = 'cm' if img.tag.get(296) == 3 else 'inches'
         elif img.format == 'JPEG' and 'jfif_density' in img.info:
             self.xResolution = img.info['jfif_density'][0]
             self.yResolution = img.info['jfif_density'][1]

--- a/ocrd_models/ocrd_models/ocrd_exif.py
+++ b/ocrd_models/ocrd_models/ocrd_exif.py
@@ -18,7 +18,7 @@ class OcrdExif():
       'F' for floating-point grayscale
       (see PIL concept `mode`)
     - `resolution` / `xResolution` / `yResolution`: pixel density
-    - `resolutionUnits`: unit of measurement (either `inches` or `cm`)
+    - `resolutionUnit`: unit of measurement (either `inches` or `cm`)
 
     """
 
@@ -41,7 +41,7 @@ class OcrdExif():
             self.yResolution = int(img.info['dpi'][1])
             if img.format == 'TIFF':
                 self.resolutionUnit = 'cm' if img.tag.get(296) == 3 else 'inches'
-            else:    
+            else:
                 self.resolutionUnit = 'inches'
         elif img.format == 'JPEG' and 'jfif_density' in img.info:
             self.xResolution = img.info['jfif_density'][0]
@@ -50,6 +50,7 @@ class OcrdExif():
         elif img.format == 'PNG' and 'aspect' in img.info:
             self.xResolution = img.info['aspect'][0]
             self.yResolution = img.info['aspect'][1]
+            self.resolutionUnit = 'inches'
         else:
             #  if img.format == 'JPEG2000':
             #      import sys

--- a/tests/model/test_exif.py
+++ b/tests/model/test_exif.py
@@ -36,6 +36,7 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.xResolution, 295)
         self.assertEqual(exif.yResolution, 295)
         self.assertEqual(exif.resolution, 295)
+        self.assertEqual(exif.resolutionUnit, 'inches')
         self.assertEqual(exif.compression, None)
         self.assertEqual(exif.photometricInterpretation, '1')
 

--- a/tests/model/test_exif.py
+++ b/tests/model/test_exif.py
@@ -7,7 +7,8 @@ from ocrd_models import OcrdExif
 class TestOcrdExif(TestCase):
 
     def test_str(self):
-        exif = OcrdExif(Image.open(assets.path_to('SBB0000F29300010000/data/OCR-D-IMG/FILE_0001_IMAGE.tif')))
+        with Image.open(assets.path_to('SBB0000F29300010000/data/OCR-D-IMG/FILE_0001_IMAGE.tif')) as img:
+            exif = OcrdExif(img)
         print(str(exif.to_xml()))
         # XXX not platform-independent/stable
         #  self.assertEqual(
@@ -17,7 +18,8 @@ class TestOcrdExif(TestCase):
 
 
     def test_tiff(self):
-        exif = OcrdExif(Image.open(assets.path_to('SBB0000F29300010000/data/OCR-D-IMG/FILE_0001_IMAGE.tif')))
+        with Image.open(assets.path_to('SBB0000F29300010000/data/OCR-D-IMG/FILE_0001_IMAGE.tif')) as img:
+            exif = OcrdExif(img)
         self.assertEqual(exif.width, 2875)
         self.assertEqual(exif.height, 3749)
         self.assertEqual(exif.xResolution, 300)
@@ -27,17 +29,19 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.photometricInterpretation, 'RGB')
 
     def test_png1(self):
-        exif = OcrdExif(Image.open(assets.path_to('kant_aufklaerung_1784-binarized/data/OCR-D-IMG-BIN/BIN_0020.png')))
+        with Image.open(assets.path_to('kant_aufklaerung_1784-binarized/data/OCR-D-IMG-BIN/BIN_0020.png')) as img:
+            exif = OcrdExif(img)
         self.assertEqual(exif.width, 1457)
         self.assertEqual(exif.height, 2084)
-        self.assertEqual(exif.xResolution, 300)
-        self.assertEqual(exif.yResolution, 300)
-        self.assertEqual(exif.resolution, 300)
+        self.assertEqual(exif.xResolution, 295)
+        self.assertEqual(exif.yResolution, 295)
+        self.assertEqual(exif.resolution, 295)
         self.assertEqual(exif.compression, None)
         self.assertEqual(exif.photometricInterpretation, '1')
 
     def test_png2(self):
-        exif = OcrdExif(Image.open(assets.path_to('scribo-test/data/OCR-D-IMG-BIN-SAUVOLA/OCR-D-SEG-PAGE-SAUVOLA-orig_tiff-BIN_sauvola.png')))
+        with Image.open(assets.path_to('scribo-test/data/OCR-D-IMG-BIN-SAUVOLA/OCR-D-SEG-PAGE-SAUVOLA-orig_tiff-BIN_sauvola.png')) as img:
+            exif = OcrdExif(img)
         self.assertEqual(exif.width, 2097)
         self.assertEqual(exif.height, 3062)
         self.assertEqual(exif.xResolution, 1)
@@ -46,7 +50,8 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.photometricInterpretation, '1')
 
     def test_jpg(self):
-        exif = OcrdExif(Image.open(assets.path_to('leptonica_samples/data/OCR-D-IMG/OCR-D-IMG_1555_007.jpg')))
+        with Image.open(assets.path_to('leptonica_samples/data/OCR-D-IMG/OCR-D-IMG_1555_007.jpg')) as img:
+            exif = OcrdExif(img)
         self.assertEqual(exif.width, 944)
         self.assertEqual(exif.height, 1472)
         self.assertEqual(exif.xResolution, 1)
@@ -56,7 +61,8 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.photometricInterpretation, 'RGB')
 
     def test_jp2(self):
-        exif = OcrdExif(Image.open(assets.path_to('kant_aufklaerung_1784-jp2/data/OCR-D-IMG/INPUT_0020.jp2')))
+        with Image.open(assets.path_to('kant_aufklaerung_1784-jp2/data/OCR-D-IMG/INPUT_0020.jp2')) as img:
+            exif = OcrdExif(img)
         self.assertEqual(exif.width, 1457)
         self.assertEqual(exif.height, 2084)
         self.assertEqual(exif.xResolution, 1)

--- a/tests/model/test_exif.py
+++ b/tests/model/test_exif.py
@@ -27,6 +27,7 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.resolution, 300)
         self.assertEqual(exif.compression, 'jpeg')
         self.assertEqual(exif.photometricInterpretation, 'RGB')
+        self.assertEqual(exif.resolutionUnit, 'inches')
 
     def test_png1(self):
         with Image.open(assets.path_to('kant_aufklaerung_1784-binarized/data/OCR-D-IMG-BIN/BIN_0020.png')) as img:
@@ -49,6 +50,7 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.yResolution, 1)
         self.assertEqual(exif.resolution, 1)
         self.assertEqual(exif.photometricInterpretation, '1')
+        self.assertEqual(exif.resolutionUnit, 'inches')
 
     def test_jpg(self):
         with Image.open(assets.path_to('leptonica_samples/data/OCR-D-IMG/OCR-D-IMG_1555_007.jpg')) as img:
@@ -60,6 +62,7 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.resolution, 1)
         self.assertEqual(exif.resolutionUnit, 'inches')
         self.assertEqual(exif.photometricInterpretation, 'RGB')
+        self.assertEqual(exif.resolutionUnit, 'inches')
 
     def test_jp2(self):
         with Image.open(assets.path_to('kant_aufklaerung_1784-jp2/data/OCR-D-IMG/INPUT_0020.jp2')) as img:
@@ -70,6 +73,7 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.yResolution, 1)
         self.assertEqual(exif.resolution, 1)
         self.assertEqual(exif.photometricInterpretation, 'RGB')
+        self.assertEqual(exif.resolutionUnit, 'inches')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The fix is trivial, the complex thing was getting the test metadata right.

