### PR TITLE
resolver: if mets_url is relative path, resolve before anything else

### DIFF
--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -122,6 +122,10 @@ class Resolver():
         if mets_url is None:
             raise ValueError("Must pass 'mets_url' workspace_from_url")
 
+        # if mets_url is a relative filename, make it absolute
+        if is_local_filename(mets_url) and not Path(mets_url).is_absolute():
+            mets_url = str(Path(Path.cwd() / mets_url))
+
         # if mets_basename is not given, use the last URL segment of the mets_url
         if mets_basename is None:
             mets_basename = nth_url_segment(mets_url, -1)

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -191,6 +191,14 @@ class TestCli(TestCase):
             self.assertEqual(len(workspace.mets.find_files()), 33)
             self.assertFalse(exists(file_path))
 
+    def test_clone_relative(self):
+        # Create a relative path to trigger make sure #319 is gone
+        src_path = str(Path(assets.path_to('kant_aufklaerung_1784/data/mets.xml')).relative_to(Path.cwd()))
+        with TemporaryDirectory() as tempdir:
+            result = self.runner.invoke(workspace_cli, ['clone', '-a', src_path, tempdir])
+            self.assertEqual(result.exit_code, 0)
+            self.assertTrue(exists(join(tempdir, 'OCR-D-GT-PAGE/PAGE_0017_PAGE.xml')))
+
     def test_copy_vs_clone(self):
         src_dir = assets.path_to('kant_aufklaerung_1784/data')
         with TemporaryDirectory() as tempdir:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -101,6 +101,22 @@ class TestWorkspace(TestCase):
             self.assertEqual(f, Path('TEMP', '%s.tif' % SAMPLE_FILE_ID))
             self.assertTrue(Path(ws1.directory, f).exists())
 
+    def test_from_url_dst_dir_download(self):
+        """
+        https://github.com/OCR-D/core/issues/319
+        """
+        with TemporaryDirectory() as tempdir:
+            # TODO re-enable once #393 is merged
+            #  ws_dir = join(tempdir, 'non-existing-for-good-measure')
+            ws_dir = tempdir
+            # Create a relative path to trigger #319
+            src_path = str(Path(assets.path_to('kant_aufklaerung_1784/data/mets.xml')).relative_to(Path.cwd()))
+            self.resolver.workspace_from_url(src_path, dst_dir=ws_dir, download=True)
+            #  from os import system
+            #  system('find %s' % ws_dir)
+            self.assertTrue(Path(ws_dir, 'mets.xml').exists())  # sanity check, mets.xml must exist
+            self.assertTrue(Path(ws_dir, 'OCR-D-GT-PAGE/PAGE_0017_PAGE.xml').exists())
+
     def test_227_1(self):
         def find_recursive(root):
             ret = []


### PR DESCRIPTION
This should fix #319.

Note that this simply concatenates `Path.cwd()` and `mets_url` if the latter is a relative filename. It does not do `Path.resolve` since that would resolve symlinks, i.e. if `mets.xml` was pointing somewhere else, this might break the contract on all files being relative to the `mets.xml`. I'm happy to change this if you think this is too cautious.