### PR TITLE
remove preceding/trailing after { } when parsing --dump-json

### DIFF
--- a/ocrd/ocrd/task_sequence.py
+++ b/ocrd/ocrd/task_sequence.py
@@ -6,7 +6,7 @@ from collections import Counter
 
 from ocrd_utils import getLogger, parse_json_string_or_file, set_json_key_value_overrides
 # from collections import Counter
-from ocrd.processor.base import run_cli
+from ocrd.processor.helpers import run_cli, run_dump_json
 from ocrd.resolver import Resolver
 from ocrd_validators import ParameterValidator, WorkspaceValidator
 from ocrd_models import ValidationReport
@@ -16,7 +16,9 @@ class ProcessorTask():
     @classmethod
     def parse(cls, argstr):
         tokens = shlex_split(argstr)
-        executable = 'ocrd-%s' % tokens.pop(0)
+        executable = tokens.pop(0)
+        if not executable.startswith('ocrd-'):
+            executable = 'ocrd-' + executable
         input_file_grps = []
         output_file_grps = []
         parameters = {}
@@ -50,8 +52,7 @@ class ProcessorTask():
     def ocrd_tool_json(self):
         if self._ocrd_tool_json:
             return self._ocrd_tool_json
-        result = run([self.executable, '--dump-json'], stdout=PIPE, check=True, universal_newlines=True)
-        self._ocrd_tool_json = json.loads(result.stdout)
+        self._ocrd_tool_json = run_dump_json(self.executable)
         return self._ocrd_tool_json
 
     def validate(self):

--- a/tests/data/wf_testcase.py
+++ b/tests/data/wf_testcase.py
@@ -24,13 +24,19 @@ SAMPLE_OCRD_TOOL_JSON = '''{
     }
 }'''
 
-SAMPLE_NAME_REQUIRED_PARAM = 'sample-processor-required-param'
+SAMPLE_NAME_REQUIRED_PARAM = SAMPLE_NAME + '-required-param'
 SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM = json.loads(SAMPLE_OCRD_TOOL_JSON)
 del SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM['parameters']['param1']['default']
-SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM['executable'] = 'ocrd-' + SAMPLE_NAME_REQUIRED_PARAM
+SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM['executable'] = SAMPLE_NAME_REQUIRED_PARAM
 SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM['parameters']['param1']['required'] = True
 SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM['input_file_grp'] += ['SECOND_IN']
 SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM = json.dumps(SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM)
+print(SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM)
+
+SAMPLE_NAME_TOO_VERBOSE = SAMPLE_NAME + '-too-verbose'
+SAMPLE_OCRD_TOOL_JSON_TOO_VERBOSE = json.loads(SAMPLE_OCRD_TOOL_JSON)
+SAMPLE_OCRD_TOOL_JSON_TOO_VERBOSE['executable'] = SAMPLE_NAME_TOO_VERBOSE
+SAMPLE_OCRD_TOOL_JSON_TOO_VERBOSE = json.dumps(SAMPLE_OCRD_TOOL_JSON_TOO_VERBOSE)
 
 PARAM_JSON = '{"foo": 42}'
 
@@ -52,11 +58,20 @@ print('''%s''')
         """ % SAMPLE_OCRD_TOOL_JSON)
         p.chmod(0o777)
 
-        p = Path(self.tempdir, 'ocrd-' + SAMPLE_NAME_REQUIRED_PARAM)
+        p = Path(self.tempdir, SAMPLE_NAME_REQUIRED_PARAM)
         p.write_text("""\
 #!/usr/bin/env python
 print('''%s''')
         """ % SAMPLE_OCRD_TOOL_JSON_REQUIRED_PARAM)
+        p.chmod(0o777)
+
+        p = Path(self.tempdir, SAMPLE_NAME_TOO_VERBOSE)
+        p.write_text("""\
+#!/usr/bin/env python
+print("00 HAHA I'M MESSING WITH YOUR OUTPUT")
+print('''%s''')
+print("11 GOOD LUCK PARSING THIS AS JSON")
+        """ % SAMPLE_OCRD_TOOL_JSON_TOO_VERBOSE)
         p.chmod(0o777)
 
         os.environ['PATH'] = os.pathsep.join([self.tempdir, os.environ['PATH']])

--- a/tests/processor/test_run_dump_json.py
+++ b/tests/processor/test_run_dump_json.py
@@ -1,0 +1,17 @@
+from pytest import main
+from tests.data.wf_testcase import TestCase, SAMPLE_NAME_TOO_VERBOSE
+
+from ocrd.processor.helpers import run_dump_json
+
+class TestProcessorHelperRunDumpJson(TestCase):
+
+    def test_540(self):
+        """
+        https://github.com/OCR-D/core/issues/540
+        https://github.com/OCR-D/core/issues/589
+        """
+        ocrd_tool = run_dump_json(SAMPLE_NAME_TOO_VERBOSE)
+        print(ocrd_tool)
+        assert ocrd_tool['executable'] == SAMPLE_NAME_TOO_VERBOSE
+
+if __name__ == '__main__': main([__file__])

--- a/tests/test_task_sequence.py
+++ b/tests/test_task_sequence.py
@@ -32,7 +32,7 @@ class TestOcrdWfStep(TestCase):
     #     self.assertTrue(task2.validate())
 
     def test_parse_implicit_after_validate(self):
-        task = ProcessorTask.parse('%s -I IN -O OUT -p \'{"param1": true}\'' % SAMPLE_NAME_REQUIRED_PARAM)
+        task = ProcessorTask.parse('%s -I IN -O OUT -P param1 true' % SAMPLE_NAME_REQUIRED_PARAM)
         task.validate()
         # TODO uncomment and adapt once OCR-D/spec#121 lands
         # self.assertEqual(task.input_file_grps, ['IN', 'SECOND_IN'])


### PR DESCRIPTION
Workaround for #540 / #589 

Removes any preceding/trailing content around the expected --dump-json output.