### PR TITLE
bashlib: escape } in default (regression from 2d89c22ae3)

### DIFF
--- a/ocrd/bashlib/src/parse_argv.bash
+++ b/ocrd/bashlib/src/parse_argv.bash
@@ -57,7 +57,7 @@ ocrd__parse_argv () {
 
 
     local params_parsed retval
-    params_parsed="$(ocrd ocrd-tool "$OCRD_TOOL_JSON" tool $OCRD_TOOL_NAME parse-params -p "${ocrd__argv[parameter]:-{}}")"
+    params_parsed="$(ocrd ocrd-tool "$OCRD_TOOL_JSON" tool $OCRD_TOOL_NAME parse-params -p "${ocrd__argv[parameter]:-{\}}")"
     retval=$?
     if [[ $retval != 0 ]];then
         echo "Error: Failed to parse parameters (retval $retval):"


### PR DESCRIPTION
I did not see it myself in the review for #400, the bash code looked unsuspicious. But it appears bash is sensitive to closing braces when doing parameter expansion.

Without the fix you will get errors like this from current master:

```bash
ocrd-im6convert -I ORIGINAL -O OCR-D-IMG-PNG -p OCR-D-IMG-PNG.json
  File "decorators.py", line 30, in <lambda>
    callback=lambda ctx, param, value: parse_json_string_or_file(value))
  File "ocrd_utils/__init__.py", line 808, in parse_json_string_or_file
    raise err       # pylint: disable=raising-bad-type
ValueError: Error parsing 'OCR-D-IMG-PNG.json}': Expecting value: line 1 column 1 (char 0)
Makefile:301: recipe for target 'OCR-D-IMG-PNG' failed
```

Maybe we should have some pseudo-processor test in `ocrd/bashlib/test` (beside the arg-parsing test).