### PR TITLE
improve workspace.remove_file/remove_group, #245

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 Changed:
 
   * layout of --help, #411
+  * OcrdMets: Removing the last file for a physical page will remove the physical page
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Fixed:
 
   * typos, #414
 
+Added:
+
+  * OcrdMets.remove_physical_page to remove `structMap[@TYPE="physical"]` entries
+
 ## [2.2.2] - 2020-01-16
 
 Added:

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -198,16 +198,17 @@ def workspace_find(ctx, file_grp, mimetype, page_id, file_id, output_field, down
 # ----------------------------------------------------------------------
 
 @workspace_cli.command('remove')
-@click.option('--force', help="Also delete file in storage if applicable", default=False, is_flag=True)
+@click.option('-k', '--keep-file', help="Do not delete file from file system", default=False, is_flag=True)
+@click.option('-f', '--force', help="Continue even if mets:file or file on file system does not exist", default=False, is_flag=True)
 @click.argument('ID', nargs=-1)
 @pass_workspace
-def workspace_remove_file(ctx, id, force):  # pylint: disable=redefined-builtin
+def workspace_remove_file(ctx, id, force, keep_file):  # pylint: disable=redefined-builtin
     """
     Delete file by ID from mets.xml
     """
     workspace = Workspace(ctx.resolver, directory=ctx.directory, mets_basename=ctx.mets_basename, automatic_backup=ctx.automatic_backup)
     for i in id:
-        workspace.remove_file(i, force=force)
+        workspace.remove_file(i, force=force, keep_file=keep_file)
     workspace.save_mets()
 
 
@@ -221,13 +222,14 @@ def workspace_remove_file(ctx, id, force):  # pylint: disable=redefined-builtin
 
 """)
 @click.option('-r', '--recursive', help="Delete any files in the group before the group itself", default=False, is_flag=True)
-@click.option('-f', '--force', help="Also delete local files", default=False, is_flag=True)
+@click.option('-f', '--force', help="Continue removing even if group or containing files not found in METS", default=False, is_flag=True)
+@click.option('-k', '--keep-files', help="Do not delete files from file system", default=False, is_flag=True)
 @click.argument('GROUP', nargs=-1)
 @pass_workspace
-def remove_group(ctx, group, recursive, force):
+def remove_group(ctx, group, recursive, force, keep_files):
     workspace = Workspace(ctx.resolver, directory=ctx.directory, mets_basename=ctx.mets_basename)
     for g in group:
-        workspace.remove_file_group(g, recursive, force)
+        workspace.remove_file_group(g, recursive=recursive, force=force, keep_files=keep_files)
     workspace.save_mets()
 
 # ----------------------------------------------------------------------

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -1,5 +1,5 @@
 import io
-from os import makedirs, unlink
+from os import makedirs, unlink, listdir
 from pathlib import Path
 
 import cv2
@@ -159,7 +159,11 @@ class Workspace():
                 self.remove_file(f.ID, force=force, keep_file=keep_files)
         if USE in self.mets.file_groups:
             self.mets.remove_file_group(USE)
-        # TODO remove empty dirs
+        # XXX this only removes directories in the workspace if they are empty
+        # and named after the fileGrp which is a convention in OCR-D.
+        with pushd_popd(self.directory):
+            if Path(USE).is_dir() and not listdir(USE):
+                Path(USE).rmdir()
 
     def add_file(self, file_grp, content=None, **kwargs):
         """

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -116,43 +116,50 @@ class Workspace():
             f.local_filename = f.url
             return f
 
-    def remove_file(self, ID, force=False):
+    def remove_file(self, ID, force=False, keep_file=False):
         """
         Remove a file from the workspace.
 
         Arguments:
             ID (string|OcrdFile): ID of the file to delete or the file itself
-            force (boolean): Whether to delete from disk as well
+            force (boolean): Continue removing even if file not found in METS
+            keep_file (boolean): Whether to keep files on disk
         """
         log.debug('Deleting mets:file %s', ID)
-        ocrd_file = self.mets.remove_file(ID)
-        if force:
-            if not ocrd_file:
-                raise Exception("File '%s' not found" % ID)
-            if not ocrd_file.local_filename:
-                raise Exception("File not locally available %s" % ocrd_file)
-            with pushd_popd(self.directory):
-                log.info("rm %s [cwd=%s]", ocrd_file.local_filename, self.directory)
-                unlink(ocrd_file.local_filename)
-        return ocrd_file
+        try:
+            ocrd_file = self.mets.remove_file(ID)
+            if not keep_file:
+                if not ocrd_file.local_filename:
+                    log.warning("File not locally available %s", ocrd_file)
+                    if not force:
+                        raise Exception("File not locally available %s" % ocrd_file)
+                else:
+                    with pushd_popd(self.directory):
+                        log.info("rm %s [cwd=%s]", ocrd_file.local_filename, self.directory)
+                        unlink(ocrd_file.local_filename)
+            return ocrd_file
+        except FileNotFoundError as e:
+            if not force:
+                raise e
 
-    def remove_file_group(self, USE, recursive=False, force=False):
+    def remove_file_group(self, USE, recursive=False, force=False, keep_files=False):
         """
         Remove a fileGrp.
 
         Arguments:
             USE (string): USE attribute of the fileGrp to delete
             recursive (boolean): Whether to recursively delete all files in the group
-            force (boolean): When deleting recursively whether to delete files from HDD
+            force (boolean): Continue removing even if group or containing files not found in METS
+            keep_files (boolean): When deleting recursively whether to keep files on disk
         """
-        if force and not recursive:
-            raise Exception("remove_file_group: force without recursive is likely a logic error")
-        if USE not in self.mets.file_groups:
+        if USE not in self.mets.file_groups and not force:
             raise Exception("No such fileGrp: %s" % USE)
         if recursive:
             for f in self.mets.find_files(fileGrp=USE):
-                self.remove_file(f.ID, force=force)
-        self.mets.remove_file_group(USE)
+                self.remove_file(f.ID, force=force, keep_file=keep_files)
+        if USE in self.mets.file_groups:
+            self.mets.remove_file_group(USE)
+        # TODO remove empty dirs
 
     def add_file(self, file_grp, content=None, **kwargs):
         """

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -245,7 +245,7 @@ class OcrdMets(OcrdXmlDocument):
         log.info("remove_file(%s)" % ID)
         ocrd_file = self.find_files(ID)
         if not ocrd_file:
-            raise Exception("File not found: %s" % ID)
+            raise FileNotFoundError("File not found: %s" % ID)
         ocrd_file = ocrd_file[0]
 
         # Delete the physical page ref

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -253,10 +253,10 @@ class OcrdMets(OcrdXmlDocument):
             log.info("Delete fptr element %s for page '%s'", fptr, ID)
             page_div = fptr.getparent()
             page_div.remove(fptr)
-            # TODO delete empty pages
-            #  if not page_div.getchildren():
-            #      log.info("Delete empty page %s", page_div)
-            #      page_div.getparent().remove(page_div)
+            # delete empty pages
+            if not page_div.getchildren():
+                log.info("Delete empty page %s", page_div)
+                page_div.getparent().remove(page_div)
 
         # Delete the file reference
         # pylint: disable=protected-access

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -317,3 +317,10 @@ class OcrdMets(OcrdXmlDocument):
             ocrd_file.ID, namespaces=NS)
         if ret:
             return ret[0]
+
+    def remove_physical_page(self, ID):
+        mets_div = self._tree.getroot().xpath(
+            'mets:structMap[@TYPE="PHYSICAL"]/mets:div[@TYPE="physSequence"]/mets:div[@TYPE="page"][@ID="%s"]' % ID,
+            namespaces=NS)
+        if mets_div:
+            mets_div[0].getparent().remove(mets_div[0])

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -153,6 +153,12 @@ class TestOcrdMets(TestCase):
         """)
         self.assertIn('Őh śéé Áŕ', mets.to_xml().decode('utf-8'))
 
