### PR TITLE
ocrd process: stdout/stderr as strings, not bytes

### DIFF
--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -118,7 +118,7 @@ def run_cli(
         args += ['--overwrite']
     log.debug("Running subprocess '%s'", ' '.join(args))
     result = run(args, check=False, stdout=PIPE, stderr=PIPE)
-    return result.returncode, result.stdout, result.stderr
+    return result.returncode, result.stdout.decode('utf-8'), result.stderr.decode('utf-8')
 
 def generate_processor_help(ocrd_tool):
     parameter_help = ''

--- a/ocrd/ocrd/task_sequence.py
+++ b/ocrd/ocrd/task_sequence.py
@@ -2,7 +2,6 @@ import json
 from shlex import split as shlex_split
 from distutils.spawn import find_executable as which # pylint: disable=import-error,no-name-in-module
 from subprocess import run, PIPE
-from collections import Counter
 
 from ocrd_utils import getLogger, parse_json_string_or_file, set_json_key_value_overrides
 # from collections import Counter
@@ -87,9 +86,6 @@ class ProcessorTask():
         if self.parameters:
             ret += " -p '%s'" % json.dumps(self.parameters)
         return ret
-from ocrd_validators import WorkspaceValidator
-from ocrd_utils import getLogger
-from ocrd_models import ValidationReport
 
 def validate_tasks(tasks, workspace, page_id=None, overwrite=False):
     report = ValidationReport()


### PR DESCRIPTION
If a task in `ocrd process` fails, STDOUT/STDERR are printed as bytes, when they should be decoded to a string.