### PR TITLE
processor.base: format profile log message params in JSON

### DIFF
--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -59,12 +59,12 @@ def run_processor(
     t0 = time()
     processor.process()
     t1 = time() - t0
-    logProfile.info('Executing processor "%s" took %fs [--input-file-grp="%s" --output-file-grp="%s" --parameter="%s"]' % (
+    logProfile.info("Executing processor '%s' took %fs [--input-file-grp='%s' --output-file-grp='%s' --parameter='%s']" % (
         ocrd_tool['executable'],
         t1,
         input_file_grp if input_file_grp else '',
         output_file_grp if output_file_grp else '',
-        parameter if parameter else {}
+        json.dumps(parameter) if parameter else {}
     ))
     workspace.mets.add_agent(
         name=name,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -144,7 +144,7 @@ class TestLogging(TestCase):
         # with open('/tmp/debug.log', 'w') as f:
         #     f.write(log_contents)
         # Check whether profile information has been logged. Dummy should finish in under 0.1s
-        self.assertTrue(match(r'.*Executing processor "ocrd-test" took 0.\d+s.*', log_contents))
+        self.assertTrue(match(r'.*Executing processor \'ocrd-test\' took 0.\d+s.*', log_contents))
 
 class TestLoggingConfiguration(TestCase):
 


### PR DESCRIPTION
This changes the formatting of messages shown in the profiling logger such that the parameter string can directly be re-used on the command line.