### PR TITLE
[app][feat] use config file for logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ tests/assets/test.ocrd.zip
 sanders*
 ws1
 *.doctree
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 Added:
 
-  * Execution of processors is tracked with logger 'profile.orcd.process.<processor-name>', #461
+  * Execution of processors is tracked with logger 'orcd.process.profile', #461
 
 ## [2.4.4] - 2020-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Added:
+
+  * Execution of processors is tracked with logger 'profile.orcd.process.<processor-name>', #461
+
 ## [2.4.4] - 2020-03-17
 
 Fixed:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY ocrd ./ocrd
 COPY ocrd_modelfactory ./ocrd_modelfactory/
 COPY ocrd_models ./ocrd_models
 COPY ocrd_utils ./ocrd_utils
+RUN mv ./ocrd_utils/ocrd_logging.conf /etc
 COPY ocrd_validators/ ./ocrd_validators
 COPY Makefile .
 COPY README.md .

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,8 @@ assets-clean:
 .PHONY: test
 # Run all unit tests
 test: spec assets
-	$(PYTHON) -m pytest --continue-on-collection-errors $(TESTDIR)
+	HOME=$(CURDIR)/ocrd_utils $(PYTHON) -m pytest --continue-on-collection-errors $(TESTDIR) -k TestLogging
+	HOME=$(CURDIR) $(PYTHON) -m pytest --continue-on-collection-errors $(TESTDIR)
 
 test-profile:
 	$(PYTHON) -m cProfile -o profile $$(which pytest)

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -54,12 +54,18 @@ def run_processor(
     ocrd_tool = processor.ocrd_tool
     name = '%s v%s' % (ocrd_tool['executable'], processor.version)
     otherrole = ocrd_tool['steps'][0]
-    logProfile = getLogger('profile.ocrd.processor.%s' % ocrd_tool['executable'])
+    logProfile = getLogger('ocrd.process.profile')
     log.debug("Processor instance %s (%s doing %s)", processor, name, otherrole)
     t0 = time()
     processor.process()
     t1 = time() - t0
-    logProfile.info('%fs' % t1)
+    logProfile.info('Executing processor "%s" took %fs [--input-file-grp="%s" --output-file-grp="%s" --parameter="%s"]' % (
+        ocrd_tool['executable'],
+        t1,
+        input_file_grp if input_file_grp else '',
+        output_file_grp if output_file_grp else '',
+        parameter if parameter else {}
+    ))
     workspace.mets.add_agent(
         name=name,
         _type='OTHER',

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -1,6 +1,7 @@
 import os
 import json
 from click import wrap_text
+from time import time
 import subprocess
 from ocrd_utils import getLogger, VERSION as OCRD_VERSION
 from ocrd_validators import ParameterValidator
@@ -53,8 +54,12 @@ def run_processor(
     ocrd_tool = processor.ocrd_tool
     name = '%s v%s' % (ocrd_tool['executable'], processor.version)
     otherrole = ocrd_tool['steps'][0]
+    logProfile = getLogger('profile.ocrd.processor.%s' % ocrd_tool['executable'])
     log.debug("Processor instance %s (%s doing %s)", processor, name, otherrole)
+    t0 = time()
     processor.process()
+    t1 = time() - t0
+    logProfile.info('%fs' % t1)
     workspace.mets.add_agent(
         name=name,
         _type='OTHER',

--- a/ocrd_utils/README.md
+++ b/ocrd_utils/README.md
@@ -3,3 +3,29 @@
 > OCR-D framework - shared code, helpers, constants
 
 See https://github.com/OCR-D/core
+
+
+## OCR-D Module Logging
+
+File-based control over logging facilities is done with standard [Python 3 logging module configuration files](https://docs.python.org/3.6/howto/logging.html#configuring-logging). This way, the level, format and destinations of log messages can be customized for all OCR-D modules individually and persistently, in the usual syntax.
+
+A template configuration file (with commented examples) is included in [ocrd_logging.conf](./ocrd_logging.conf). This is meant as an example, and should be **customized**. 
+
+To get into effect, you must put a copy (under the same name) into:
+1. your current working directory, 
+2. your user directory, or
+3. `/etc`. 
+These directories are searched in said order, and the first find wins. When no config file is found, the default logging configuration applies (which uses only stdout and the `INFO` loglevel for most loggers, cf. [here](./ocrd_logging.py)).
+
+Thus, a configuration file will override *all* settings from the default configuration, and from configuration files in lower-priority directories.
+
+For more information about logging, handlers and formats, see [Python documentation](https://docs.python.org/3/howto/logging.htm).
+
+#### Docker containers
+
+In the Dockerfiles used to build `ocrd/core` (and subsequently `ocrd/all`), the above mentioned template is directly copied to `/etc/ocrd_logging.conf` within the container image. This cofiguration is thereby also the default configuration for OCR-D containers. 
+
+Thus, if you want to customize logging rules in one of these Docker containers, you can create a custom configuration file and either:
+- place it into your local workspace directory when running the OCR-D container.
+- mount it under `/etc` when starting up the container, e.g. `docker run --mount type=bind,source=host/path/to/your-template.conf,destination=/etc/ocrd_logging.conf ocrd/all`
+- include a Dockerfile step (layer or stage) which copies this into `/etc/ocrd_logging.conf` at build time in your own Docker image.

--- a/ocrd_utils/ocrd_logging.conf
+++ b/ocrd_utils/ocrd_logging.conf
@@ -1,0 +1,84 @@
+# This is a template configuration file which allows customizing
+# format and destination of log messages with OCR-D.
+# It is meant as an example, and should be customized.
+# To get into effect, you must put a copy (under the same name)
+# into your CWD, HOME or /etc. These directories are searched
+# in said order, and the first find wins. When no config file
+# is found, the default logging configuration applies (cf. ocrd_logging.py).
+# 
+# mandatory loggers section
+# configure loggers with correspnding keys "root", ""
+# each logger requires a corresponding configuration section below
+#
+[loggers]
+#keys=root,ocrd_workspace
+keys=root
+#
+# mandatory handlers section
+# handle output for each logging "channel"
+# i.e. console, file, smtp, syslog, http, ...
+# each handler requires a corresponding configuration section below
+#
+[handlers]
+keys=consoleHandler,fileHandler
+
+#
+# optional custom formatters section
+# format message fields, to be used differently by logging handlers
+# each formatter requires a corresponding formatter section below
+#
+[formatters]
+keys=defaultFormatter,detailedFormatter
+
+#
+# default logger "root" using consoleHandler
+#
+[logger_root]
+level=INFO
+handlers=consoleHandler
+
+#
+# additional logger configurations can be added
+# as separate configuration sections like below
+#
+# example logger "ocrd_workspace" uses fileHandler and overrides
+# default log level "INFO" with custom level "DEBUG" 
+# "qualname" must match the logger label used in the corresponding 
+# ocrd modul
+# see in the modul-of-interrest (moi)
+#
+#[logger_ocrd_workspace]
+#level=DEBUG
+#handlers=fileHandler
+#qualname=ocrd.workspace
+
+#
+# handle stdout output
+#
+[handler_consoleHandler]
+class=StreamHandler
+formatter=defaultFormatter
+args=(sys.stdout,)
+
+#
+# example logfile handler
+# handle output with logfile
+#
+[handler_fileHandler]
+class=FileHandler
+formatter=detailedFormatter
+args=('ocrd.log','a+')
+
+#
+# default log format conforming to OCR-D (https://ocr-d.de/en/spec/cli#logging)
+#
+[formatter_defaultFormatter]
+format=%(asctime)s.%(msecs)03d %(levelname)s %(name)s - %(message)s
+datefm=%H:%M:%S
+
+#
+# store more logging context information
+#
+[formatter_detailedFormatter]
+format=%(asctime)s.%(msecs)03d %(levelname)-8s (%(name)s)[%(filename)s:%(lineno)d] - %(message)s
+datefm=%H:%M:%S

--- a/ocrd_utils/ocrd_utils/constants.py
+++ b/ocrd_utils/ocrd_utils/constants.py
@@ -10,6 +10,8 @@ __all__ = [
     'MIME_TO_EXT',
     'PIL_TO_MIME',
     'MIME_TO_PIL',
+    'LOG_FORMAT',
+    'LOG_DATEFMT',
 ]
 
 VERSION = get_distribution('ocrd_utils').version
@@ -73,3 +75,7 @@ MIME_TO_PIL = {
     'image/x-portable-pixmap': 'PPM',
     'image/tiff': 'TIFF',
 }
+
+# Log level format implementing https://ocr-d.de/en/spec/cli#logging
+LOG_FORMAT = r'%(asctime)s.%(msecs)03d %(levelname)s %(name)s - %(message)s'
+LOG_DATEFMT = r'%Y-%m-%d %H:%M:%S'

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -19,6 +19,8 @@ import logging
 import logging.config
 import os
 
+from .constants import LOG_FORMAT, LOG_DATEFMT
+
 __all__ = [
     'logging',
     'getLogger',
@@ -90,7 +92,7 @@ def initLogging():
 
     global _overrideLogLevel # pylint: disable=global-statement
     _overrideLogLevel = None
-    
+
     CONFIG_PATHS = [
         os.path.curdir,
         os.path.join(os.path.expanduser('~')),
@@ -104,8 +106,8 @@ def initLogging():
 
     logging.basicConfig(
         level=logging.INFO,
-        format='%(asctime)s.%(msecs)03d %(levelname)s %(name)s - %(message)s',
-        datefmt='%H:%M:%S')
+        format=LOG_FORMAT,
+        datefmt=LOG_DATEFMT)
     logging.getLogger('').setLevel(logging.INFO)
     #  logging.getLogger('ocrd.resolver').setLevel(logging.INFO)
     #  logging.getLogger('ocrd.resolver.download_to_directory').setLevel(logging.INFO)
@@ -113,6 +115,6 @@ def initLogging():
     logging.getLogger('PIL').setLevel(logging.INFO)
     # To cut back on the `Self-intersection at or near point` INFO messages
     logging.getLogger('shapely.geos').setLevel(logging.ERROR)
-    
+
 
 initLogging()

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,7 @@ codecov >= 2.0.15
 recommonmark >= 0.5.0
 docstr-coverage
 pylint
+atomicwrites
+opencv-python
+deprecated
+click

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,6 +3,9 @@
 from os.path import dirname, realpath
 import sys
 from unittest import TestCase, skip, main
+import logging
+import io
+import collections
 
 from .assets import assets, copy_of_directory
 
@@ -13,5 +16,26 @@ from .assets import assets, copy_of_directory
 #      traceback.print_stack(file=log)
 #      log.write(warnings.formatwarning(message, category, filename, lineno, line))
 #  warnings.showwarning = warn_with_traceback
+
+# https://stackoverflow.com/questions/37944111/python-rolling-log-to-a-variable
+# Adapted from http://alanwsmith.com/capturing-python-log-output-in-a-variable
+
+class FIFOIO(io.TextIOBase):
+    def __init__(self, size, *args):
+        self.maxsize = size
+        io.TextIOBase.__init__(self, *args)
+        self.deque = collections.deque()
+    def getvalue(self):
+        return ''.join(self.deque)
+    def write(self, x):
+        self.deque.append(x)
+        self.shrink()
+    def shrink(self):
+        if self.maxsize is None:
+            return
+        size = sum(len(x) for x in self.deque)
+        while size > self.maxsize:
+            x = self.deque.popleft()
+            size -= len(x)
 
 sys.path.append(dirname(realpath(__file__)) + '/../ocrd')

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,12 +2,18 @@
 
 from os.path import dirname, realpath
 import sys
-from unittest import TestCase, skip, main
 import logging
 import io
 import collections
+from unittest import TestCase as VanillaTestCase, skip, main
+from ocrd_utils import initLogging
 
 from .assets import assets, copy_of_directory
+
+class TestCase(VanillaTestCase):
+
+    def tearDown(self):
+        initLogging()
 
 #  import traceback
 #  import warnings

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,6 +1,7 @@
 # pylint: disable=unused-import
 
 from os.path import dirname, realpath
+from os import chdir
 import sys
 import logging
 import io
@@ -11,6 +12,10 @@ from ocrd_utils import initLogging
 from .assets import assets, copy_of_directory
 
 class TestCase(VanillaTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        chdir(dirname(realpath(__file__)) + '/..')
 
     def tearDown(self):
         initLogging()

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -31,7 +31,7 @@ class DummyProcessor(Processor):
 class IncompleteProcessor(Processor):
     pass
 
-class TestResolver(TestCase):
+class TestProcessor(TestCase):
 
     def setUp(self):
         self.resolver = Resolver()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -10,7 +10,7 @@ from ocrd.decorators import (
     ocrd_loglevel,
     ocrd_cli_wrap_processor,
 )    # pylint: disable=protected-access
-from ocrd_utils.logging import setOverrideLogLevel, initLogging
+from ocrd_utils.logging import initLogging
 from ocrd_utils import pushd_popd, VERSION as OCRD_VERSION
 
 @click.command()
@@ -49,7 +49,6 @@ class DummyProcessor(Processor):
 def cli_dummy_processor(*args, **kwargs):
     return ocrd_cli_wrap_processor(DummyProcessor, *args, **kwargs)
 
-
 class TestDecorators(TestCase):
 
     def setUp(self):
@@ -72,7 +71,7 @@ class TestDecorators(TestCase):
         result = self.runner.invoke(cli_with_ocrd_loglevel, ['--log-level', 'DEBUG'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(logging.getLogger('PIL').getEffectiveLevel(), logging.DEBUG)
-        setOverrideLogLevel('INFO')
+        initLogging()
 
     def test_processor_dump_json(self):
         result = self.runner.invoke(cli_dummy_processor, ['--dump-json'])

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -16,6 +16,9 @@ from ocrd_utils import (
 
 class TestLogging(TestCase):
 
+    def setUp(self):
+        initLogging()
+
     def test_setOverrideLogLevel(self):
         rootLogger = logging.getLogger('')
         somelogger = getLogger('foo.bar')
@@ -29,25 +32,48 @@ class TestLogging(TestCase):
         self.assertEqual(notherlogger.getEffectiveLevel(), logging.ERROR)
         setOverrideLogLevel('INFO')
         somelogger = getLogger('foo.bar')
-        setOverrideLogLevel('INFO')
-
-
-class TestLogging2(TestCase):
-
-    def setUp(self):
-        initLogging()
 
     def test_getLevelName(self):
         self.assertEqual(getLevelName('ERROR'), logging.ERROR)
         self.assertEqual(getLevelName('FATAL'), logging.ERROR)
         self.assertEqual(getLevelName('OFF'), logging.CRITICAL)
 
-    def test_configfile(self):
+    def tearDown(self):
+        initLogging()
+
+class TestLoggingConfiguration(TestCase):
+
+    def test_tmpConfigfile(self):
+        self.assertNotEqual(logging.getLogger('').getEffectiveLevel(), logging.NOTSET)
         with TemporaryDirectory() as tempdir:
             with pushd_popd(tempdir):
-                with open('ocrd_logging.py', 'w') as f:
-                    f.write('print("this is mighty dangerous")')
+                with open('ocrd_logging.conf', 'w') as f:
+                    # write logging configuration file (MWE)
+                    f.write('''
+                        [loggers]
+                        keys=root
+
+                        [handlers]
+                        keys=consoleHandler
+
+                        [formatters]
+                        keys=
+
+                        [logger_root]
+                        level=ERROR
+                        handlers=consoleHandler
+
+                        [handler_consoleHandler]
+                        class=StreamHandler
+                        formatter=
+                        args=(sys.stdout,)
+                        ''')
+                # this will call logging.config.fileConfig with disable_existing_loggers=True,
+                # so the defaults from the import-time initLogging should be invalided
                 initLogging()
+                # ensure log level is set from temporary config file
+                self.assertEqual(logging.getLogger('').getEffectiveLevel(), logging.ERROR)
+
 
 class TestProfileLogging(TestCase):
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -55,16 +55,15 @@ class TestProfileLogging(TestCase):
         log_capture_string = FIFOIO(256)
         ch = logging.StreamHandler(log_capture_string)
         ch.setFormatter(logging.Formatter('%(asctime)s.%(msecs)03d %(levelname)s %(name)s - %(message)s'))
-        getLogger('profile').setLevel('DEBUG')
-        getLogger('profile').addHandler(ch)
+        getLogger('ocrd.process.profile').setLevel('DEBUG')
+        getLogger('ocrd.process.profile').addHandler(ch)
 
         run_processor(DummyProcessor, resolver=Resolver(), mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml'))
 
         log_contents = log_capture_string.getvalue()
         log_capture_string.close()
-        # Check whether profile information has been logged. Dummy should
-        # finish in under 0.1s
-        self.assertTrue(match(r'.*profile.ocrd.processor.ocrd-test - 0.0\d+s.*', log_contents))
+        # Check whether profile information has been logged. Dummy should finish in under 0.1s
+        self.assertTrue(match(r'.*Executing processor "ocrd-test" took 0.\d+s.*', log_contents))
 
 if __name__ == '__main__':
     main()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -7,9 +7,6 @@ from tests.base import TestCase, assets, main, copy_of_directory
 from ocrd.resolver import Resolver
 from ocrd_utils import pushd_popd
 
-#  from ocrd_utils import setOverrideLogLevel
-#  setOverrideLogLevel('DEBUG')
-
 METS_HEROLD = assets.url_of('SBB0000F29300010000/data/mets.xml')
 FOLDER_KANT = assets.path_to('kant_aufklaerung_1784')
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -9,8 +9,6 @@ from tests.base import TestCase, assets, main, copy_of_directory
 from ocrd.resolver import Resolver
 from ocrd.workspace import Workspace
 
-from ocrd_utils import setOverrideLogLevel
-setOverrideLogLevel('DEBUG')
 
 TMP_FOLDER = '/tmp/test-core-workspace'
 SRC_METS = assets.path_to('kant_aufklaerung_1784/data/mets.xml')
@@ -110,8 +108,6 @@ class TestWorkspace(TestCase):
             # Create a relative path to trigger #319
             src_path = str(Path(assets.path_to('kant_aufklaerung_1784/data/mets.xml')).relative_to(Path.cwd()))
             self.resolver.workspace_from_url(src_path, dst_dir=ws_dir, download=True)
-            from os import system
-            system('find %s' % ws_dir)
             self.assertTrue(Path(ws_dir, 'mets.xml').exists())  # sanity check, mets.xml must exist
             self.assertTrue(Path(ws_dir, 'OCR-D-GT-PAGE/PAGE_0017_PAGE.xml').exists())
 


### PR DESCRIPTION
Enable python log files (see: https://docs.python.org/3.6/howto/logging.html#configuring-logging)

Advance: Configuration logic and behavior is separated from programming flow

Example Configuration: 
[ocrd_logging.zip](https://github.com/OCR-D/core/files/4455950/ocrd_logging.zip)

The example Configuration affects out-of-the the following ocr-modules:

* ocrd_utils
* ocrd.workspace
* processor.RepairSegmentation
* processor.OcropySegment
* processor.OcropyDewarp
* processor.TesserocrRecognize

The following ocrd-modules are not affected (due they are not pythonic or of other reasons)
* ocrd-im6convert
* ocrd-olena-binarize
* OCR-D-SEG-PAGE-anyocr

