### PR TITLE
workspace validation: clarify why _validate_dimension requires --download

### DIFF
--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -166,8 +166,8 @@ class WorkspaceValidator():
         Validate image height and PAGE imageHeight match
         """
         for f in self.mets.find_files(mimetype=MIMETYPE_PAGE):
-            if not f.local_filename and not self.download:
-                self.report.add_notice("Won't download remote PAGE XML <%s>" % f.url)
+            if not self.download:
+                self.report.add_notice("_validate_dimension: Not executed because --download wasn't set and PAGE might reference remote (Alternatve)Images <%s>" % f.url)
                 continue
             page = page_from_file(f).get_Page()
             _, _, exif = self.workspace.image_from_page(page, f.pageId)

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -168,11 +168,15 @@ class TestWorkspaceValidator(TestCase):
             copytree(assets.path_to('kant_aufklaerung_1784/data'), wsdir)
             with pushd_popd(wsdir):
                 os.system("""sed -i 's,imageHeight="2083",imageHeight="1234",' OCR-D-GT-PAGE/PAGE_0017_PAGE.xml""")
-                report = WorkspaceValidator.validate(self.resolver, join(wsdir, 'mets.xml'), src_dir=wsdir, skip=[
-                    'page', 'mets_unique_identifier', 'mets_file_group_names', 'mets_files', 'pixel_density', 'imagefilename'
-                    ], download=False)
+                report = WorkspaceValidator.validate(
+                    self.resolver,
+                    join(wsdir, 'mets.xml'),
+                    src_dir=wsdir,
+                    skip=['page', 'mets_unique_identifier', 'mets_file_group_names', 'mets_files', 'pixel_density', 'imagefilename'],
+                    download=True
+                )
                 self.assertIn("PAGE 'PAGE_0017_PAGE': @imageHeight != image's actual height (1234 != 2083)", report.errors)
-                print(report.errors)
+                #  print(report.errors)
                 self.assertEqual(len(report.errors), 1)
                 self.assertEqual(report.is_valid, False)
                 report2 = WorkspaceValidator.validate(self.resolver, join(wsdir, 'mets.xml'), src_dir=wsdir, skip=[


### PR DESCRIPTION
Debugging #324 I understand now that the `TEMP/*` files are being created for the AlternativeImages in PAGE. Even if the PAGE is available locally, the images might not be. Even without `--download`, these images were loaded.

Instead of further complicating the logic for image resolving, this PR requires `--download` for the `_validate_dimensions` check. This is too strict for PAGE files with only local image references or w/o any image references.