+    def test_remove_page(self):
+        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
+            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
+            self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002', 'PHYS_0005'])
+            mets.remove_physical_page('PHYS_0001')
+            self.assertEqual(mets.physical_pages, ['PHYS_0002', 'PHYS_0005'])
 
     def test_remove_file_group(self):
         """

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -160,6 +160,13 @@ class TestOcrdMets(TestCase):
             mets.remove_physical_page('PHYS_0001')
             self.assertEqual(mets.physical_pages, ['PHYS_0002', 'PHYS_0005'])
 
+    def test_remove_page_after_remove_file(self):
+        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
+            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
+            self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002', 'PHYS_0005'])
+            mets.remove_file('FILE_0005_IMAGE')
+            self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002'])
+
     def test_remove_file_group(self):
         """
         Test removal of filegrp

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -136,17 +136,33 @@ class TestWorkspace(TestCase):
             self.assertEqual(len(find_recursive(wsdir)), 2)
             self.assertTrue(exists(join(wsdir, 'OCR-D-IMG/FILE_0005_IMAGE.tif')))
 
-    #  def test_remove(self):
-    #      with TemporaryDirectory() as tempdir:
-    #          dst_dir =
-    #          ws1 = self.resolver.workspace_from_url(SRC_METS, dst_dir=dst_dir)
-    #          res = ws1.download_url(SAMPLE_FILE_URL)
-    #          print('>>>>>> %s' % res)
-    #          ocrd_file = ws1.remove_file(SAMPLE_FILE_ID)
-    #          print(ocrd_file)
-    #          import os
-    #          self.assertTrue(exists(join(ws1.directory, ocrd_file.local_filename)))
-    #          #  with copy_of_directory(FOLDER_KANT) as tempdir:
+    def test_remove_file_force(self):
+        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
+            workspace = Workspace(self.resolver, directory=tempdir)
+            with self.assertRaisesRegex(FileNotFoundError, "not found"):
+                # should fail
+                workspace.remove_file('non-existing-id')
+            # should succeed
+            workspace.remove_file('non-existing-id', force=True)
+
+    def test_remove_file_remote(self):
+        with TemporaryDirectory() as tempdir:
+            ws = self.resolver.workspace_from_nothing(directory=tempdir)
+            ws.add_file('IMG', ID='page1_img', mimetype='image/tiff', url='http://remote')
+            with self.assertRaisesRegex(Exception, "not locally available"):
+                # should fail
+                ws.remove_file('page1_img')
+            # should succeed
+            ws.remove_file('page1_img', force=True)
+
+    def test_remove_file_group_force(self):
+        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
+            workspace = Workspace(self.resolver, directory=tempdir)
+            with self.assertRaisesRegex(Exception, "No such fileGrp"):
+                # raise error unless force
+                workspace.remove_file_group('I DO NOT EXIST')
+            # no error
+            workspace.remove_file_group('I DO NOT EXIST', force=True)
 
     def test_download_to_directory_from_workspace_download_file(self):
         """

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -164,6 +164,13 @@ class TestWorkspace(TestCase):
             # no error
             workspace.remove_file_group('I DO NOT EXIST', force=True)
 
+    def test_remove_file_group_rmdir(self):
+        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
+            workspace = Workspace(self.resolver, directory=tempdir)
+            self.assertTrue(exists(join(tempdir, 'OCR-D-IMG')))
+            workspace.remove_file_group('OCR-D-IMG', recursive=True)
+            self.assertFalse(exists(join(tempdir, 'OCR-D-IMG')))
+
     def test_download_to_directory_from_workspace_download_file(self):
         """
         https://github.com/OCR-D/core/issues/342


### PR DESCRIPTION
This changes the semantics of the kwargs/CLI params:

## remove

* `--keep-file`: Whether to keep local file on disk. Defaults to `false`, so files on disk are deleted by default
* `--force`: Do not abort if the file is not found in METS or on disk

## remove-group

* `--recursive`: also delete containing files. Required for non-empty group
* `--keep-files`: Passed as `--keep-file` to `remove`
* `--force`: Continue removing even if group or containing mets:files not found in METS or any files not found on HDD



```sh
# Remove a fileGrp, no matter what:
ocrd workspace remove-group -rf DEFAULT
# Remove mets:file and local file
ocrd workspace remove -f page1_img
# Remove mets:file but keep local file (but don't fail if page1_img doesn't exist in METS)
ocrd wworkspace remove -f -k page1_img
```

This is not yet finished but I'd appreciate feedback whether this is the right direction, esp. @bertsky @mikegerber E.g. do you want a `--recursive` option (as it is now) or a `--non-recursive` option so the default is to remove recursively (empty fileGrp are unlikely).

TODO:
* [x] remove empty dirs after remove-group
* [x] remove empty page entries in the structMap after remove
