### PR TITLE
customized --help for processors

### DIFF
--- a/ocrd/bashlib/src/usage.bash
+++ b/ocrd/bashlib/src/usage.bash
@@ -3,24 +3,9 @@
 ## Print usage
 ## 
 ocrd__usage () {
-    echo "
-Usage: $OCRD_TOOL_NAME [OPTIONS]
 
-`ocrd ocrd-tool "$OCRD_TOOL_JSON" tool "$OCRD_TOOL_NAME" description`
+    ocrd ocrd-tool "$OCRD_TOOL_JSON" tool "$OCRD_TOOL_NAME" help
 
-Options:
--l, --log-level [OFF|ERROR|WARN|INFO|DEBUG|TRACE]
-                                Log level
--J, --dump-json                 Dump tool description as JSON and exit
--p, --parameter PATH
--g, --page-id TEXT              ID(s) of the physical page
--O, --output-file-grp TEXT      File group(s) used as output.
--I, --input-file-grp TEXT       File group(s) used as input.
--w, --working-dir TEXT          Working Directory
--m, --mets TEXT                 METS URL to validate  [required]
---help                          Show this message and exit.
--V, --version                   Show version.
-    "
 }
 
 

--- a/ocrd/ocrd/cli/ocrd_tool.py
+++ b/ocrd/ocrd/cli/ocrd_tool.py
@@ -5,10 +5,11 @@ import sys
 import click
 
 from ocrd.decorators import parameter_option
+from ocrd.processor import generate_processor_help
 from ocrd_utils import VERSION as OCRD_VERSION
 from ocrd_validators import ParameterValidator, OcrdToolValidator
 
-class OcrdToolCtx(object):
+class OcrdToolCtx():
 
     def __init__(self, filename):
         self.filename = filename
@@ -79,6 +80,11 @@ def ocrd_tool_tool(ctx, tool_name):
 @pass_ocrd_tool
 def ocrd_tool_tool_description(ctx):
     print(ctx.json['tools'][ctx.tool_name]['description'])
+
+@ocrd_tool_tool.command('help', help="Generate help for processors")
+@pass_ocrd_tool
+def ocrd_tool_tool_params_help(ctx):
+    print(generate_processor_help(ctx.json['tools'][ctx.tool_name]))
 
 # ----------------------------------------------------------------------
 # ocrd ocrd-tool tool categories

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -1,5 +1,3 @@
-import json
-import os
 from os.path import isfile
 
 import click
@@ -30,14 +28,16 @@ parameter_option = click.option('-p', '--parameter',
                                 default='{}',
                                 callback=lambda ctx, param, value: parse_json_string_or_file(value))
 
-def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_dir=None, dump_json=False, version=False, **kwargs):
+def ocrd_cli_wrap_processor(processorClass, ocrd_tool=None, mets=None, working_dir=None, dump_json=False, help=False, version=False, **kwargs):
     LOG = getLogger('ocrd_cli_wrap_processor')
     if dump_json:
         processorClass(workspace=None, dump_json=True)
+    elif help:
+        processorClass(workspace=None, show_help=True)
     elif version:
         try:
             p = processorClass(workspace=None)
-        except e:
+        except: # pylint: disable=bare-except
             pass
         print("Version %s, ocrd/core %s" % (p.version, OCRD_VERSION))
     elif mets is None:
@@ -82,7 +82,8 @@ def ocrd_cli_options(f):
         parameter_option,
         click.option('-J', '--dump-json', help="Dump tool description as JSON and exit", is_flag=True, default=False),
         loglevel_option,
-        click.option('-V', '--version', help="Show version", is_flag=True, default=False)
+        click.option('-V', '--version', help="Show version", is_flag=True, default=False),
+        click.option('-h', '--help', help="This help message", is_flag=True, default=False),
     ]
     for param in params:
         param(f)

