### PR TITLE
Ocrd file eq

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -61,6 +61,13 @@ class OcrdFile():
         ])
         return '<OcrdFile ' + props + ']/> '
 
+    def __eq__(self, other):
+        print(self, other)
+        return self.ID == other.ID and \
+               self.url == other.url and \
+               self.mimetype == other.mimetype and \
+               self.fileGrp == other.fileGrp
+
     @property
     def basename(self):
         """

--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -3,7 +3,7 @@ API to ``mets:file``
 """
 from os.path import splitext, basename
 
-from ocrd_utils import is_local_filename, get_local_filename
+from ocrd_utils import is_local_filename, get_local_filename, MIME_TO_EXT, EXT_TO_MIME
 
 from .ocrd_xml_base import ET
 from .constants import NAMESPACES as NS, TAG_METS_FLOCAT, TAG_METS_FILE
@@ -65,7 +65,7 @@ class OcrdFile():
         print(self, other)
         return self.ID == other.ID and \
                self.url == other.url and \
-               self.mimetype == other.mimetype and \
+               EXT_TO_MIME[MIME_TO_EXT[self.mimetype]] == EXT_TO_MIME[MIME_TO_EXT[other.mimetype]] and \
                self.fileGrp == other.fileGrp
 
     @property

--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -63,10 +63,10 @@ class OcrdFile():
 
     def __eq__(self, other):
         print(self, other)
-        return self.ID == other.ID and \
-               self.url == other.url and \
-               EXT_TO_MIME[MIME_TO_EXT[self.mimetype]] == EXT_TO_MIME[MIME_TO_EXT[other.mimetype]] and \
-               self.fileGrp == other.fileGrp
+        return self.ID == other.ID # and \
+               # self.url == other.url and \
+               # EXT_TO_MIME[MIME_TO_EXT[self.mimetype]] == EXT_TO_MIME[MIME_TO_EXT[other.mimetype]] and \
+               # self.fileGrp == other.fileGrp
 
     @property
     def basename(self):

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -116,6 +116,7 @@ class OcrdMets(OcrdXmlDocument):
         """
         return [el.get('USE') for el in self._tree.getroot().findall('.//mets:fileGrp', NS)]
 
+    # pylint: disable=multiple-statements
     def find_files(self, ID=None, fileGrp=None, pageId=None, mimetype=None, url=None, local_only=False):
         """
         Search ``mets:file`` in this METS document.
@@ -177,12 +178,12 @@ class OcrdMets(OcrdXmlDocument):
                 else:
                     if cand_url != url: continue
 
-            file = OcrdFile(cand, mets=self)
+            f = OcrdFile(cand, mets=self)
 
-            # If only local resources should be returned and file is not a file path: skip the file
-            if local_only and not is_local_filename(file.url):
+            # If only local resources should be returned and f is not a file path: skip the file
+            if local_only and not is_local_filename(f.url):
                 continue
-            ret.append(file)
+            ret.append(f)
         return ret
 
     def add_file_group(self, fileGrp):

--- a/ocrd_utils/ocrd_utils/constants.py
+++ b/ocrd_utils/ocrd_utils/constants.py
@@ -38,6 +38,7 @@ EXT_TO_MIME = {
 
 MIME_TO_EXT = {
     'image/tiff': '.tif',
+    'image/tif': '.tif',
     'image/png': '.png',
     'image/jpg': '.jpg',
     'image/jpeg': '.jpg',

--- a/tests/model/test_ocrd_file.py
+++ b/tests/model/test_ocrd_file.py
@@ -1,5 +1,5 @@
 from tests.base import TestCase, main
-from ocrd_models import OcrdFile
+from ocrd_models import OcrdFile, OcrdMets
 
 class TestOcrdFile(TestCase):
 
@@ -69,5 +69,19 @@ class TestOcrdFile(TestCase):
         f = OcrdFile(None)
         self.assertEqual(f.fileGrp, 'TEMP')
 
+    def test_ocrd_file_eq(self):
+        mets = OcrdMets.empty_mets()
+        f1 = mets.add_file('FOO', ID='FOO_1', mimetype='image/tiff')
+        self.assertEqual(f1 == f1, True)
+        self.assertEqual(f1 != f1, False)
+        f2 = mets.add_file('FOO', ID='FOO_2', mimetype='image/tiff')
+        self.assertEqual(f1 == f2, False)
+        f3 = OcrdFile(None, ID='TEMP_1', mimetype='image/tiff')
+        f4 = OcrdFile(None, ID='TEMP_1', mimetype='image/tif')
+        # TODO probably makes sense to be tolerant of different equivalent mimetypes
+        # self.assertEqual(f3 == f4, True)
+        f5 = mets.add_file('TEMP', ID='TEMP_1', mimetype='image/tiff')
+        self.assertEqual(f3 == f5, True)
+
 if __name__ == '__main__':
-    main()
+    main(__file__)

--- a/tests/model/test_ocrd_file.py
+++ b/tests/model/test_ocrd_file.py
@@ -78,8 +78,8 @@ class TestOcrdFile(TestCase):
         self.assertEqual(f1 == f2, False)
         f3 = OcrdFile(None, ID='TEMP_1', mimetype='image/tiff')
         f4 = OcrdFile(None, ID='TEMP_1', mimetype='image/tif')
-        # TODO probably makes sense to be tolerant of different equivalent mimetypes
-        # self.assertEqual(f3 == f4, True)
+        # be tolerant of different equivalent mimetypes
+        self.assertEqual(f3 == f4, True)
         f5 = mets.add_file('TEMP', ID='TEMP_1', mimetype='image/tiff')
         self.assertEqual(f3 == f5, True)
 


### PR DESCRIPTION
Implement `__eq__`, so different instances of equivalent OcrdFile can be compared with `==` and `!=`.