### PR TITLE
drop OcrdFile caching in OcrdMets, one-go regex search, fix #446

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,6 +15,7 @@ disable =
     no-self-use,
     superfluous-parens,
     too-few-public-methods,
+    wrong-import-order,
     too-many-arguments,
     too-many-branches,
     too-many-instance-attributes,

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -1,13 +1,11 @@
 import os
 from os.path import relpath, exists
 import sys
-from tempfile import mkdtemp
 
 import click
 
 from ocrd import Resolver, Workspace, WorkspaceValidator, WorkspaceBackupManager
 from ocrd_utils import getLogger, pushd_popd
-from ..constants import TMP_PREFIX
 
 log = getLogger('ocrd.cli.workspace')
 
@@ -133,29 +131,27 @@ def workspace_create(ctx, clobber_mets, directory):
 @click.option('-m', '--mimetype', help="Media type of the file", required=True)
 @click.option('-g', '--page-id', help="ID of the physical page")
 @click.option('--force', help="If file with ID already exists, replace it", default=False, is_flag=True)
-@click.argument('local_filename', type=click.Path(dir_okay=False, readable=True, resolve_path=True), required=True)
+@click.argument('fname', type=click.Path(dir_okay=False, readable=True, resolve_path=True), required=True)
 @pass_workspace
-def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, force, local_filename):
+def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, force, fname):
     """
-    Add a file LOCAL_FILENAME to METS in a workspace.
+    Add a file FNAME to METS in a workspace.
     """
     workspace = Workspace(ctx.resolver, directory=ctx.directory, mets_basename=ctx.mets_basename, automatic_backup=ctx.automatic_backup)
 
-    #  log.warning(ctx.directory)
-    #  log.error(local_filename)
-    if not local_filename.startswith(ctx.directory):
-        log.debug("File '%s' is not in workspace, copying", local_filename)
-        local_filename = ctx.resolver.download_to_directory(ctx.directory, local_filename, subdir=file_grp)
-    local_filename = relpath(local_filename, ctx.directory)
+    if not fname.startswith(ctx.directory):
+        log.debug("File '%s' is not in workspace, copying", fname)
+        fname = ctx.resolver.download_to_directory(ctx.directory, fname, subdir=file_grp)
+    fname = relpath(fname, ctx.directory)
 
     workspace.mets.add_file(
         fileGrp=file_grp,
         ID=file_id,
         mimetype=mimetype,
-        url=local_filename,
+        url=fname,
         pageId=page_id,
         force=force,
-        local_filename=local_filename
+        local_filename=fname
     )
     workspace.save_mets()
 

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -118,7 +118,7 @@ class OcrdMets(OcrdXmlDocument):
         Search ``mets:file`` in this METS document.
 
 
-        The ``ID``, ``fileGrp``, ``pageId``, ``url`` and ``mimetype`` parameters can be
+        The ``ID``, ``fileGrp``, ``url`` and ``mimetype`` parameters can be
         either a literal string or a regular expression if the string starts
         with ``//`` (double slash). If it is a regex, the leading ``//`` is removed
         and candidates are matched against the regex with ``re.fullmatch``. If it is

--- a/ocrd_utils/ocrd_utils/constants.py
+++ b/ocrd_utils/ocrd_utils/constants.py
@@ -10,6 +10,7 @@ __all__ = [
     'MIME_TO_EXT',
     'PIL_TO_MIME',
     'MIME_TO_PIL',
+    'REGEX_PREFIX',
 ]
 
 VERSION = get_distribution('ocrd_utils').version
@@ -73,3 +74,7 @@ MIME_TO_PIL = {
     'image/x-portable-pixmap': 'PPM',
     'image/tiff': 'TIFF',
 }
+
+
+# Prefix to denote query is regular expression not fixed string
+REGEX_PREFIX = 're:'

--- a/ocrd_utils/ocrd_utils/constants.py
+++ b/ocrd_utils/ocrd_utils/constants.py
@@ -10,12 +10,9 @@ __all__ = [
     'MIME_TO_EXT',
     'PIL_TO_MIME',
     'MIME_TO_PIL',
-<<<<<<< HEAD
     'REGEX_PREFIX',
-=======
     'LOG_FORMAT',
     'LOG_TIMEFMT',
->>>>>>> master
 ]
 
 VERSION = get_distribution('ocrd_utils').version

