### PR TITLE
workspace: ensure PIL.Image.open FD gets closed

### DIFF
--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -278,6 +278,7 @@ class Workspace():
 
         with pushd_popd(self.directory):
             pil_image = Image.open(image_filename)
+            pil_image.load() # alloc and give up the FD
 
         if coords is None:
             return pil_image


### PR DESCRIPTION
This can be considered a follow-up to #390. We missed that instance of `PIL.Image.open` usage without closing the FD. Since in this function we must return the `Image` object, we cannot use a context manager, but have to just give up the FD itself. See [here](https://pillow.readthedocs.io/en/stable/reference/open_files.html#file-handling)