### PR TITLE
Parse empty string  as json object

### DIFF
--- a/ocrd/bashlib/src/parse_argv.bash
+++ b/ocrd/bashlib/src/parse_argv.bash
@@ -57,7 +57,7 @@ ocrd__parse_argv () {
 
 
     local params_parsed retval
-    params_parsed="$(ocrd ocrd-tool "$OCRD_TOOL_JSON" tool $OCRD_TOOL_NAME parse-params -p "${ocrd__argv[parameter]}")"
+    params_parsed="$(ocrd ocrd-tool "$OCRD_TOOL_JSON" tool $OCRD_TOOL_NAME parse-params -p "${ocrd__argv[parameter]:-{}}")"
     retval=$?
     if [[ $retval != 0 ]];then
         echo "Error: Failed to parse parameters (retval $retval):"

--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -111,7 +111,7 @@ ocrd__parse_argv () {
 
 
     local params_parsed retval
-    params_parsed="$(ocrd ocrd-tool "$OCRD_TOOL_JSON" tool $OCRD_TOOL_NAME parse-params -p "${ocrd__argv[parameter]}")"
+    params_parsed="$(ocrd ocrd-tool "$OCRD_TOOL_JSON" tool $OCRD_TOOL_NAME parse-params -p "${ocrd__argv[parameter]:-{}}")"
     retval=$?
     if [[ $retval != 0 ]];then
         echo "Error: Failed to parse parameters (retval $retval):"

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -787,9 +787,13 @@ def xywh_from_points(points):
 def parse_json_string_or_file(value='{}'):    # pylint: disable=unused-argument
     """
     Parse a string as either the path to a JSON object or a literal JSON object.
+
+    Empty strings are equivalent to '{}'
     """
     ret = None
     err = None
+    if re.fullmatch(r"\s*", value):
+        return {}
     try:
         try:
             with open(value, 'r') as f:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -181,6 +181,8 @@ class TestUtils(TestCase):
 
     def test_parse_json_string_or_file(self):
         self.assertEqual(parse_json_string_or_file(), {})
+        self.assertEqual(parse_json_string_or_file(''), {})
+        self.assertEqual(parse_json_string_or_file(' '), {})
         self.assertEqual(parse_json_string_or_file('{}'), {})
         self.assertEqual(parse_json_string_or_file('{"foo": 32}'), {'foo': 32})
 


### PR DESCRIPTION
Currently

```python
self.assertEqual(parse_json_string_or_file(), {})  # true
# but
self.assertEqual(parse_json_string_or_file(''), {}) # error
```

This makes empty strings equivalent to `None` which is already equivalent to an empty object. Which makes sense in this context I think.

Also fixes the bashlib to default `${ocrd__argv[parameter]}` to be `"{}"` as [proposed by @bertsky](https://github.com/OCR-D/core/issues/381)