### PR TITLE
assert_file_grp_cardinality: allow optional "msg" keyword param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Changed:
+
+  * `assert_file_grp_cardinality` accepts a third `msg` parameter
+
 ## [2.13.0] - 2020-08-04
 
 Changed:

--- a/ocrd_utils/ocrd_utils/str.py
+++ b/ocrd_utils/ocrd_utils/str.py
@@ -20,15 +20,20 @@ __all__ = [
 ]
 
 
-def assert_file_grp_cardinality(grps, n):
+def assert_file_grp_cardinality(grps, n, msg=None):
     """
     Assert that a string of comma-separated fileGrps contains exactly ``n`` entries.
     """
     if isinstance(grps, str):
         grps = grps.split(',')
     assert len(grps) == n, \
-            "Expected exactly %d output file group%s, but '%s' has %d" % (
-                n, '' if n == 1 else 's', grps, len(grps))
+            "Expected exactly %d output file group%s%s, but '%s' has %d" % (
+                n,
+                '' if n == 1 else 's',
+                ' (%s)' % msg if msg else '',
+                grps,
+                len(grps)
+            )
 
 def concat_padded(base, *args):
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -261,6 +261,8 @@ class TestUtils(TestCase):
         with self.assertRaisesRegex(AssertionError, "Expected exactly 1 output file group, but '.'FOO', 'BAR'.' has 2"):
             assert_file_grp_cardinality('FOO,BAR', 1)
         assert_file_grp_cardinality('FOO,BAR', 2)
+        with self.assertRaisesRegex(AssertionError, r"Expected exactly 1 output file group .foo bar., but '.'FOO', 'BAR'.' has 2"):
+            assert_file_grp_cardinality('FOO,BAR', 1, 'foo bar')
 
     def test_mock_file(self):
         f = MockOcrdFile(None, ID="MAX_0012", fileGrp='MAX')


### PR DESCRIPTION
To allow more expressive error messages in case input/output group cardinality is not what is expected.