--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -30,24 +30,9 @@ ocrd__dumpjson () {
 ## Print usage
 ## 
 ocrd__usage () {
-    echo "
-Usage: $OCRD_TOOL_NAME [OPTIONS]
 
-`ocrd ocrd-tool "$OCRD_TOOL_JSON" tool "$OCRD_TOOL_NAME" description`
+    ocrd ocrd-tool "$OCRD_TOOL_JSON" tool "$OCRD_TOOL_NAME" help
 
-Options:
--l, --log-level [OFF|ERROR|WARN|INFO|DEBUG|TRACE]
-                                Log level
--J, --dump-json                 Dump tool description as JSON and exit
--p, --parameter PATH
--g, --page-id TEXT              ID(s) of the physical page
--O, --output-file-grp TEXT      File group(s) used as output.
--I, --input-file-grp TEXT       File group(s) used as input.
--w, --working-dir TEXT          Working Directory
--m, --mets TEXT                 METS URL to validate  [required]
---help                          Show this message and exit.
--V, --version                   Show version.
-    "
 }
 
 # END-INCLUDE 

--- a/ocrd/ocrd/processor/__init__.py
+++ b/ocrd/ocrd/processor/__init__.py
@@ -1,0 +1,6 @@
+from .base import (
+    Processor,
+    run_cli,
+    run_processor,
+    generate_processor_help
+)

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -180,7 +180,7 @@ Options:
 
     def verify(self):
         """
-        Verify that the input is fulfills the processor's requirements.
+        Verify that the input fulfills the processor's requirements.
         """
         return True
 

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -146,12 +146,13 @@ class Processor(object):
             parameter_help = '  NONE\n'
         else:
             for param_name, param in self.ocrd_tool['parameters'].items():
-                parameter_help += '  "%s" [%s%s]%s\n' % (
+                parameter_help += wrap_text('  "%s" [%s%s] %s' % (
                     param_name,
                     param['type'],
-                    ' - REQUIRED' if param.required else '',
+                    ' - REQUIRED' if 'required' in param and param['required'] else '',
                     param['description']
-                )
+                ), subsequent_indent='    ', width=72, preserve_paragraphs=True)
+                parameter_help += "\n"
         print('''
 Usage: %s [OPTIONS]
 

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -1,5 +1,6 @@
 import os
 import json
+from click import wrap_text
 import subprocess
 from ocrd_utils import getLogger
 from ocrd_validators import ParameterValidator
@@ -145,7 +146,12 @@ class Processor(object):
             parameter_help = '  NONE\n'
         else:
             for param_name, param in self.ocrd_tool['parameters'].items():
-                parameter_help += '  "%s" [%s] %s\n' % (param_name, param['type'], param['description'])
+                parameter_help += '  "%s" [%s%s]%s\n' % (
+                    param_name,
+                    param['type'],
+                    ' - REQUIRED' if param.required else '',
+                    param['description']
+                )
         print('''
 Usage: %s [OPTIONS]
 

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -96,6 +96,52 @@ def run_cli(
     log.debug("Running subprocess '%s'", ' '.join(args))
     return subprocess.call(args)
 
+def generate_processor_help(ocrd_tool):
+    parameter_help = ''
+    if 'parameters' not in ocrd_tool or not ocrd_tool['parameters']:
+        parameter_help = '  NONE\n'
+    else:
+        for param_name, param in ocrd_tool['parameters'].items():
+            parameter_help += wrap_text('  "%s" [%s%s] %s' % (
+                param_name,
+                param['type'],
+                ' - REQUIRED' if 'required' in param and param['required'] else '',
+                param['description']
+            ), subsequent_indent='    ', width=72, preserve_paragraphs=True)
+            parameter_help += "\n"
+    return '''
+Usage: %s [OPTIONS]
+
+  %s
+
+Parameters:
+%s
+Default Wiring:
+  %s -> %s
+
+Options:
+  -V, --version                   Show version
+  -l, --log-level [OFF|ERROR|WARN|INFO|DEBUG|TRACE]
+                                  Log level
+  -J, --dump-json                 Dump tool description as JSON and exit
+  -p, --parameter TEXT            Parameters, either JSON string or path 
+                                  JSON file
+  -g, --page-id TEXT              ID(s) of the pages to process
+  -O, --output-file-grp TEXT      File group(s) used as output.
+  -I, --input-file-grp TEXT       File group(s) used as input.
+  -w, --working-dir TEXT          Working Directory
+  -m, --mets TEXT                 METS to process
+  -h, --help                      This help message
+
+''' % (
+    ocrd_tool['executable'],
+    ocrd_tool['description'],
+    parameter_help,
+    ocrd_tool['input_file_grp'],
+    ocrd_tool.get('output_file_grp', 'NONE')
+)
+
+
 class Processor(object):
     """
     A processor runs an algorithm based on the workspace, the mets.xml in the
@@ -141,49 +187,7 @@ class Processor(object):
         self.parameter = parameter
 
     def show_help(self):
-        parameter_help = ''
-        if 'parameters' not in self.ocrd_tool or not self.ocrd_tool['parameters']:
-            parameter_help = '  NONE\n'
-        else:
-            for param_name, param in self.ocrd_tool['parameters'].items():
-                parameter_help += wrap_text('  "%s" [%s%s] %s' % (
-                    param_name,
-                    param['type'],
-                    ' - REQUIRED' if 'required' in param and param['required'] else '',
-                    param['description']
-                ), subsequent_indent='    ', width=72, preserve_paragraphs=True)
-                parameter_help += "\n"
-        print('''
-Usage: %s [OPTIONS]
-
-  %s
-
-Parameters:
-%s
-Default Wiring:
-  %s -> %s
-
-Options:
-  -V, --version                   Show version
-  -l, --log-level [OFF|ERROR|WARN|INFO|DEBUG|TRACE]
-                                  Log level
-  -J, --dump-json                 Dump tool description as JSON and exit
-  -p, --parameter TEXT            Parameters, either JSON string or path 
-                                  JSON file
-  -g, --page-id TEXT              ID(s) of the pages to process
-  -O, --output-file-grp TEXT      File group(s) used as output.
-  -I, --input-file-grp TEXT       File group(s) used as input.
-  -w, --working-dir TEXT          Working Directory
-  -m, --mets TEXT                 METS to process
-  -h, --help                      This help message
-
-''' % (
-    self.ocrd_tool['executable'],
-    self.ocrd_tool['description'],
-    parameter_help,
-    self.ocrd_tool['input_file_grp'],
-    self.ocrd_tool.get('output_file_grp', 'NONE')
-))
+        print(generate_processor_help(self.ocrd_tool))
 
     def verify(self):
         """

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -175,7 +175,7 @@ Options:
     self.ocrd_tool['description'],
     parameter_help,
     self.ocrd_tool['input_file_grp'],
-    self.ocrd_tool['output_file_grp'],
+    self.ocrd_tool.get('output_file_grp', 'NONE')
 ))
 
     def verify(self):


### PR DESCRIPTION
Before:

```
$ ocrd-tesserocr-recognize -h
Usage: ocrd-tesserocr-recognize [OPTIONS]
Try "ocrd-tesserocr-recognize --help" for help.

Error: no such option: -h

$ ocrd-tesserocr-recognize --help
Usage: ocrd-tesserocr-recognize [OPTIONS]

Options:
  -V, --version                   Show version
  -l, --log-level [OFF|ERROR|WARN|INFO|DEBUG|TRACE]
                                  Log level
  -J, --dump-json                 Dump tool description as JSON and exit
  -p, --parameter TEXT            Parameters, either JSON string or path to
                                  JSON file
  -g, --page-id TEXT              ID(s) of the pages to process
  -O, --output-file-grp TEXT      File group(s) used as output.
  -I, --input-file-grp TEXT       File group(s) used as input.
  -w, --working-dir TEXT          Working Directory
  -m, --mets TEXT                 METS to process
  --help                          Show this message and exit.
```

With this PR:

```
ocrd-tesserocr-recognize -h

Usage: ocrd-tesserocr-recognize [OPTIONS]

  Recognize text in lines with tesseract

Parameters:
  "textequiv_level" [string] PAGE XML hierarchy level to add the TextEquiv results to (requires existing layout annotation up to one level above that)
  "overwrite_words" [boolean] remove existing layout and text annotation below the TextLine level (regardless of textequiv_level)
  "model" [string] tessdata model to apply (an ISO 639-3 language specification or some other basename, e.g. deu-frak or Fraktur)

Default Wiring:
  ['OCR-D-SEG-BLOCK', 'OCR-D-SEG-LINE', 'OCR-D-SEG-WORD', 'OCR-D-SEG-GLYPH'] -> ['OCR-D-OCR-TESS']

Options:
  -V, --version                   Show version
  -l, --log-level [OFF|ERROR|WARN|INFO|DEBUG|TRACE]
                                  Log level
  -J, --dump-json                 Dump tool description as JSON and exit
  -p, --parameter TEXT            Parameters, either JSON string or path
                                  JSON file
  -g, --page-id TEXT              ID(s) of the pages to process
  -O, --output-file-grp TEXT      File group(s) used as output.
  -I, --input-file-grp TEXT       File group(s) used as input.
  -w, --working-dir TEXT          Working Directory
  -m, --mets TEXT                 METS to process
  -h, --help                      This help message
```