--- a/ocrd_utils/ocrd_utils/constants.py
+++ b/ocrd_utils/ocrd_utils/constants.py
@@ -77,4 +77,4 @@ MIME_TO_PIL = {
 
 
 # Prefix to denote query is regular expression not fixed string
-REGEX_PREFIX = 're:'
+REGEX_PREFIX = '//'

--- a/ocrd_validators/ocrd_validators/bagit-profile.yml
+++ b/ocrd_validators/ocrd_validators/bagit-profile.yml
@@ -1,5 +1,5 @@
 BagIt-Profile-Info:
-  BagIt-Profile-Identifier: https://ocr-d.github.io/bagit-profile.json
+  BagIt-Profile-Identifier: https://ocr-d.de/bagit-profile.json
   BagIt-Profile-Version: '1.2.0'
   Source-Organization: OCR-D
   External-Description: BagIt profile for OCR data

--- a/tests/model/test_ocrd_file.py
+++ b/tests/model/test_ocrd_file.py
@@ -1,4 +1,3 @@
-from lxml import etree as ET
 from tests.base import TestCase, main
 from ocrd_models import OcrdFile
 

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -49,9 +49,13 @@ class TestOcrdMets(TestCase):
     def test_find_files(self):
         self.assertEqual(len(self.mets.find_files()), 35, '35 files total')
         self.assertEqual(len(self.mets.find_files(fileGrp='OCR-D-IMG')), 3, '3 files in "OCR-D-IMG"')
+        self.assertEqual(len(self.mets.find_files(fileGrp='re:OCR-D-I.*')), 13, '13 files in "re:OCR-D-I.*"')
+        self.assertEqual(len(self.mets.find_files(ID="FILE_0001_IMAGE")), 1, '1 files with ID "FILE_0001_IMAGE"')
+        self.assertEqual(len(self.mets.find_files(ID="re:FILE_0005_.*")), 1, '1 files with ID "re:FILE_0005_.*"')
         self.assertEqual(len(self.mets.find_files(pageId='PHYS_0001')), 17, '17 files for page "PHYS_0001"')
         self.assertEqual(len(self.mets.find_files(pageId='PHYS_0001-NOTEXIST')), 0, '0 pages for "PHYS_0001-NOTEXIST"')
         self.assertEqual(len(self.mets.find_files(mimetype='image/tiff')), 13, '13 image/tiff')
+        self.assertEqual(len(self.mets.find_files(mimetype='re:application/.*')), 22, '22 application/.*')
         self.assertEqual(len(self.mets.find_files(mimetype=MIMETYPE_PAGE)), 20, '20 ' + MIMETYPE_PAGE)
         self.assertEqual(len(self.mets.find_files(url='OCR-D-IMG/FILE_0005_IMAGE.tif')), 1, '1 xlink:href="OCR-D-IMG/FILE_0005_IMAGE.tif"')
 

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -21,8 +21,9 @@ class TestOcrdMets(TestCase):
         self.mets.unique_identifier = 'foo'
         self.assertEqual(self.mets.unique_identifier, 'foo', 'Right identifier after change')
 
+    # pylint: disable=no-member
     def test_unique_identifier_from_nothing(self):
-        mets = OcrdMets.empty_mets()
+        mets = OcrdMets.empty_mets(datetime.now().isoformat())
         self.assertEqual(mets.unique_identifier, None, 'no identifier')
         mets.unique_identifier = 'foo'
         self.assertEqual(mets.unique_identifier, 'foo', 'Right identifier after change')
@@ -58,6 +59,10 @@ class TestOcrdMets(TestCase):
         self.assertEqual(len(self.mets.find_files(mimetype='//application/.*')), 22, '22 application/.*')
         self.assertEqual(len(self.mets.find_files(mimetype=MIMETYPE_PAGE)), 20, '20 ' + MIMETYPE_PAGE)
         self.assertEqual(len(self.mets.find_files(url='OCR-D-IMG/FILE_0005_IMAGE.tif')), 1, '1 xlink:href="OCR-D-IMG/FILE_0005_IMAGE.tif"')
+
+    def test_find_files_no_regex_for_pageid(self):
+        with self.assertRaisesRegex(Exception, "not support regex search for pageId"):
+            self.mets.find_files(pageId='//foo')
 
     def test_find_files_local_only(self):
         self.assertEqual(len(self.mets.find_files(pageId='PHYS_0001', local_only=True)), 3, '3 local files for page "PHYS_0001"')

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -49,13 +49,13 @@ class TestOcrdMets(TestCase):
     def test_find_files(self):
         self.assertEqual(len(self.mets.find_files()), 35, '35 files total')
         self.assertEqual(len(self.mets.find_files(fileGrp='OCR-D-IMG')), 3, '3 files in "OCR-D-IMG"')
-        self.assertEqual(len(self.mets.find_files(fileGrp='re:OCR-D-I.*')), 13, '13 files in "re:OCR-D-I.*"')
+        self.assertEqual(len(self.mets.find_files(fileGrp='//OCR-D-I.*')), 13, '13 files in "//OCR-D-I.*"')
         self.assertEqual(len(self.mets.find_files(ID="FILE_0001_IMAGE")), 1, '1 files with ID "FILE_0001_IMAGE"')
-        self.assertEqual(len(self.mets.find_files(ID="re:FILE_0005_.*")), 1, '1 files with ID "re:FILE_0005_.*"')
+        self.assertEqual(len(self.mets.find_files(ID="//FILE_0005_.*")), 1, '1 files with ID "//FILE_0005_.*"')
         self.assertEqual(len(self.mets.find_files(pageId='PHYS_0001')), 17, '17 files for page "PHYS_0001"')
         self.assertEqual(len(self.mets.find_files(pageId='PHYS_0001-NOTEXIST')), 0, '0 pages for "PHYS_0001-NOTEXIST"')
         self.assertEqual(len(self.mets.find_files(mimetype='image/tiff')), 13, '13 image/tiff')
-        self.assertEqual(len(self.mets.find_files(mimetype='re:application/.*')), 22, '22 application/.*')
+        self.assertEqual(len(self.mets.find_files(mimetype='//application/.*')), 22, '22 application/.*')
         self.assertEqual(len(self.mets.find_files(mimetype=MIMETYPE_PAGE)), 20, '20 ' + MIMETYPE_PAGE)
         self.assertEqual(len(self.mets.find_files(url='OCR-D-IMG/FILE_0005_IMAGE.tif')), 1, '1 xlink:href="OCR-D-IMG/FILE_0005_IMAGE.tif"')
 

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -38,10 +38,10 @@ class TestOcrdMets(TestCase):
         mets = OcrdMets(content='<mets/>')
         self.assertEqual(str(mets), 'OcrdMets[fileGrps=[],files=[]]')
 
-    def test_override_constructor_args(self):
-        id2file = {'foo': {}}
-        mets = OcrdMets(id2file, content='<mets/>')
-        self.assertEqual(mets._file_by_id, id2file)
+    #  def test_override_constructor_args(self):
+    #      id2file = {'foo': {}}
+    #      mets = OcrdMets(id2file, content='<mets/>')
+    #      self.assertEqual(mets._file_by_id, id2file)
 
     def test_file_groups(self):
         self.assertEqual(len(self.mets.file_groups), 17, '17 file groups')


### PR DESCRIPTION
<del>Still WIP, need to ensure that this won't break anything. In particular the `local_filename` handling of OcrdFile. Ideally we can remove that too and can be certain that all information is serializable.

Two important changes:

  * files are no longer trivially cached in a dict in OcrdMets. This was useful in development but is a recipe for Out-of-memory errors for real-world data
  * `OcrdMets.find_files` has been changed from two-step process with search implemented using Xpath filters and instantiation of OcrdFiles by file ID to a single-step process that iterates over **all** the files in METS and filters. In all cases I have tested, this "filtering" approach is equal or faster in speed. It's less noticeable with few files but with very large METS file, the improvement in speed is significant (factor 10)
  * OcrdMets.find_files supports regex search for `ID`, `url`, `mimetype` and `fileGrp` parameters by setting the resp. parameter to `//<REGEX>`, e.g. `find_files(ID="^.*_MAX_.*")` or `find_files(url="//https://myhost/.*")`.