### PR TITLE
Clone filter

### DIFF
--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -56,6 +56,7 @@ def workspace_cli(ctx, directory, mets, mets_basename, backup):
     """
     Working with workspace
     """
+    ctx.max_content_width = 100
     ctx.obj = WorkspaceCtx(directory, mets_url=mets, mets_basename=mets_basename, automatic_backup=backup)
 
 # ----------------------------------------------------------------------

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -198,6 +198,7 @@ class ocrd_mets_filter_options():
             args = [_tpl('parameter')()]
             kwargs = dict(
                 default=None,
+                callback=lambda ctx, param, value: value.split(',') if value and ',' in value else value,
                 required=_tpl('required')(),
                 metavar=_tpl('metavar')(),
                 help=_tpl('help')(

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -12,7 +12,7 @@ from ocrd_utils import (
     nth_url_segment
 )
 from ocrd.workspace import Workspace
-from ocrd_models import OcrdMets
+from ocrd_models import OcrdMets, OcrdMetsFilter
 
 log = getLogger('ocrd.resolver')
 
@@ -155,8 +155,12 @@ class Resolver():
 
         workspace = Workspace(self, dst_dir, mets_basename=mets_basename, baseurl=src_baseurl)
 
-        if download:
-            for f in workspace.mets.find_files():
+        # XXX an empty dict is false-y but valid in this context
+        if download or download == {}:
+            if not isinstance(download, dict):
+                download = {}
+            mets_filter = OcrdMetsFilter(**download)
+            for f in mets_filter.find_files(workspace):
                 workspace.download_file(f)
 
         return workspace

--- a/ocrd_models/ocrd_models/__init__.py
+++ b/ocrd_models/ocrd_models/__init__.py
@@ -7,3 +7,4 @@ from .ocrd_file import OcrdFile
 from .ocrd_mets import OcrdMets
 from .ocrd_xml_base import OcrdXmlDocument
 from .report import ValidationReport
+from .ocrd_mets_filter import OcrdMetsFilter

--- a/ocrd_models/ocrd_models/ocrd_mets_filter.py
+++ b/ocrd_models/ocrd_models/ocrd_mets_filter.py
@@ -1,9 +1,11 @@
 from re import fullmatch
-from ocrd_utils import REGEX_PREFIX, getLogger
+from ocrd_utils import REGEX_PREFIX, getLogger, is_local_filename, equals_or_regex_matches
+from .constants import NAMESPACES as NS
+from .ocrd_file import OcrdFile
 
 LOG = getLogger('ocrd.models.ocrd_mets_filter')
 
-FIELDS = ['fileGrp', 'pageId', 'mimetype', 'ID']
+FIELDS = ['fileGrp', 'pageId', 'mimetype', 'ID', 'url']
 FIELDS_INCLUDE = ['%s_include' % f for f in FIELDS]
 FIELDS_EXCLUDE = ['%s_exclude' % f for f in FIELDS]
 SYNONYMS = {
@@ -14,21 +16,56 @@ SYNONYMS = {
     'id': 'ID',
     'file_id': 'ID',
 }
+SELECTORS = {
+    'ID': lambda el: el.get('ID'),
+    'fileGrp': lambda el: el.getparent().get('USE'),
+    'mimetype': lambda el: el.get('MIMETYPE') or '',
+    'ID': lambda el: el.get('ID'),
+    'url': lambda el: el.find('mets:FLocat', namespaces=NS).get('{%s}href' % NS['xlink']),
+}
 
 class OcrdMetsFilter():
     """
     Define file restrictions on mets:files
+
+    The ``ID``, ``fileGrp``, ``url`` and ``mimetype`` parameters as well as
+    thei ``${field}_exclude`` counterparts can be either a literal string or a
+    regular expression (regex) or a list of either. A regex starts with ``//``
+    (double slash). If it is a regex, the leading ``//`` is removed and
+    candidates are matched against the regex with ``re.fullmatch``. If it is a
+    literal string, comparison is done with string equality. 
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, local_only=False, **kwargs):
+        """
+
+        Args:
+            ID (string|list) : ID(s) to include
+            fileGrp (string|list) : fileGrp USE(s) to include
+            pageId (string|list) : ID(s) of physical page(s) to include
+            url (string|list) : FLocat/@xlink:href(s) to include
+            mimetype (string|list) : MIMETYPE(s) to include
+            ID_exclude (string|list) : ID(s) to exclude
+            fileGrp_exclude (string|list) : fileGrp USE(s) to exclude
+            pageId_exclude (string|list) : ID(s) of physical page(s) to exclude
+            url_exclude (string|list) : FLocat/@xlink:href(s) to exclude
+            mimetype_exclude (string|list) : MIMETYPE(s) to exclude
+            local_only (boolean) : Whether to restrict results to local files
+        """
+        self.local_only = local_only
         for attr in FIELDS_INCLUDE + FIELDS_EXCLUDE:
             setattr(self, attr, None)
-        for k in kwargs:
-            field, include_or_exclude = k.split('_', 2) if k.endswith('clude') else (k, 'include')
+        for k, val in kwargs.items():
+            field, op = k.rsplit('_', 2) if k.endswith('clude') else (k, 'include')
             field = SYNONYMS.get(field, field)
+            LOG.debug('k=%s field=%s op=%s val=%s', k, field, op, val)
             if field not in FIELDS:
                 raise ValueError("Unrecognized filter option: %s" % k)
-            setattr(self, '%s_%s' % (field, include_or_exclude), kwargs[k])
+            setattr(self, '%s_%s' % (field, op), val)
+            # pylint: disable=no-member
+            if (isinstance(self.pageId_include, str) and self.pageId_include.startswith(REGEX_PREFIX)) or \
+                (isinstance(self.pageId_include, list) and any([x.startswith(REGEX_PREFIX) for x in self.pageId_include])):
+                raise Exception("OcrdMetsFilter does not support regex search for pageId")
 
     def __str__(self):
         ret = []
@@ -39,43 +76,79 @@ class OcrdMetsFilter():
                 ret.append('%s!=%s' % (field, getattr(self, FIELDS_EXCLUDE[n])))
         return 'OcrdMetsFilter(%s)' % (' and '.join(ret))
 
-    def _equals_or_regex_matches(self, val, needle):
-        # XXX string comparison only
-        val = str(val)
-        if needle.startswith(REGEX_PREFIX):
-            return fullmatch(needle[len(REGEX_PREFIX):], val)
-        return val == needle
-
-    def _file_is_excluded(self, ocrd_file):
+    def _file_is_excluded(self, f):
+        # If only local resources should be returned and f is not a file path: skip the file
+        if self.local_only and not is_local_filename(f.url):
+            return True
         for n, field in enumerate(FIELDS):
+            val = getattr(f, field)
             needle = getattr(self, FIELDS_EXCLUDE[n])
-            if not needle:
+            # print('val=%s needle=%s' % (val, needle))
+            if not needle or not val:
                 continue
-            val = getattr(ocrd_file, field)
-            if not val:
-                continue
-            if isinstance(needle, list):
-                if any(self._equals_or_regex_matches(val, k) for k in needle):
-                    return True
-            else:
-                if self._equals_or_regex_matches(val, needle):
-                    return True
+            if equals_or_regex_matches(val, needle):
+                return True
+
+    # pylint: disable=no-member
+    def _file_is_included(self, cand, by_page_id=None):
+        # LOG.debug('enter _file_is_included cand=%s by_page_id=%s', cand, by_page_id)
+        ID = SELECTORS['ID'](cand)
+        if self.ID_include:
+            LOG.debug('ID=%s', equals_or_regex_matches(ID, self.ID_include))
+            if not equals_or_regex_matches(ID, self.ID_include):
+                return
+        if by_page_id is not None and ID not in by_page_id:
+            return
+        fileGrp = SELECTORS['fileGrp'](cand)
+        if self.fileGrp_include:
+            if not equals_or_regex_matches(fileGrp, self.fileGrp_include):
+                return
+        mimetype = SELECTORS['mimetype'](cand)
+        if self.mimetype_include:
+            if not equals_or_regex_matches(mimetype, self.mimetype_include):
+                return
+        url = SELECTORS['url'](cand)
+        if self.url_include:
+            if not equals_or_regex_matches(url, self.url_include):
+                return
+        return True
 
     def find_files(self, mets):
         """
-        Translate OcrdMetsFilter into a OcrdMets.find_files query
+        Search ``mets:file`` in this METS document.
 
         Args:
             mets (OcrdMets|Workspace): OcrdMets or Workspace wrapping OcrdMets
         """
         LOG.info('Filtering METS with %s' % self)
+        # XXX: Also support passing an OcrdWorkspace
         if hasattr(mets, 'mets'):
             mets = mets.mets
         files = []
-        include_args = {field:getattr(self, FIELDS_INCLUDE[n]) for n, field in enumerate(FIELDS)}
-        LOG.info("find_files args: %s" % include_args)
-        for ocrd_file in mets.find_files(**include_args):
-            if self._file_is_excluded(ocrd_file):
+
+        # IDs by page
+        by_page_id = None
+        if self.pageId_include:
+            by_page_id = []
+            for page in mets.etree_xpath('//mets:div[@TYPE="page"]'):
+                page_id = page.get('ID')
+                # print(page_id, self.pageId_include)
+                if equals_or_regex_matches(page_id, self.pageId_include):
+                    by_page_id.extend([fptr.get('FILEID') for fptr in mets.etree_findall('mets:fptr', page)])
+
+        # include
+        included = []
+        for cand in mets.etree_xpath('//mets:file'):
+            if not self._file_is_included(cand, by_page_id):
                 continue
-            files.append(ocrd_file)
-        return files
+            f = OcrdFile(cand, mets=mets)
+            included.append(f)
+
+        # exclude
+        ret = []
+        for f in included:
+            if self._file_is_excluded(f):
+                continue
+            ret.append(f)
+
+        return ret

--- a/ocrd_models/ocrd_models/ocrd_mets_filter.py
+++ b/ocrd_models/ocrd_models/ocrd_mets_filter.py
@@ -1,0 +1,81 @@
+from re import fullmatch
+from ocrd_utils import REGEX_PREFIX, getLogger
+
+LOG = getLogger('ocrd.models.ocrd_mets_filter')
+
+FIELDS = ['fileGrp', 'pageId', 'mimetype', 'ID']
+FIELDS_INCLUDE = ['%s_include' % f for f in FIELDS]
+FIELDS_EXCLUDE = ['%s_exclude' % f for f in FIELDS]
+SYNONYMS = {
+    'filegrp': 'fileGrp',
+    'file_grp': 'fileGrp',
+    'pageid': 'pageId',
+    'page_id': 'pageId',
+    'id': 'ID',
+    'file_id': 'ID',
+}
+
+class OcrdMetsFilter():
+    """
+    Define file restrictions on mets:files
+    """
+
+    def __init__(self, **kwargs):
+        for attr in FIELDS_INCLUDE + FIELDS_EXCLUDE:
+            setattr(self, attr, None)
+        for k in kwargs:
+            field, include_or_exclude = k.split('_', 2) if k.endswith('clude') else (k, 'include')
+            field = SYNONYMS.get(field, field)
+            if field not in FIELDS:
+                raise ValueError("Unrecognized filter option: %s" % k)
+            setattr(self, '%s_%s' % (field, include_or_exclude), kwargs[k])
+
+    def __str__(self):
+        ret = []
+        for n, field in enumerate(FIELDS):
+            if getattr(self, FIELDS_INCLUDE[n]):
+                ret.append('%s==%s' % (field, getattr(self, FIELDS_INCLUDE[n])))
+            if getattr(self, FIELDS_EXCLUDE[n]):
+                ret.append('%s!=%s' % (field, getattr(self, FIELDS_EXCLUDE[n])))
+        return 'OcrdMetsFilter(%s)' % (' and '.join(ret))
+
+    def _equals_or_regex_matches(self, val, needle):
+        # XXX string comparison only
+        val = str(val)
+        if needle.startswith(REGEX_PREFIX):
+            return fullmatch(needle[len(REGEX_PREFIX):], val)
+        return val == needle
+
+    def _file_is_excluded(self, ocrd_file):
+        for n, field in enumerate(FIELDS):
+            needle = getattr(self, FIELDS_EXCLUDE[n])
+            if not needle:
+                continue
+            val = getattr(ocrd_file, field)
+            if not val:
+                continue
+            if isinstance(needle, list):
+                if any(self._equals_or_regex_matches(val, k) for k in needle):
+                    return True
+            else:
+                if self._equals_or_regex_matches(val, needle):
+                    return True
+
+    def find_files(self, mets):
+        """
+        Translate OcrdMetsFilter into a OcrdMets.find_files query
+
+        Args:
+            mets (OcrdMets|Workspace): OcrdMets or Workspace wrapping OcrdMets
+        """
+        LOG.info('Filtering METS with %s' % self)
+        if hasattr(mets, 'mets'):
+            mets = mets.mets
+        files = []
+        include_args = {field:getattr(self, FIELDS_INCLUDE[n]) for n, field in enumerate(FIELDS)}
+        LOG.info("find_files args: %s" % include_args)
+        for ocrd_file in mets.find_files(**include_args):
+            if self._file_is_excluded(ocrd_file):
+                continue
+            files.append(ocrd_file)
+        return files

--- a/ocrd_models/ocrd_models/ocrd_xml_base.py
+++ b/ocrd_models/ocrd_models/ocrd_xml_base.py
@@ -4,12 +4,12 @@ Base class for XML documents loaded from either content or filename.
 from os.path import exists
 from lxml import etree as ET
 
-from .constants import NAMESPACES
+from .constants import NAMESPACES as NS
 from .utils import xmllint_format
 
 
-for curie in NAMESPACES:
-    ET.register_namespace(curie, NAMESPACES[curie])
+for curie in NS:
+    ET.register_namespace(curie, NS[curie])
 
 class OcrdXmlDocument():
     """
@@ -25,7 +25,7 @@ class OcrdXmlDocument():
         #  print(self, filename, content)
         if filename is None and content is None:
             raise Exception("Must pass 'filename' or 'content' to " + self.__class__.__name__)
-        elif content:
+        if content:
             self._tree = ET.ElementTree(ET.XML(content, parser=ET.XMLParser(encoding='utf-8')))
         else:
             self._tree = ET.ElementTree()
@@ -34,6 +34,31 @@ class OcrdXmlDocument():
                 raise Exception('File does not exist: %s' % filename)
             self._tree.parse(filename)
 
+    @property
+    def etree_root(self):
+        """
+        Return root element
+        """
+        return self._tree.getroot()
+
+    def etree_xpath(self, xpath, el=None):
+        """
+        ET.xpath from ``el`` or root element
+        """
+        return (el if el else self.etree_root).xpath(xpath, namespaces=NS)
+
+    def etree_find(self, xpath, el=None):
+        """
+        ET.find from ``el`` or root element
+        """
+        return (el if el else self.etree_root).find(xpath, namespaces=NS)
+
+    def etree_findall(self, xpath, el=None):
+        """
+        ET.findall from ``el`` or root elemen
+        """
+        return (el if el else self.etree_root).findall(xpath, namespaces=NS)
+
     def to_xml(self, xmllint=False):
         """
         Serialize all properties as pretty-printed XML
@@ -41,8 +66,7 @@ class OcrdXmlDocument():
         Args:
             xmllint (boolean): Format with ``xmllint`` in addition to pretty-printing
         """
-        root = self._tree.getroot()
-        ret = ET.tostring(ET.ElementTree(root), pretty_print=True, encoding='UTF-8')
+        ret = ET.tostring(ET.ElementTree(self.etree_root), pretty_print=True, encoding='UTF-8')
         if xmllint:
             ret = xmllint_format(ret)
         return ret

--- a/ocrd_models/ocrd_models/ocrd_xml_base.py
+++ b/ocrd_models/ocrd_models/ocrd_xml_base.py
@@ -45,19 +45,19 @@ class OcrdXmlDocument():
         """
         ET.xpath from ``el`` or root element
         """
-        return (el if el else self.etree_root).xpath(xpath, namespaces=NS)
+        return (el if el is not None else self.etree_root).xpath(xpath, namespaces=NS)
 
     def etree_find(self, xpath, el=None):
         """
         ET.find from ``el`` or root element
         """
-        return (el if el else self.etree_root).find(xpath, namespaces=NS)
+        return (el if el is not None else self.etree_root).find(xpath, namespaces=NS)
 
     def etree_findall(self, xpath, el=None):
         """
         ET.findall from ``el`` or root elemen
         """
-        return (el if el else self.etree_root).findall(xpath, namespaces=NS)
+        return (el if el is not None else self.etree_root).findall(xpath, namespaces=NS)
 
     def to_xml(self, xmllint=False):
         """

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -131,6 +131,7 @@ from .os import (
 from .str import (
     assert_file_grp_cardinality,
     concat_padded,
+    equals_or_regex_matches,
     get_local_filename,
     is_local_filename,
     is_string,

--- a/ocrd_utils/ocrd_utils/str.py
+++ b/ocrd_utils/ocrd_utils/str.py
@@ -4,10 +4,12 @@ Utility functions for strings, paths and URL.
 
 import re
 import json
+from .constants import REGEX_PREFIX
 
 __all__ = [
     'assert_file_grp_cardinality',
     'concat_padded',
+    'equals_or_regex_matches',
     'get_local_filename',
     'is_local_filename',
     'is_string',
@@ -172,4 +174,19 @@ def safe_filename(url):
     ret = re.sub('[^A-Za-z0-9]+', '.', url)
     #  print('safe filename: %s -> %s' % (url, ret))
     return ret
+
+def equals_or_regex_matches_recursive(val, needle):
+    # XXX string comparison only
+    val = str(val)
+    if needle.startswith(REGEX_PREFIX):
+        return re.fullmatch(needle[len(REGEX_PREFIX):], val)
+    return val == needle
+
+def equals_or_regex_matches(val, needle):
+    if isinstance(needle, list):
+        if any(equals_or_regex_matches_recursive(val, k) for k in needle):
+            return True
+    else:
+        if equals_or_regex_matches_recursive(val, needle):
+            return True
 

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -361,11 +361,12 @@ class TestCli(TestCase):
 
     def test_find_files_multiple_physical_pages_for_fileids(self):
         with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
-            result = self.runner.invoke(workspace_cli, ['-d', tempdir, 'find', '--page-id', 'PHYS_0005,PHYS_0005', '-k', 'url'])
-            self.assertEqual(result.stdout, 'OCR-D-IMG/FILE_0005_IMAGE.tif\n')
-            self.assertEqual(result.exit_code, 0)
-            result = self.runner.invoke(workspace_cli, ['-d', tempdir, 'find', '--page-id', 'PHYS_0005,PHYS_0001', '-k', 'url'])
-            self.assertEqual(len(result.stdout.split('\n')), 19)
+            code, out, err = self.invoke_cli(workspace_cli, ['-d', tempdir, 'find', '--page-id', 'PHYS_0005,PHYS_0005', '-k', 'url'])
+            print(code, out, err)
+            assert out == 'OCR-D-IMG/FILE_0005_IMAGE.tif\n'
+            assert not code
+            _, out, _ = self.invoke_cli(workspace_cli, ['-d', tempdir, 'find', '--page-id', 'PHYS_0005,PHYS_0001', '-k', 'url'])
+            self.assertEqual(len(out.split('\n')), 19)
 
     def test_mets_basename(self):
         with TemporaryDirectory() as tempdir:

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -47,18 +47,22 @@ class TestOcrdMets(TestCase):
     def test_file_groups(self):
         self.assertEqual(len(self.mets.file_groups), 17, '17 file groups')
 
-    def test_find_files(self):
+    def test_find_files_basic(self):
         self.assertEqual(len(self.mets.find_files()), 35, '35 files total')
         self.assertEqual(len(self.mets.find_files(fileGrp='OCR-D-IMG')), 3, '3 files in "OCR-D-IMG"')
         self.assertEqual(len(self.mets.find_files(fileGrp='//OCR-D-I.*')), 13, '13 files in "//OCR-D-I.*"')
         self.assertEqual(len(self.mets.find_files(ID="FILE_0001_IMAGE")), 1, '1 files with ID "FILE_0001_IMAGE"')
         self.assertEqual(len(self.mets.find_files(ID="//FILE_0005_.*")), 1, '1 files with ID "//FILE_0005_.*"')
-        self.assertEqual(len(self.mets.find_files(pageId='PHYS_0001')), 17, '17 files for page "PHYS_0001"')
-        self.assertEqual(len(self.mets.find_files(pageId='PHYS_0001-NOTEXIST')), 0, '0 pages for "PHYS_0001-NOTEXIST"')
         self.assertEqual(len(self.mets.find_files(mimetype='image/tiff')), 13, '13 image/tiff')
         self.assertEqual(len(self.mets.find_files(mimetype='//application/.*')), 22, '22 application/.*')
         self.assertEqual(len(self.mets.find_files(mimetype=MIMETYPE_PAGE)), 20, '20 ' + MIMETYPE_PAGE)
         self.assertEqual(len(self.mets.find_files(url='OCR-D-IMG/FILE_0005_IMAGE.tif')), 1, '1 xlink:href="OCR-D-IMG/FILE_0005_IMAGE.tif"')
+
+    def test_find_files_pageid(self):
+        self.assertEqual(len(self.mets.find_files(pageId='PHYS_0001')), 17, '17 files for page "PHYS_0001"')
+
+    def test_find_files_pageid_notexist(self):
+        self.assertEqual(len(self.mets.find_files(pageId='PHYS_0001-NOTEXIST')), 0, '0 pages for "PHYS_0001-NOTEXIST"')
 
     def test_find_files_no_regex_for_pageid(self):
         with self.assertRaisesRegex(Exception, "not support regex search for pageId"):
@@ -233,4 +237,4 @@ class TestOcrdMets(TestCase):
             self.assertEqual(len(mets.find_files()), 31)
 
 if __name__ == '__main__':
-    main()
+    main(__file__)

--- a/tests/model/test_ocrd_mets_filter.py
+++ b/tests/model/test_ocrd_mets_filter.py
@@ -7,7 +7,7 @@ from tests.base import main
 
 from ocrd import Resolver
 from ocrd_models import OcrdMetsFilter
-from ocrd_utils import setOverrideLogLevel; setOverrideLogLevel('DEBUG')
+# from ocrd_utils import setOverrideLogLevel; setOverrideLogLevel('DEBUG')
 
 @fixture(name="sample_workspace")
 def fixture_sample_workspace(tmpdir):

--- a/tests/model/test_ocrd_mets_filter.py
+++ b/tests/model/test_ocrd_mets_filter.py
@@ -1,0 +1,73 @@
+from unittest import mock
+from pytest import fixture, raises
+from shutil import copy
+from os.path import join, dirname
+
+from tests.base import main
+
+from ocrd import Resolver
+from ocrd_models import OcrdMetsFilter
+
+@fixture(name="sample_workspace")
+def fixture_sample_workspace(tmpdir):
+    resolver = Resolver()
+    ws = resolver.workspace_from_nothing(str(tmpdir))
+    ws.add_file('GRP1', mimetype='image/tiff', ID='GRP1_IMG1', pageId='PHYS_0001')
+    ws.add_file('GRP1', mimetype='image/png', ID='GRP1_IMG2', pageId='PHYS_0002')
+    ws.add_file('GRP2', mimetype='image/tiff', ID='GRP2_IMG1', pageId='PHYS_0001')
+    ws.add_file('GRP2', mimetype='image/png', ID='GRP2_IMG2', pageId='PHYS_0002')
+    ws.add_file('GRP3', mimetype='image/tiff', ID='GRP3_IMG1', pageId='PHYS_0001')
+    ws.add_file('GRP3', mimetype='image/png', ID='GRP3_IMG2', pageId='PHYS_0002')
+    return ws
+
+def test_ocrd_mets_filter_noarg(sample_workspace):
+    """Test w/o arguments"""
+    mets_filter = OcrdMetsFilter()
+    files = mets_filter.find_files(sample_workspace)
+    assert len(files) == 6
+
+def test_ocrd_mets_filter_bad_arg(sample_workspace):
+    """Test unknown field"""
+    with raises(ValueError):
+        OcrdMetsFilter(foo_include='baz')
+
+def test_ocrd_mets_filter_basic(sample_workspace):
+    """Test basic filtering"""
+    mets_filter = OcrdMetsFilter(mimetype_include='image/tiff', fileGrp_exclude=['GRP2'])
+    files = mets_filter.find_files(sample_workspace)
+    assert len(files) == 2
+
+def test_ocrd_mets_filter_regex(sample_workspace):
+    """Test filtering by regex"""
+    mets_filter = OcrdMetsFilter(mimetype_include='image/tiff', fileGrp_exclude='//[GH][rR]P[2-3].*')
+    files = mets_filter.find_files(sample_workspace)
+    assert len(files) == 1
+
+def test_ocrd_mets_filter_complex(sample_workspace):
+    """Test complex arguments"""
+    mets_filter = OcrdMetsFilter(ID_include='//GRP._IMG[0-9]', pageId_include='PHYS_0002', ID_exclude=['GRP1_IMG2'])
+    files = mets_filter.find_files(sample_workspace)
+    assert len(files) == 2
+
+def test_ocrd_mets_filter_nested_regex(sample_workspace):
+    """//-prefixed elements in exclude list"""
+    mets_filter = OcrdMetsFilter(mimetype_include='image/tiff', ID_exclude=['//.R[pP]2.*_IMG1'])
+    files = mets_filter.find_files(sample_workspace)
+    assert len(files) == 2
+
+def test_ocrd_mets_filter_lowercase(sample_workspace):
+    """lowercase alternatives should be accepted"""
+    # from ocrd_utils import setOverrideLogLevel; setOverrideLogLevel('DEBUG')
+    mets_filter = OcrdMetsFilter(pageid_exclude='//.*1', ID_exclude='GRP1_IMG2')
+    files = mets_filter.find_files(sample_workspace)
+    # print([str(f) for f  in files])
+    assert len(files) == 2
+
+def test_ocrd_mets_filter_include_aliases(sample_workspace):
+    """field without _ implies field_include"""
+    mets_filter = OcrdMetsFilter(pageid='PHYS_0001', ID='GRP1_IMG1')
+    files = mets_filter.find_files(sample_workspace)
+    assert len(files) == 1
+
+if __name__ == '__main__':
+    main(__file__)

--- a/tests/model/test_ocrd_mets_filter.py
+++ b/tests/model/test_ocrd_mets_filter.py
@@ -7,6 +7,7 @@ from tests.base import main
 
 from ocrd import Resolver
 from ocrd_models import OcrdMetsFilter
+from ocrd_utils import setOverrideLogLevel; setOverrideLogLevel('DEBUG')
 
 @fixture(name="sample_workspace")
 def fixture_sample_workspace(tmpdir):
@@ -57,11 +58,10 @@ def test_ocrd_mets_filter_nested_regex(sample_workspace):
 
 def test_ocrd_mets_filter_lowercase(sample_workspace):
     """lowercase alternatives should be accepted"""
-    # from ocrd_utils import setOverrideLogLevel; setOverrideLogLevel('DEBUG')
-    mets_filter = OcrdMetsFilter(pageid_exclude='//.*1', ID_exclude='GRP1_IMG2')
+    mets_filter = OcrdMetsFilter(filegrp_exclude='GRP3', ID_exclude='GRP1_IMG2')
     files = mets_filter.find_files(sample_workspace)
     # print([str(f) for f  in files])
-    assert len(files) == 2
+    assert len(files) == 3
 
 def test_ocrd_mets_filter_include_aliases(sample_workspace):
     """field without _ implies field_include"""


### PR DESCRIPTION
* New class `OcrdMetsFilter`  in `ocrd_models` that represents restrictions on files (include/exclude by fileGrp, mimetype currently)
* `ocrd workspace clone` supports
  * `--fileGrp-include`
  * `--fileGrp-exclude`
  * `--mimetype-include`
  * `--mimetype-exclude`

Proposed by @bertsky  in #506

<del>This is a very rushed implementation because we need this feature now.,</del> Implementation has been improved now.