### PR TITLE
[rfct] split decorators into topical modules

### DIFF
--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -6,39 +6,18 @@ import click
 from ocrd_utils import (
     is_local_filename,
     get_local_filename,
-    setOverrideLogLevel,
-    parse_json_string_or_file,
     set_json_key_value_overrides,
 )
 
 from ocrd_utils import getLogger, initLogging
-from .resolver import Resolver
-from .processor.base import run_processor
 from ocrd_validators import WorkspaceValidator
 
-def _set_root_logger_version(ctx, param, value):    # pylint: disable=unused-argument
-    setOverrideLogLevel(value)
-    return value
+from ..resolver import Resolver
+from ..processor.base import run_processor
 
-loglevel_option = click.option('-l', '--log-level', help="Log level",
-                               type=click.Choice(['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']),
-                               default=None, callback=_set_root_logger_version)
-
-def _handle_param_option(ctx, param, value):
-    return parse_json_string_or_file(*list(value))
-
-parameter_option = click.option('-p', '--parameter',
-                                help="Parameters, either JSON string or path to JSON file",
-                                multiple=True,
-                                default=['{}'],
-                                callback=_handle_param_option)
-
-parameter_override_option = click.option('-P', '--parameter-override',
-                                help="Parameter override",
-                                nargs=2,
-                                multiple=True,
-                                callback=lambda ctx, param, kv: kv)
-                                # callback=lambda ctx, param, kv: {kv[0]: kv[1]})
+from .loglevel_option import loglevel_option, ocrd_loglevel
+from .parameter_option import parameter_option, parameter_override_option
+from .ocrd_cli_options import ocrd_cli_options
 
 def ocrd_cli_wrap_processor(
     processorClass,
@@ -100,44 +79,3 @@ def ocrd_cli_wrap_processor(
         if not report.is_valid:
             raise Exception("Invalid input/output file grps:\n\t%s" % '\n\t'.join(report.errors))
         run_processor(processorClass, ocrd_tool, mets, workspace=workspace, **kwargs)
-
-def ocrd_loglevel(f):
-    """
-    Add an option '--log-level' to set the log level.
-    """
-    loglevel_option(f)
-    return f
-
-def ocrd_cli_options(f):
-    """
-    Implement MP CLI.
-
-    Usage::
-
-        import ocrd_click_cli from ocrd.utils
-
-        @click.command()
-        @ocrd_click_cli
-        def cli(mets_url):
-            print(mets_url)
-    """
-    params = [
-        click.option('-m', '--mets', help="METS to process", default="mets.xml"),
-        click.option('-w', '--working-dir', help="Working Directory"),
-        # TODO OCR-D/core#274
-        # click.option('-I', '--input-file-grp', help='File group(s) used as input. **required**'),
-        # click.option('-O', '--output-file-grp', help='File group(s) used as output. **required**'),
-        click.option('-I', '--input-file-grp', help='File group(s) used as input.', default='INPUT'),
-        click.option('-O', '--output-file-grp', help='File group(s) used as output.', default='OUTPUT'),
-        click.option('-g', '--page-id', help="ID(s) of the pages to process"),
-        click.option('--overwrite', help="Overwrite the output file group or a page range (--page-id)", is_flag=True, default=False),
-        parameter_option,
-        parameter_override_option,
-        click.option('-J', '--dump-json', help="Dump tool description as JSON and exit", is_flag=True, default=False),
-        loglevel_option,
-        click.option('-V', '--version', help="Show version", is_flag=True, default=False),
-        click.option('-h', '--help', help="This help message", is_flag=True, default=False),
-    ]
-    for param in params:
-        param(f)
-    return f

--- a/ocrd/ocrd/decorators/loglevel_option.py
+++ b/ocrd/ocrd/decorators/loglevel_option.py
@@ -1,0 +1,22 @@
+import click
+from ocrd_utils.logging import setOverrideLogLevel
+
+__all__ = ['loglevel_option', 'ocrd_loglevel']
+
+def _set_root_logger_version(ctx, param, value):    # pylint: disable=unused-argument
+    setOverrideLogLevel(value)
+    return value
+
+loglevel_option = click.option('-l', '--log-level', help="Log level",
+                               type=click.Choice([
+                                   'OFF', 'ERROR', 'WARN',
+                                   'INFO', 'DEBUG', 'TRACE'
+                               ]),
+                               default=None, callback=_set_root_logger_version)
+
+def ocrd_loglevel(f):
+    """
+    Add an option '--log-level' to set the log level.
+    """
+    loglevel_option(f)
+    return f

--- a/ocrd/ocrd/decorators/ocrd_cli_options.py
+++ b/ocrd/ocrd/decorators/ocrd_cli_options.py
@@ -1,0 +1,37 @@
+from click import option
+from .parameter_option import parameter_option, parameter_override_option
+from .loglevel_option import loglevel_option
+
+def ocrd_cli_options(f):
+    """
+    Implement MP CLI.
+
+    Usage::
+
+        import ocrd_click_cli from ocrd.utils
+
+        @click.command()
+        @ocrd_click_cli
+        def cli(mets_url):
+            print(mets_url)
+    """
+    params = [
+        option('-m', '--mets', help="METS to process", default="mets.xml"),
+        option('-w', '--working-dir', help="Working Directory"),
+        # TODO OCR-D/core#274
+        # option('-I', '--input-file-grp', help='File group(s) used as input. **required**'),
+        # option('-O', '--output-file-grp', help='File group(s) used as output. **required**'),
+        option('-I', '--input-file-grp', help='File group(s) used as input.', default='INPUT'),
+        option('-O', '--output-file-grp', help='File group(s) used as output.', default='OUTPUT'),
+        option('-g', '--page-id', help="ID(s) of the pages to process"),
+        option('--overwrite', help="Overwrite the output file group or a page range (--page-id)", is_flag=True, default=False),
+        parameter_option,
+        parameter_override_option,
+        option('-J', '--dump-json', help="Dump tool description as JSON and exit", is_flag=True, default=False),
+        loglevel_option,
+        option('-V', '--version', help="Show version", is_flag=True, default=False),
+        option('-h', '--help', help="This help message", is_flag=True, default=False),
+    ]
+    for param in params:
+        param(f)
+    return f

--- a/ocrd/ocrd/decorators/parameter_option.py
+++ b/ocrd/ocrd/decorators/parameter_option.py
@@ -1,0 +1,21 @@
+from click import option
+from ocrd_utils import parse_json_string_or_file
+
+__all__ = ['parameter_option', 'parameter_override_option']
+
+
+def _handle_param_option(ctx, param, value):
+    return parse_json_string_or_file(*list(value))
+
+parameter_option = option('-p', '--parameter',
+                                help="Parameters, either JSON string or path to JSON file",
+                                multiple=True,
+                                default=['{}'],
+                                callback=_handle_param_option)
+
+parameter_override_option = option('-P', '--parameter-override',
+                                help="Parameter override",
+                                nargs=2,
+                                multiple=True,
+                                callback=lambda ctx, param, kv: kv)
+                                # callback=lambda ctx, param, kv: {kv[0]: kv[1]})

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -7,7 +7,7 @@ from os import environ as ENV
 from tests.base import CapturingTestCase as TestCase, main, assets, copy_of_directory
 
 from ocrd.decorators import ocrd_loglevel
-from ocrd_utils import setOverrideLogLevel, initLogging
+from ocrd_utils import initLogging
 
 @click.group()
 @ocrd_loglevel
@@ -53,11 +53,10 @@ class TestLogCli(TestCase):
         self.assertIn('ERROR ocrd.foo - foo', self.invoke_cli(log_cli, ['error', 'foo'])[2])
         self.assertIn('CRITICAL ocrd.foo - foo', self.invoke_cli(log_cli, ['critical', 'foo'])[2])
 
-    def test_log_name_levels(self):
+    def test_log_error(self):
         code, out, err  = self.invoke_cli(log_cli, ['-n', 'foo',  'info', 'foo bar', 'foo bar'])
         print('code=%s out=%s err=%s' % (code, out, err))
         assert 'Logging error' not in err
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Just a refactoring, `ocrd/decorators.py` was becoming unwieldly.