### PR TITLE
Bugfix/workspace remove groups

### DIFF
--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -193,7 +193,7 @@ class Workspace():
                 self.remove_file(f, force=force, keep_file=keep_files, page_recursive=page_recursive, page_same_group=page_same_group)
                 file_dirs.append(path.dirname(f.local_filename))
 
-        self.mets.remove_file_group(USE)
+        self.mets.remove_file_group(USE, force=force)
 
         # PLEASE NOTE: this only removes directories in the workspace if they are empty
         # and named after the fileGrp which is a convention in OCR-D.

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -1,5 +1,5 @@
 import io
-from os import makedirs, unlink, listdir
+from os import makedirs, unlink, listdir, path
 from pathlib import Path
 
 import cv2
@@ -29,7 +29,8 @@ from ocrd_utils import (
     pushd_popd,
     MIME_TO_EXT,
     MIME_TO_PIL,
-    MIMETYPE_PAGE
+    MIMETYPE_PAGE,
+    REGEX_PREFIX
 )
 
 from .workspace_backup import WorkspaceBackupManager
@@ -182,18 +183,28 @@ class Workspace():
         """
         if not force and self.overwrite_mode:
             force = True
-        if USE not in self.mets.file_groups and not force:
+            
+        if (not USE.startswith(REGEX_PREFIX)) and (USE not in self.mets.file_groups) and (not force):
             raise Exception("No such fileGrp: %s" % USE)
+        
+        file_dirs = []
         if recursive:
             for f in self.mets.find_files(fileGrp=USE):
                 self.remove_file(f, force=force, keep_file=keep_files, page_recursive=page_recursive, page_same_group=page_same_group)
-        if USE in self.mets.file_groups:
-            self.mets.remove_file_group(USE)
-        # XXX this only removes directories in the workspace if they are empty
+                file_dirs.append(path.dirname(f.local_filename))
+
+        self.mets.remove_file_group(USE)
+
+        # PLEASE NOTE: this only removes directories in the workspace if they are empty
         # and named after the fileGrp which is a convention in OCR-D.
         with pushd_popd(self.directory):
             if Path(USE).is_dir() and not listdir(USE):
                 Path(USE).rmdir()
+            if file_dirs:
+                for file_dir in set(file_dirs):
+                    if Path(file_dir).is_dir() and not listdir(file_dir):
+                        Path(file_dir).rmdir()
+
 
     def add_file(self, file_grp, content=None, **kwargs):
         """

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -204,13 +204,14 @@ class OcrdMets(OcrdXmlDocument):
             el_fileGrp.set('USE', fileGrp)
         return el_fileGrp
 
-    def remove_file_group(self, USE, recursive=False):
+    def remove_file_group(self, USE, recursive=False, force=False):
         """
         Remove a fileGrp (fixed ``USE``) or fileGrps (regex ``USE``)
 
         Arguments:
             USE (string): USE attribute of the fileGrp to delete. Can be a regex if prefixed with //
             recursive (boolean): Whether to recursively delete all files in the group
+            force (boolean): Do not raise an exception if file group doesn't exist
         """
         el_fileSec = self._tree.getroot().find('mets:fileSec', NS)
         if el_fileSec is None:
@@ -226,7 +227,11 @@ class OcrdMets(OcrdXmlDocument):
         else:
             el_fileGrp = USE
         if el_fileGrp is None:   # pylint: disable=len-as-condition
-            raise Exception("No such fileGrp: %s" % USE)
+            msg = "No such fileGrp: %s" % USE
+            if force:
+                log.warning(msg)
+                return
+            raise Exception(msg)
         files = el_fileGrp.findall('mets:file', NS)
         if files:
             if not recursive:

--- a/tests/test_workspace_remove.py
+++ b/tests/test_workspace_remove.py
@@ -4,6 +4,7 @@ import os
 import shutil
 
 import lxml.etree as ET
+from tests.base import main
 
 import pytest
 
@@ -28,7 +29,7 @@ def test_workspace_init_missing_mets():
 @pytest.fixture(name="workspace_directory")
 def fixture_workspace_directory(tmpdir):
     src_data_kant = './tests/assets/kant_aufklaerung_1784/data'
