### PR TITLE
show help for no-arg processor calls, fix #562, fix #274

### DIFF
--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -30,6 +30,11 @@ def ocrd_cli_wrap_processor(
     overwrite=False,
     **kwargs
 ):
+    if not (dump_json or help or version or overwrite) and \
+            mets == 'mets.xml' and \
+            not (kwargs['input_file_grp'] or kwargs['output_file_grp']):
+        processorClass(workspace=None, show_help=True)
+        sys.exit(1)
     if dump_json or help or version:
         processorClass(workspace=None, dump_json=dump_json, show_help=help, show_version=version)
         sys.exit()

--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -30,9 +30,7 @@ def ocrd_cli_wrap_processor(
     overwrite=False,
     **kwargs
 ):
-    if not (dump_json or help or version or overwrite) and \
-            mets == 'mets.xml' and \
-            not (kwargs['input_file_grp'] or kwargs['output_file_grp']):
+    if not sys.argv[1:]:
         processorClass(workspace=None, show_help=True)
         sys.exit(1)
     if dump_json or help or version:
@@ -40,9 +38,6 @@ def ocrd_cli_wrap_processor(
         sys.exit()
     else:
         LOG = getLogger('ocrd_cli_wrap_processor')
-        if not mets or (is_local_filename(mets) and not isfile(get_local_filename(mets))):
-            processorClass(workspace=None, show_help=True)
-            sys.exit(1)
         initLogging()
         # LOG.info('kwargs=%s' % kwargs)
         # Merge parameter overrides and parameters

--- a/tests/base.py
+++ b/tests/base.py
@@ -45,6 +45,7 @@ class CapturingTestCase(TestCase):
         """
         self.capture_out_err()  # XXX snapshot just before executing the CLI
         code = 0
+        sys.argv[1:] = args # XXX necessary because sys.argv reflects pytest args not cli args
         try:
             cli.main(args=args)
         except SystemExit as e:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -68,7 +68,9 @@ class TestDecorators(TestCase):
         https://github.com/OCR-D/spec/pull/156
         """
         _, out_help, _ = self.invoke_cli(cli_dummy_processor, ['--help'])
-        exit_code, out_none, _ = self.invoke_cli(cli_dummy_processor, [])
+        exit_code, out_none, err = self.invoke_cli(cli_dummy_processor, [])
+        print("exit_code=%s\nout=%s\nerr=%s" % (exit_code, out_none, err))
+        #  assert 0
         self.assertEqual(exit_code, 1)
         self.assertEqual(out_help, out_none)
 


### PR DESCRIPTION
<del>This is a surprisingly tricky-to-implement problem: We want processor calls without any arguments to print the help screen and exit with code `1`, i.e. if `sys.argv[2:] == []`.</del>

It really isn't, it was just hard to test because sys.argv contained the arguments to pytest, not to the CLI. Turns out, sys.argv can be overridden at runtime for the tests and checking `not sys.argv[1:]` was enough

<del>
However, I could not find a way to get the un-procesed command line arguments to click. `get_current_context()` does have an `args` property but that only contains the remaining positional arguments after parsing.

If anyone knows a better way to get the click equivalent of `sys.argv[2:]`, I'd be interested!

For now, I've disabled the defaults for `input_file_grp`/`output_file_grp` (as proposed in https://github.com/OCR-D/core/issues/274) and check for all relevant CLI options one-by-one:

```python
    if not (dump_json or help or version or overwrite) and \
            mets == 'mets.xml' and \
            not (kwargs['input_file_grp'] or kwargs['output_file_grp']):
        processorClass(workspace=None, show_help=True)
        sys.exit(1)
```

As I said before, I would prefer a more robust solution. The clause above will also trigger for processors being called with `--mets mets.xml` but neither input nor output file group (such as the ocrd-sanitize processor...).
</del>