### PR TITLE
Map between PIL and media type

### DIFF
--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -26,6 +26,7 @@ from ocrd_utils import (
     xywh_from_bbox,
     pushd_popd,
     MIME_TO_EXT,
+    MIME_TO_PIL,
 )
 
 from .workspace_backup import WorkspaceBackupManager
@@ -779,7 +780,7 @@ class Workspace():
                         file_id,
                         file_grp,
                         page_id=None,
-                        format='PNG',
+                        mimetype='image/png',
                         force=True):
         """Store and reference an image as file into the workspace.
 
@@ -791,14 +792,14 @@ class Workspace():
         Return the (absolute) path of the created file.
         """
         image_bytes = io.BytesIO()
-        image.save(image_bytes, format=format)
-        file_path = str(Path(file_grp, '%s.%s' % (file_id, format.lower())))
+        image.save(image_bytes, format=MIME_TO_PIL[mimetype])
+        file_path = str(Path(file_grp, '%s%s' % (file_id, MIME_TO_EXT[mimetype])))
         out = self.add_file(
             ID=file_id,
             file_grp=file_grp,
             pageId=page_id,
             local_filename=file_path,
-            mimetype='image/' + format.lower(),
+            mimetype=mimetype,
             content=image_bytes.getvalue(),
             force=force)
         log.info('created file ID: %s, file_grp: %s, path: %s',

--- a/ocrd_utils/ocrd_utils/constants.py
+++ b/ocrd_utils/ocrd_utils/constants.py
@@ -7,7 +7,9 @@ __all__ = [
     'VERSION',
     'MIMETYPE_PAGE',
     'EXT_TO_MIME',
-    'MIME_TO_EXT'
+    'MIME_TO_EXT',
+    'PIL_TO_MIME',
+    'MIME_TO_PIL',
 ]
 
 VERSION = get_distribution('ocrd_utils').version
@@ -45,4 +47,29 @@ MIME_TO_EXT = {
     'image/x-portable-pixmap': '.ppm',
     'image/x-portable-anymap': '.pnm',
     'image/x-portable-bitmap': '.pbm',
+}
+
+#
+# Translate between what PIL expects as ``format`` and IANA media types.
+#
+PIL_TO_MIME = {
+    'BMP':  'image/bmp',
+    'EPS':  'application/postscript',
+    'GIF':  'image/gif',
+    'JPEG': 'image/jpeg',
+    'JP2':  'image/jp2',
+    'PNG':  'image/png',
+    'PPM':  'image/x-portable-pixmap',
+    'TIFF': 'image/tiff',
+}
+
+MIME_TO_PIL = {
+    'image/bmp': 'BMP',
+    'application/postscript': 'EPS',
+    'image/gif': 'GIF',
+    'image/jpeg': 'JPEG',
+    'image/jp2': 'JP2',
+    'image/png': 'PNG',
+    'image/x-portable-pixmap': 'PPM',
+    'image/tiff': 'TIFF',
 }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,9 +34,8 @@ from ocrd_utils import (
     xywh_from_polygon,
     pushd_popd,
 
-    MIME_TO_EXT,
-    EXT_TO_MIME,
-
+    MIME_TO_EXT, EXT_TO_MIME,
+    MIME_TO_PIL, PIL_TO_MIME,
 )
 from ocrd_models.utils import xmllint_format
 
@@ -205,8 +204,10 @@ class TestUtils(TestCase):
             parse_json_string_or_file('[}')
 
     def test_mime_ext(self):
-        self.assertEquals(MIME_TO_EXT['image/jp2'], '.jp2')
-        self.assertEquals(EXT_TO_MIME['.jp2'], 'image/jp2')
+        self.assertEqual(MIME_TO_EXT['image/jp2'], '.jp2')
+        self.assertEqual(EXT_TO_MIME['.jp2'], 'image/jp2')
+        self.assertEqual(MIME_TO_PIL['image/jp2'], 'JP2')
+        self.assertEqual(PIL_TO_MIME['JP2'], 'image/jp2')
 
 
 if __name__ == '__main__':

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -192,6 +192,16 @@ class TestWorkspace(TestCase):
             self.assertEqual(f1.url, 'test.tif')
             self.assertEqual(f2.url, 'test.xml')
 
+    def test_save_image_file(self):
+        from PIL import Image
+        img = Image.new('RGB', (1000, 1000))
+        with TemporaryDirectory() as tempdir:
+            ws = self.resolver.workspace_from_nothing(directory=tempdir)
+            with self.assertRaisesRegex(KeyError, ''):
+                ws.save_image_file(img, 'page1_img', 'IMG', 'page1', 'ceci/nest/pas/une/mimetype')
+            ws.save_image_file(img, 'page1_img', 'IMG', 'page1', 'image/jpeg')
+            self.assertTrue(exists(join(tempdir, 'IMG', 'page1_img.jpg')))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes #439

Maps from the [most common PIL/Pillow supported image formats](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html) to media types.

Changes the signature of `workspace.save_image_file`, replacing the `format` parameter with a `mimetype` parameter.