### PR TITLE
Clobber mets download to directory

### DIFF
--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -151,7 +151,7 @@ class Resolver():
         log.debug("workspace_from_url\nmets_basename='%s'\nmets_url='%s'\nsrc_baseurl='%s'\ndst_dir='%s'",
             mets_basename, mets_url, src_baseurl, dst_dir)
 
-        self.download_to_directory(dst_dir, mets_url, basename=mets_basename, if_exists='overwrite' if clobber_mets else 'raise')
+        self.download_to_directory(dst_dir, mets_url, basename=mets_basename, if_exists='overwrite' if clobber_mets else 'skip')
 
         workspace = Workspace(self, dst_dir, mets_basename=mets_basename, baseurl=src_baseurl)
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -39,12 +39,13 @@ class TestResolver(TestCase):
 
     def test_workspace_from_url_no_clobber(self):
         with TemporaryDirectory() as dst_dir:
+            src_mets = Path(assets.path_to('kant_aufklaerung_1784-binarized/data/mets.xml'))
             dst_mets = Path(dst_dir, 'mets.xml')
-            dst_mets.write_text('CONTENT')
-            with self.assertRaisesRegex(FileExistsError, "File already exists and if_exists == 'raise': %s" % dst_mets):
-                self.resolver.workspace_from_url(
-                        'https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xml',
-                        dst_dir=dst_dir)
+            dst_mets.write_text(src_mets.read_text())
+            self.resolver.workspace_from_url(
+                    'https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xml',
+                    clobber_mets=False,
+                    dst_dir=dst_dir)
 
     def test_workspace_from_url_404(self):
         with self.assertRaisesRegex(Exception, "HTTP request failed"):


### PR DESCRIPTION
This changes the behavior: if `clobber_mets` is `False` and METS is to be downloaded but already exists in the destination: **skip downloading** instead of **rasing an exception**.

Translating between `clobber_mets` and `if_exists` is not a good solution. The former should be replaced with the latter.