### PR TITLE
validation of file groups downgraded to notice, allow PRE fileGrp/USE prefix

### DIFF
--- a/ocrd_validators/ocrd_validators/constants.py
+++ b/ocrd_validators/ocrd_validators/constants.py
@@ -9,7 +9,7 @@ OCRD_BAGIT_PROFILE = yaml.safe_load(resource_string(__name__, 'bagit-profile.yml
 
 BAGIT_TXT = 'BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8'
 FILE_GROUP_PREFIX = 'OCR-D-'
-FILE_GROUP_CATEGORIES = ['IMG', 'SEG', 'OCR', 'COR', 'GT']
+FILE_GROUP_CATEGORIES = ['IMG', 'PRE', 'SEG', 'OCR', 'COR', 'GT']
 TMP_BAGIT_PREFIX = 'ocrd-bagit-'
 OCRD_BAGIT_PROFILE_URL = 'https://ocr-d.github.io/bagit-profile.json'
 XSD_METS_URL = 'https://www.loc.gov/standards/mets/mets.xsd'

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -243,9 +243,9 @@ class WorkspaceValidator():
                 if '-' in category:
                     category, name = category.split('-', 1)
                 if category not in FILE_GROUP_CATEGORIES:
-                    self.report.add_warning("Unspecified USE category '%s' in fileGrp '%s'" % (category, fileGrp))
+                    self.report.add_notice("Unspecified USE category '%s' in fileGrp '%s'" % (category, fileGrp))
                 if name is not None and not re.match(r'^[A-Z0-9-]{3,}$', name):
-                    self.report.add_warning("Invalid USE name '%s' in fileGrp '%s'" % (name, fileGrp))
+                    self.report.add_notice("Invalid USE name '%s' in fileGrp '%s'" % (name, fileGrp))
 
     def _validate_mets_files(self):
         """

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,3 +11,4 @@ opencv-python
 deprecated
 click
 twine
+wheel

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -96,8 +96,8 @@ class TestWorkspaceValidator(TestCase):
             workspace.save_mets()
             report = WorkspaceValidator.validate(self.resolver, join(tempdir, 'mets.xml'))
             self.assertEqual(len(report.errors), 1)
-            self.assertEqual(len(report.warnings), 1)
-            self.assertEqual(report.warnings[0], "Unspecified USE category 'INVALID' in fileGrp 'OCR-D-INVALID-FILEGRP'")
+            self.assertEqual(len(report.notices), 1)
+            self.assertEqual(report.notices[0], "Unspecified USE category 'INVALID' in fileGrp 'OCR-D-INVALID-FILEGRP'")
             self.assertIn('No files', report.errors[0])
 
     def test_validate_file_groups_bad_name(self):
@@ -108,8 +108,8 @@ class TestWorkspaceValidator(TestCase):
             workspace.save_mets()
             report = WorkspaceValidator.validate(self.resolver, join(tempdir, 'mets.xml'))
             self.assertEqual(len(report.errors), 1)
-            self.assertEqual(len(report.warnings), 1)
-            self.assertIn("Invalid USE name 'X' in fileGrp", report.warnings[0])
+            self.assertEqual(len(report.notices), 1)
+            self.assertIn("Invalid USE name 'X' in fileGrp", report.notices[0])
             self.assertIn('No files', report.errors[0])
 
     def test_validate_files_nopageid(self):


### PR DESCRIPTION
* Let's stop complaining about fileGrp `@USE` not fitting our naming convention. Outside of GT, it's just pointless.
* `wheel` is required to build `bdist_wheel` for core
