### PR TITLE
Improve coordinate validator

### DIFF
--- a/ocrd_validators/ocrd_validators/page_validator.py
+++ b/ocrd_validators/ocrd_validators/page_validator.py
@@ -196,9 +196,10 @@ def validate_consistency(node, page_textequiv_consistency, page_textequiv_strate
                     or child_poly.bounds[0] < 0
                     or child_poly.bounds[1] < 0
                     or child_poly.length < 4):
-                    report.add_error(CoordinateValidityError(child_tag, child.id, file_id, child_points))
-                    log.debug("Invalid coords of %s %s", child_tag, child.id)
-                    consistent = False
+                    # report.add_error(CoordinateValidityError(child_tag, child.id, file_id, child_points))
+                    # log.debug("Invalid coords of %s %s", child_tag, child.id)
+                    # consistent = False
+                    pass # already reported in recursive call above
                 elif not child_poly.within(node_poly):
                     # TODO: automatic repair?
                     report.add_error(CoordinateConsistencyError(tag, child.id, file_id,


### PR DESCRIPTION
By request of @tboenig, this slightly improves useability of the coordinate checks.

Example output (scroll right to see the change):
```
  <error>INVALIDITY in Word ID 'w46' of 'weigel_gnothi02_1618/page/weigel_gnothi02_1618_0003.xml': coords '1270,526 1270,527 1271,527 1271,529 1272,529 1272,531 1273,531 1273,544 1283,544 1283,545 1284,545 1283,545 1283,560 1282,560 1282,561 1281,561 1281,562 1280,562 1280,563 1279,563 1279,564 1265,564 1265,565 1221,565 1221,566 1196,566 1196,541 1197,541 1197,540 1239,540 1239,532 1240,532 1240,530 1241,530 1241,529 1242,529 1242,527 1256,527 1257,526' - Self-intersection[1283 545]</error>
```