### PR TITLE
--help: show 'enum' values for parameters that define them, fix #426

### DIFF
--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -102,12 +102,13 @@ def generate_processor_help(ocrd_tool):
         parameter_help = '  NONE\n'
     else:
         for param_name, param in ocrd_tool['parameters'].items():
-            parameter_help += wrap_text('  "%s" [%s%s] %s' % (
+            parameter_help += wrap_text('  "%s" [%s%s] %s%s' % (
                 param_name,
                 param['type'],
                 ' - REQUIRED' if 'required' in param and param['required'] else
                 ' - %s' % param['default'] if 'default' in param else '',
-                param['description']
+                param['description'],
+                ' Possible values: %s' % json.dumps(param['enum']) if 'enum' in param else ''
             ), subsequent_indent='    ', width=72, preserve_paragraphs=True)
             parameter_help += "\n"
     return '''


### PR DESCRIPTION
e.g. for ocrd-olena-binarize:

```
Parameters:
  "impl" [string - REQUIRED] The name of the actual binarization
      algorithm
  "win-size" [number - 101] Window size
  "k" [number - 0.34] Sauvola's formulae parameter
```
becomes
```
Parameters:
  "impl" [string - REQUIRED] The name of the actual binarization
      algorithm Possible values: ["otsu", "singh", "niblack", "wolf",
      "kim", "sauvola-ms-split", "sauvola-ms-fg", "sauvola-ms",
      "sauvola"]
  "win-size" [number - 101] Window size
  "k" [number - 0.34] Sauvola's formulae parameter
```