### PR TITLE
Use nvidia/cuda instead of ubuntu:18.04 as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM nvidia/cuda:10.2-base-ubuntu18.04
 MAINTAINER OCR-D
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONIOENCODING utf8


### PR DESCRIPTION
... to enable usage of cuda in dewarp.

nvidia/cuda:10.2-base-ubuntu18.04 is itself based on ubuntu:18.04, so the underlying dependencies do not change.

See https://github.com/OCR-D/ocrd_anybaseocr/issues/4