### PR TITLE
replace package_data with MANIFEST.in

### DIFF
--- a/ocrd/MANIFEST.in
+++ b/ocrd/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include ocrd *.json *.yml *.yaml *.bash *.xml

--- a/ocrd/setup.py
+++ b/ocrd/setup.py
@@ -21,9 +21,6 @@ setup(
     packages=find_packages(exclude=('tests', 'docs')),
     include_package_data=True,
     install_requires=install_requires,
-    package_data={
-        '': ['*.json', '*.yml', '*.yaml', '*.bash', '*.xml'],
-    },
     entry_points={
         'console_scripts': [
             'ocrd=ocrd.cli:cli',


### PR DESCRIPTION
It's more reliable than `package_data` to catch all data files we want to ship with the package dist.