-    target_data_kant = tmpdir.join('kant_aufklaerung_1784').join('data')
+    target_data_kant = str(tmpdir.join('kant_aufklaerung_1784').join('data'))
     shutil.copytree(src_data_kant, target_data_kant)
     return str(target_data_kant)
 
@@ -79,6 +80,9 @@ def test_workspace_remove_groups_unforce(workspace_directory):
 
     # assert
     written_data = ET.parse(os.path.join(workspace_directory, 'mets.xml')).getroot()
-    assert written_data
+    assert written_data is not None
     groups_new = written_data.findall('.//{http://www.loc.gov/METS/}fileGrp[@USE="OCR-D-GT-ALTO"]')
     assert not groups_new
+
+if __name__ == '__main__':
+    main(__file__)

--- a/tests/test_workspace_remove.py
+++ b/tests/test_workspace_remove.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+import os
+import shutil
+
+import lxml.etree as ET
+
+import pytest
+
+from ocrd.resolver import (
+    Resolver
+)
+
+from ocrd.workspace import (
+    Workspace
+)
+
+
+def test_workspace_init_missing_mets():
+    """Raise Exception when missing mets-file in workspace"""
+
+    with pytest.raises(Exception) as exc:
+        Workspace(Resolver(), "foo/bar")
+
+    assert "File does not exist" in str(exc.value)
+
+
+@pytest.fixture(name="workspace_directory")
+def fixture_workspace_directory(tmpdir):
+    src_data_kant = './tests/assets/kant_aufklaerung_1784/data'
+    target_data_kant = tmpdir.join('kant_aufklaerung_1784').join('data')
+    shutil.copytree(src_data_kant, target_data_kant)
+    return str(target_data_kant)
+
+
+def test_workspace_remove_group_not_found(workspace_directory):
+    """Group identified by name not found raises exception"""
+
+    resolver = Resolver()
+    workspace = Workspace(resolver, workspace_directory)
+    with pytest.raises(Exception) as exc:
+        workspace.remove_file_group('FOO-BAR')
+
+    assert "No such fileGrp" in str(exc)
+
+
+def test_workspace_remove_single_group_recursive(workspace_directory):
+    """Remove single group recursive by name succeeds"""
+
+    # arrange
+    resolver = Resolver()
+    workspace = Workspace(resolver, workspace_directory)
+    files = workspace.mets.find_files(fileGrp='OCR-D-GT-ALTO')
+    assert len(files) == 2
+
+    # act
+    workspace.remove_file_group('OCR-D-GT-ALTO', recursive=True)
+
+    # assert
+    files = workspace.mets.find_files(fileGrp='OCR-D-GT-ALTO')
+    assert len(files) == 0
+
+
+def test_workspace_remove_groups_unforce(workspace_directory):
+    """Remove groups by pattern recursive"""
+
+    # arrange
+    original_data = ET.parse(os.path.join(workspace_directory, 'mets.xml')).getroot()
+    alto_groups = original_data.findall('.//{http://www.loc.gov/METS/}fileGrp[@USE="OCR-D-GT-ALTO"]')
+    assert len(alto_groups) == 1
+    altos = alto_groups[0].findall('.//{http://www.loc.gov/METS/}file')
+    assert len(altos) == 2
+
+    # act
+    resolver = Resolver()
+    workspace = Workspace(resolver, workspace_directory)
+    workspace.remove_file_group('//OCR-D-GT.*', recursive=True)
+    workspace.save_mets()
+
+    # assert
+    written_data = ET.parse(os.path.join(workspace_directory, 'mets.xml')).getroot()
+    assert written_data
+    groups_new = written_data.findall('.//{http://www.loc.gov/METS/}fileGrp[@USE="OCR-D-GT-ALTO"]')
+    assert not groups_new


### PR DESCRIPTION
This is an approach to handle https://github.com/OCR-D/core/issues/569

The new implementation makes existing test case `TestWorkspace.test_remove_file_group_force` fail, but IMHO this one is to be discussed.
