### PR TITLE
workspace add: os.path.join behavior led to faulty existence check

### DIFF
--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -154,15 +154,16 @@ def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, ignore, check_
 
     kwargs = {'fileGrp': file_grp, 'ID': file_id, 'mimetype': mimetype, 'pageId': page_id, 'force': force, 'ignore': ignore}
     log = getLogger('ocrd.cli.workspace.add')
+    log.debug("Adding '%s' (%s)", fname, kwargs)
     if not (fname.startswith('http://') or fname.startswith('https://')):
         if not fname.startswith(ctx.directory):
-            if exists(join(ctx.directory, fname)):
-                fname = join(ctx.directory, fname)
+            if exists(ctx.directory + '/' + fname):
+                fname = ctx.directory + '/' + fname
             else:
-                log.debug("File '%s' is not in workspace, copying", fname)
+                log.info("File '%s' is not in workspace, copying", fname)
                 try:
                     fname = ctx.resolver.download_to_directory(ctx.directory, fname, subdir=file_grp)
-                except FileNotFoundError as e:
+                except FileNotFoundError:
                     if check_file_exists:
                         log.error("File '%s' does not exist, halt execution!" % fname)
                         sys.exit(1)

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -1,5 +1,5 @@
 import os
-from os.path import relpath, exists, join
+from os.path import relpath, exists, join, isabs
 from pathlib import Path
 import sys
 from glob import glob   # XXX pathlib.Path.glob does not support absolute globs
@@ -157,10 +157,10 @@ def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, ignore, check_
     log.debug("Adding '%s' (%s)", fname, kwargs)
     if not (fname.startswith('http://') or fname.startswith('https://')):
         if not fname.startswith(ctx.directory):
-            if exists(ctx.directory + '/' + fname):
-                fname = ctx.directory + '/' + fname
+            if not isabs(fname) and exists(join(ctx.directory, fname)):
+                fname = join(ctx.directory, fname)
             else:
-                log.info("File '%s' is not in workspace, copying", fname)
+                log.debug("File '%s' is not in workspace, copying", fname)
                 try:
                     fname = ctx.resolver.download_to_directory(ctx.directory, fname, subdir=file_grp)
                 except FileNotFoundError:

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -191,6 +191,32 @@ class TestCli(TestCase):
             self.assertEqual(exit_code, 1)
             self.assertIn("File 'does-not-exist.xml' does not exist, halt execution!", err)
 
+    def test_add_519(self):
+        """
+        https://github.com/OCR-D/core/issues/519
+        """
+        with TemporaryDirectory() as tempdir:
+            wsdir = Path(tempdir, "workspace")
+            wsdir.mkdir()
+            srcdir = Path(tempdir, "source")
+            srcdir.mkdir()
+            srcfile = Path(srcdir, "srcfile.jpg")
+            srcfile_content = 'foo'
+            srcfile.write_text(srcfile_content)
+            with pushd_popd(wsdir):
+                exit_code, out, err = self.invoke_cli(workspace_cli, ['init'])
+                exit_code, out, err = self.invoke_cli(workspace_cli, [
+                    'add',
+                    '-m', 'image/jpg',
+                    '-G', 'MAX',
+                    '-i', 'IMG_MAX_1818975',
+                    '-C',
+                    str(srcfile)
+                    ])
+                self.assertEqual(exit_code, 0)
+                self.assertTrue(Path(wsdir, 'MAX', 'srcfile.jpg').exists())
+                self.assertEquals(Path(wsdir, 'MAX', 'srcfile.jpg').read_text(), srcfile_content)
+
     def test_add_existing_checked(self):
         ID = 'foo123file'
         page_id = 'foo123page'

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -203,7 +203,7 @@ class TestCli(TestCase):
             srcfile = Path(srcdir, "srcfile.jpg")
             srcfile_content = 'foo'
             srcfile.write_text(srcfile_content)
-            with pushd_popd(wsdir):
+            with pushd_popd(str(wsdir)):
                 exit_code, out, err = self.invoke_cli(workspace_cli, ['init'])
                 exit_code, out, err = self.invoke_cli(workspace_cli, [
                     'add',
@@ -213,9 +213,10 @@ class TestCli(TestCase):
                     '-C',
                     str(srcfile)
                     ])
+                # print(out, err)
                 self.assertEqual(exit_code, 0)
                 self.assertTrue(Path(wsdir, 'MAX', 'srcfile.jpg').exists())
-                self.assertEquals(Path(wsdir, 'MAX', 'srcfile.jpg').read_text(), srcfile_content)
+                self.assertEqual(Path(wsdir, 'MAX', 'srcfile.jpg').read_text(), srcfile_content)
 
     def test_add_existing_checked(self):
         ID = 'foo123file'


### PR DESCRIPTION
The problem was that `os.path.join` has a peculiar behavior when trying to concatenate absolute paths: It will just return the last one. Therefore the `exists` check only checked whether the source file exists - which it does, obviously - and never copied them to the workspace.

I added a test to reproduce #519 so this won't happen in the future.