### PR TITLE
Adapt Processor.input_files to handle PAGE-XML and images in same group

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -167,7 +167,7 @@ class OcrdMets(OcrdXmlDocument):
 
             if mimetype:
                 if mimetype.startswith(REGEX_PREFIX):
-                    if not fullmatch(mimetype[REGEX_PREFIX_LEN:], cand.get('MIMETYPE')): continue
+                    if not fullmatch(mimetype[REGEX_PREFIX_LEN:], cand.get('MIMETYPE') or ''): continue
                 else:
                     if cand.get('MIMETYPE') != mimetype: continue
 

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -105,4 +105,4 @@ class TestCli(TestTaskSequence):
 
 
 if __name__ == '__main__':
-    main()
+    main(__file__)

--- a/tests/model/test_exif.py
+++ b/tests/model/test_exif.py
@@ -42,7 +42,7 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.photometricInterpretation, '1')
 
     def test_png2(self):
-        with Image.open(assets.path_to('scribo-test/data/OCR-D-IMG-BIN-SAUVOLA/OCR-D-SEG-PAGE-SAUVOLA-orig_tiff-BIN_sauvola.png')) as img:
+        with Image.open(assets.path_to('scribo-test/data/OCR-D-PRE-BIN-SAUVOLA/OCR-D-PRE-BIN-SAUVOLA_0001-BIN_sauvola.png')) as img:
             exif = OcrdExif(img)
         self.assertEqual(exif.width, 2097)
         self.assertEqual(exif.height, 3062)
@@ -76,4 +76,4 @@ class TestOcrdExif(TestCase):
         self.assertEqual(exif.resolutionUnit, 'inches')
 
 if __name__ == '__main__':
-    main()
+    main(__file__)

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -5,6 +5,7 @@ from os.path import join
 from tests.base import TestCase, assets, main # pylint: disable=import-error, no-name-in-module
 from tests.data import DummyProcessor, DummyProcessorWithRequiredParameters, IncompleteProcessor, DUMMY_TOOL
 
+from ocrd_utils import MIMETYPE_PAGE
 from ocrd.resolver import Resolver
 from ocrd.processor.base import Processor, run_processor, run_cli
 
@@ -29,7 +30,8 @@ class TestProcessor(TestCase):
 
     def test_with_mets_url_input_files(self):
         processor = run_processor(DummyProcessor, resolver=self.resolver, mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml'))
-        self.assertEqual(len(processor.input_files), 35)
+        self.assertEqual(len(processor.input_files), 20)
+        self.assertTrue(all([f.mimetype == MIMETYPE_PAGE for f in processor.input_files]))
 
     def test_parameter(self):
         with TemporaryDirectory() as tempdir:
@@ -43,7 +45,7 @@ class TestProcessor(TestCase):
                     resolver=self.resolver,
                     mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml')
                 )
-            self.assertEqual(len(processor.input_files), 35)
+            self.assertEqual(len(processor.input_files), 20)
 
     def test_verify(self):
         proc = DummyProcessor(self.workspace)

--- a/tests/test_task_sequence.py
+++ b/tests/test_task_sequence.py
@@ -8,7 +8,7 @@ from os.path import join
 
 from tests.base import TestCase, main, assets
 
-from ocrd_utils import pushd_popd
+from ocrd_utils import pushd_popd, MIMETYPE_PAGE
 from ocrd.resolver import Resolver
 from ocrd.task_sequence import ProcessorTask, validate_tasks, run_tasks
 
@@ -191,7 +191,7 @@ print('''%s''')
             with pushd_popd(tempdir):
                 # def run_tasks(mets, log_level, page_id, task_strs, overwrite=False):
                 ws = resolver.workspace_from_nothing(tempdir)
-                ws.add_file('GRP0', content='', local_filename='GRP0/foo', ID='file0')
+                ws.add_file('GRP0', content='', local_filename='GRP0/foo', ID='file0', mimetype=MIMETYPE_PAGE)
                 ws.save_mets()
                 run_tasks('mets.xml', 'DEBUG', None, [
                     "dummy -I GRP0 -O GRP1",


### PR DESCRIPTION
Implements the logic [proposed by @bertsky](https://github.com/cisocrgroup/ocrd_cis/pull/57#issuecomment-656336593).