### PR TITLE
avoid module-level initLogging for non-interactive CLI commands

### DIFF
--- a/ocrd/ocrd/cli/log.py
+++ b/ocrd/ocrd/cli/log.py
@@ -2,7 +2,9 @@
 Logging CLI
 """
 import click
-from ocrd_utils import getLogger, getLevelName
+from ocrd_utils import initLogging, getLogger, getLevelName
+
+initLogging()
 
 class LogCtx():
 

--- a/ocrd/ocrd/cli/process.py
+++ b/ocrd/ocrd/cli/process.py
@@ -3,11 +3,12 @@ CLI for task_sequence
 """
 import click
 
-from ocrd_utils import getLogger
+from ocrd_utils import initLogging, getLogger
 from ocrd.task_sequence import run_tasks
 
 from ..decorators import ocrd_loglevel
 
+initLogging()
 
 # ----------------------------------------------------------------------
 # ocrd process

--- a/ocrd/ocrd/cli/validate.py
+++ b/ocrd/ocrd/cli/validate.py
@@ -8,7 +8,8 @@ from ocrd import Resolver, Workspace
 from ocrd.task_sequence import ProcessorTask, validate_tasks
 
 from ocrd_utils import (
-    parse_json_string_or_file
+    parse_json_string_or_file,
+    initLogging
 )
 from ocrd_validators import (
     OcrdToolValidator,
@@ -17,6 +18,8 @@ from ocrd_validators import (
     ParameterValidator,
     WorkspaceValidator,
 )
+
+initLogging()
 
 def _inform_of_result(report):
     if not report.is_valid:

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -9,9 +9,10 @@ import re
 import click
 
 from ocrd import Resolver, Workspace, WorkspaceValidator, WorkspaceBackupManager
-from ocrd_utils import getLogger, pushd_popd, EXT_TO_MIME
+from ocrd_utils import initLogging, getLogger, pushd_popd, EXT_TO_MIME
 from . import command_with_replaced_help
 
+initLogging()
 log = getLogger('ocrd.cli.workspace')
 
 class WorkspaceCtx():

--- a/ocrd/ocrd/cli/zip.py
+++ b/ocrd/ocrd/cli/zip.py
@@ -2,11 +2,14 @@ import sys
 
 import click
 
+from ocrd_utils import initLogging
 from ocrd_validators import OcrdZipValidator
 
 from ..resolver import Resolver
 from ..workspace import Workspace
 from ..workspace_bagger import WorkspaceBagger
+
+initLogging()
 
 @click.group("zip")
 def zip_cli():

--- a/ocrd/ocrd/decorators.py
+++ b/ocrd/ocrd/decorators.py
@@ -11,7 +11,7 @@ from ocrd_utils import (
     set_json_key_value_overrides,
 )
 
-from ocrd_utils import getLogger
+from ocrd_utils import getLogger, initLogging
 from .resolver import Resolver
 from .processor.base import run_processor
 from ocrd_validators import WorkspaceValidator
@@ -52,7 +52,6 @@ def ocrd_cli_wrap_processor(
     **kwargs
 ):
     if dump_json or help or version:
-        setOverrideLogLevel('OFF', silent=True)
         processorClass(workspace=None, dump_json=dump_json, show_help=help, show_version=version)
         sys.exit()
     else:
@@ -60,6 +59,7 @@ def ocrd_cli_wrap_processor(
         if not mets or (is_local_filename(mets) and not isfile(get_local_filename(mets))):
             processorClass(workspace=None, show_help=True)
             sys.exit(1)
+        initLogging()
         # LOG.info('kwargs=%s' % kwargs)
         # Merge parameter overrides and parameters
         if 'parameter_override' in kwargs:

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -129,4 +129,13 @@ def initLogging():
     logging.getLogger('shapely.geos').setLevel(logging.ERROR)
 
 
-initLogging()
+# Initializing stream handlers at module level
+# would cause message output in all runtime contexts,
+# including those which are already run for std output
+# (--dump-json, --version, ocrd-tool, bashlib etc).
+# So this needs to be an opt-in from the CLIs/decorators:
+#initLogging()
+# Also, we even have to block log output for libraries
+# (like matplotlib/tensorflow) which set up logging
+# themselves already:
+logging.basicConfig(level=logging.CRITICAL)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -84,6 +84,8 @@ class TestDecorators(TestCase):
         self.assertEqual(result.exit_code, 0)
 
     # TODO cannot be tested in this way because logging is reused and not part of output
+    # (but perhaps one could use runner.invoke() instead;
+    #  anyway, now calling with non-existing local METS paths will only show the help text)
     # def test_processor_non_existing_mets(self):
     #     code, out, err = self.invoke_cli(cli_dummy_processor, ['-m', 'exist.xml', *DEFAULT_IN_OUT])
     #     print("code=%s\nout=%s\nerr=%s" % (code, out, err))
@@ -186,24 +188,24 @@ class TestDecorators(TestCase):
     def test_parameter_override_basic(self):
         with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
             with pushd_popd(tempdir):
-                result = self.runner.invoke(cli_dummy_processor, [
+                code, out, err = self.invoke_cli(cli_dummy_processor, [
                     '-p', '{"baz": "forty-two"}',
                     '-P', 'baz', 'one',
                     '-P', 'baz', 'two',
                     *DEFAULT_IN_OUT
                 ])
-                print(result)
-                self.assertEqual(result.stdout, '{"baz": "two"}\n')
+                print(out)
+                self.assertEqual(out, '{"baz": "two"}\n')
 
     def test_parameter_override_wo_param(self):
         with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
             with pushd_popd(tempdir):
-                result = self.runner.invoke(cli_dummy_processor, [
+                code, out, err = self.invoke_cli(cli_dummy_processor, [
                     '-P', 'baz', 'two',
                     *DEFAULT_IN_OUT
                 ])
-                print(result)
-                self.assertEqual(result.stdout, '{"baz": "two"}\n')
+                print(out)
+                self.assertEqual(out, '{"baz": "two"}\n')
 
 if __name__ == '__main__':
     main(__file__)


### PR DESCRIPTION
Fix #589 (instead of #591)

This seems to work. Not so sure about the placement of `initLogging()` at the module level of `ocrd.cli.*` though...