### PR TITLE
Ocrdfile cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Changed:
+
+  * `OcrdFile` constructor accepts `ID` parameter
+
 ## [2.8.1] - 2020-06-06
 
 Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 Changed:
 
   * `OcrdFile` constructor accepts `ID` parameter
+  * `OcrdFile` constructor: removed long-obsolete `instance` parameter
 
 ## [2.8.1] - 2020-06-06
 

--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -17,7 +17,7 @@ class OcrdFile():
     #  def create(mimetype, ID, url, local_filename):
     #      el_fileGrp.SubElement('file')
 
-    def __init__(self, el, mimetype=None, loctype='OTHER', instance=None, local_filename=None, mets=None, url=None):
+    def __init__(self, el, mimetype=None, loctype='OTHER', instance=None, local_filename=None, mets=None, url=None, ID=None):
         """
         Args:
             el (LxmlElement):
@@ -34,6 +34,7 @@ class OcrdFile():
         self._instance = instance
         self.mets = mets
         self.loctype = loctype
+        self.ID = ID
 
         if url:
             self.url = url

--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -17,21 +17,22 @@ class OcrdFile():
     #  def create(mimetype, ID, url, local_filename):
     #      el_fileGrp.SubElement('file')
 
-    def __init__(self, el, mimetype=None, loctype='OTHER', instance=None, local_filename=None, mets=None, url=None, ID=None):
+    def __init__(self, el, mimetype=None, loctype='OTHER', local_filename=None, mets=None, url=None, ID=None):
         """
         Args:
-            el (LxmlElement):
-            mimetype (string):
-            instance (OcrdFile):
-            local_filename (string):
-            mets (OcrdMets):
+            el (LxmlElement): etree Element of the mets:file this represents. Create new if not provided
+            mimetype (string): MIME type of the file
+            loctype (string): METS @LOCTYPE
+            local_filename (string): Local filename
+            mets (OcrdMets): Containing OcrdMets
+            url (string): xlink:href of the file
+            ID (string): @ID of the mets:file
         """
         if el is None:
             el = ET.Element(TAG_METS_FILE)
         self._el = el
         self.mimetype = mimetype
         self.local_filename = local_filename
-        self._instance = instance
         self.mets = mets
         self.loctype = loctype
         self.ID = ID

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -17,13 +17,8 @@ class TestModelFactory(TestCase):
         with self.assertRaisesRegex(Exception, "Must pass 'image_filename' to 'exif_from_filename'"):
             exif_from_filename(None)
 
-    def test_page_from_image(self):
-        exif_from_filename(SAMPLE_IMG)
-        with self.assertRaisesRegex(Exception, "Must pass 'image_filename' to 'exif_from_filename'"):
-            exif_from_filename(None)
-
     def test_page_from_file(self):
-        f = OcrdFile(None, mimetype='image/tiff', local_filename=SAMPLE_IMG)
+        f = OcrdFile(None, mimetype='image/tiff', local_filename=SAMPLE_IMG, ID='file1')
         self.assertEqual(f.mimetype, 'image/tiff')
         p = page_from_file(f)
         self.assertEqual(p.get_Page().imageWidth, 1457)


### PR DESCRIPTION
Removes unused argument `instance` and adds `ID` as a constructor argument.

Required by upcoming PR, so will merge if tests pass.