### PR TITLE
Fix logging yet again

### DIFF
--- a/ocrd/ocrd/cli/log.py
+++ b/ocrd/ocrd/cli/log.py
@@ -23,7 +23,7 @@ def log_cli(ctx, name, *args, **kwargs):
     """
     Logging
     """
-    initLogging(True)  # reinit because setOverrideLogLevel may have come before
+    initLogging()
     ctx.obj = LogCtx(name)
 
 def _bind_log_command(lvl):

--- a/ocrd/ocrd/cli/log.py
+++ b/ocrd/ocrd/cli/log.py
@@ -4,11 +4,10 @@ Logging CLI
 import click
 from ocrd_utils import initLogging, getLogger, getLevelName
 
-initLogging()
-
 class LogCtx():
 
     def __init__(self, name):
+        initLogging()
         self.logger = getLogger(name)
 
     def log(self, lvl, *args, **kwargs):

--- a/ocrd/ocrd/cli/log.py
+++ b/ocrd/ocrd/cli/log.py
@@ -9,7 +9,6 @@ class LogCtx():
 
     def __init__(self, name):
         self.name = name
-        initLogging(True)  # reinit because setOverrideLogLevel may have come before
 
     def log(self, lvl, *args, **kwargs):
         logger = getLogger(self.name)
@@ -24,6 +23,7 @@ def log_cli(ctx, name, *args, **kwargs):
     """
     Logging
     """
+    initLogging(True)  # reinit because setOverrideLogLevel may have come before
     ctx.obj = LogCtx(name)
 
 def _bind_log_command(lvl):

--- a/ocrd/ocrd/cli/log.py
+++ b/ocrd/ocrd/cli/log.py
@@ -3,15 +3,17 @@ Logging CLI
 """
 import click
 from ocrd_utils import initLogging, getLogger, getLevelName
+import logging
 
 class LogCtx():
 
     def __init__(self, name):
-        initLogging()
-        self.logger = getLogger(name)
+        self.name = name
+        initLogging(True)  # reinit because setOverrideLogLevel may have come before
 
     def log(self, lvl, *args, **kwargs):
-        self.logger.log(getLevelName(lvl), *args, **kwargs)
+        logger = getLogger(self.name)
+        logger.log(getLevelName(lvl), *args, **kwargs)
 
 pass_log = click.make_pass_decorator(LogCtx)
 
@@ -35,5 +37,5 @@ def _bind_log_command(lvl):
             ctx.log(lvl.upper(), msg)
     return _log_wrapper
 
-for lvl in ['trace', 'debug', 'info', 'warning', 'error', 'critical']:
-    log_cli.command(lvl, help="Log a %s message" % lvl.upper())(_bind_log_command(lvl))
+for _lvl in ['trace', 'debug', 'info', 'warning', 'error', 'critical']:
+    log_cli.command(_lvl, help="Log a %s message" % _lvl.upper())(_bind_log_command(_lvl))

--- a/ocrd/ocrd/cli/process.py
+++ b/ocrd/ocrd/cli/process.py
@@ -21,7 +21,7 @@ def process_cli(log_level, mets, page_id, tasks, overwrite):
     """
     Process a series of tasks
     """
-    initLogging(True)
+    initLogging()
     log = getLogger('ocrd.cli.process')
     run_tasks(mets, log_level, page_id, tasks, overwrite)
     log.info("Finished")

--- a/ocrd/ocrd/cli/process.py
+++ b/ocrd/ocrd/cli/process.py
@@ -3,12 +3,10 @@ CLI for task_sequence
 """
 import click
 
-from ocrd_utils import initLogging, getLogger
+from ocrd_utils import getLogger, initLogging
 from ocrd.task_sequence import run_tasks
 
 from ..decorators import ocrd_loglevel
-
-initLogging()
 
 # ----------------------------------------------------------------------
 # ocrd process
@@ -23,7 +21,7 @@ def process_cli(log_level, mets, page_id, tasks, overwrite):
     """
     Process a series of tasks
     """
+    initLogging(True)
     log = getLogger('ocrd.cli.process')
-
     run_tasks(mets, log_level, page_id, tasks, overwrite)
     log.info("Finished")

--- a/ocrd/ocrd/cli/validate.py
+++ b/ocrd/ocrd/cli/validate.py
@@ -7,10 +7,7 @@ import codecs
 from ocrd import Resolver, Workspace
 from ocrd.task_sequence import ProcessorTask, validate_tasks
 
-from ocrd_utils import (
-    parse_json_string_or_file,
-    initLogging
-)
+from ocrd_utils import initLogging, parse_json_string_or_file
 from ocrd_validators import (
     OcrdToolValidator,
     OcrdZipValidator,
@@ -18,8 +15,6 @@ from ocrd_validators import (
     ParameterValidator,
     WorkspaceValidator,
 )
-
-initLogging()
 
 def _inform_of_result(report):
     if not report.is_valid:
@@ -32,6 +27,7 @@ def validate_cli():
     """
     All the validation in one CLI
     """
+    initLogging(True)
 
 @validate_cli.command('tool-json')
 @click.argument('ocrd_tool', required=False, nargs=1)

--- a/ocrd/ocrd/cli/validate.py
+++ b/ocrd/ocrd/cli/validate.py
@@ -27,7 +27,7 @@ def validate_cli():
     """
     All the validation in one CLI
     """
-    initLogging(True)
+    initLogging()
 
 @validate_cli.command('tool-json')
 @click.argument('ocrd_tool', required=False, nargs=1)

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -9,19 +9,18 @@ import re
 import click
 
 from ocrd import Resolver, Workspace, WorkspaceValidator, WorkspaceBackupManager
-from ocrd_utils import initLogging, getLogger, pushd_popd, EXT_TO_MIME
+from ocrd_utils import getLogger, initLogging, pushd_popd, EXT_TO_MIME
 from . import command_with_replaced_help
 
-initLogging()
-log = getLogger('ocrd.cli.workspace')
 
 class WorkspaceCtx():
 
     def __init__(self, directory, mets_url, mets_basename, automatic_backup):
+        self.log = getLogger('ocrd.cli.workspace')
         if mets_basename and mets_url:
             raise ValueError("Use either --mets or --mets-basename, not both")
         if mets_basename and not mets_url:
-            log.warning(DeprecationWarning("--mets-basename is deprecated. Use --mets/--directory instead"))
+            self.log.warning(DeprecationWarning("--mets-basename is deprecated. Use --mets/--directory instead"))
         mets_basename = mets_basename if mets_basename else 'mets.xml'
         if directory and mets_url:
             directory = abspath(directory)
@@ -57,6 +56,7 @@ def workspace_cli(ctx, directory, mets, mets_basename, backup):
     """
     Working with workspace
     """
+    initLogging(True)
     ctx.obj = WorkspaceCtx(directory, mets_url=mets, mets_basename=mets_basename, automatic_backup=backup)
 
 # ----------------------------------------------------------------------
@@ -212,7 +212,7 @@ def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, ignore, check_
 # ocrd workspace add-bulk
 # ----------------------------------------------------------------------
 
-# pylint: disable=bad-whitespace, broad-except
+# pylint: disable=broad-except
 @workspace_cli.command('bulk-add')
 @click.option('-r', '--regex', help="Regular expression matching the FILE_GLOB filesystem paths to define named captures usable in the other parameters", required=True)
 @click.option('-m', '--mimetype', help="Media type of the file. If not provided, guess from filename", required=False)
@@ -317,7 +317,6 @@ def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, file_grp
 @click.option('-m', '--mimetype', help="Media type to look for", metavar='FILTER')
 @click.option('-g', '--page-id', help="Page ID", metavar='FILTER')
 @click.option('-i', '--file-id', help="ID", metavar='FILTER')
-# pylint: disable=bad-continuation
 @click.option('-k', '--output-field', help="Output field. Repeat for multiple fields, will be joined with tab",
         default=['url'],
         multiple=True,
@@ -438,7 +437,7 @@ def prune_files(ctx, file_grp, mimetype, page_id, file_id):
                 if not f.local_filename or not exists(f.local_filename):
                     workspace.mets.remove_file(f.ID)
             except Exception as e:
-                log.exception("Error removing %f: %s", f, e)
+                ctx.log.exception("Error removing %f: %s", f, e)
                 raise(e)
         workspace.save_mets()
 

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -56,7 +56,7 @@ def workspace_cli(ctx, directory, mets, mets_basename, backup):
     """
     Working with workspace
     """
-    initLogging(True)
+    initLogging()
     ctx.obj = WorkspaceCtx(directory, mets_url=mets, mets_basename=mets_basename, automatic_backup=backup)
 
 # ----------------------------------------------------------------------

--- a/ocrd/ocrd/cli/zip.py
+++ b/ocrd/ocrd/cli/zip.py
@@ -14,7 +14,7 @@ def zip_cli():
     """
     Bag/Spill/Validate OCRD-ZIP bags
     """
-    initLogging(True)
+    initLogging()
 
 # ----------------------------------------------------------------------
 # ocrd zip bag

--- a/ocrd/ocrd/cli/zip.py
+++ b/ocrd/ocrd/cli/zip.py
@@ -9,13 +9,12 @@ from ..resolver import Resolver
 from ..workspace import Workspace
 from ..workspace_bagger import WorkspaceBagger
 
-initLogging()
-
 @click.group("zip")
 def zip_cli():
     """
     Bag/Spill/Validate OCRD-ZIP bags
     """
+    initLogging(True)
 
 # ----------------------------------------------------------------------
 # ocrd zip bag

--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -34,11 +34,11 @@ def ocrd_cli_wrap_processor(
         processorClass(workspace=None, dump_json=dump_json, show_help=help, show_version=version)
         sys.exit()
     else:
-        LOG = getLogger('ocrd_cli_wrap_processor')
         if not mets or (is_local_filename(mets) and not isfile(get_local_filename(mets))):
             processorClass(workspace=None, show_help=True)
             sys.exit(1)
-        initLogging()
+        initLogging(True)
+        LOG = getLogger('ocrd_cli_wrap_processor')
         # LOG.info('kwargs=%s' % kwargs)
         # Merge parameter overrides and parameters
         if 'parameter_override' in kwargs:

--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -37,7 +37,7 @@ def ocrd_cli_wrap_processor(
         if not mets or (is_local_filename(mets) and not isfile(get_local_filename(mets))):
             processorClass(workspace=None, show_help=True)
             sys.exit(1)
-        initLogging(True)
+        initLogging()
         LOG = getLogger('ocrd_cli_wrap_processor')
         # LOG.info('kwargs=%s' % kwargs)
         # Merge parameter overrides and parameters

--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -15,7 +15,7 @@ from ocrd_validators import WorkspaceValidator
 from ..resolver import Resolver
 from ..processor.base import run_processor
 
-from .loglevel_option import loglevel_option, ocrd_loglevel
+from .loglevel_option import ocrd_loglevel
 from .parameter_option import parameter_option, parameter_override_option
 from .ocrd_cli_options import ocrd_cli_options
 

--- a/ocrd/ocrd/decorators/loglevel_option.py
+++ b/ocrd/ocrd/decorators/loglevel_option.py
@@ -1,9 +1,9 @@
 import click
 from ocrd_utils.logging import setOverrideLogLevel
 
-__all__ = ['loglevel_option', 'ocrd_loglevel']
+__all__ = ['ocrd_loglevel']
 
-def _set_root_logger_version(ctx, param, value):    # pylint: disable=unused-argument
+def _setOverrideLogLevel(ctx, param, value):    # pylint: disable=unused-argument
     setOverrideLogLevel(value)
     return value
 
@@ -12,7 +12,7 @@ loglevel_option = click.option('-l', '--log-level', help="Log level",
                                    'OFF', 'ERROR', 'WARN',
                                    'INFO', 'DEBUG', 'TRACE'
                                ]),
-                               default=None, callback=_set_root_logger_version)
+                               default=None, callback=_setOverrideLogLevel)
 
 def ocrd_loglevel(f):
     """

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -6,14 +6,12 @@ __all__ = ['Processor', 'generate_processor_help', 'run_cli', 'run_processor']
 
 import os
 import json
-from ocrd_utils import getLogger, VERSION as OCRD_VERSION, MIMETYPE_PAGE
+from ocrd_utils import VERSION as OCRD_VERSION, MIMETYPE_PAGE
 from ocrd_validators import ParameterValidator
 from ocrd_models.ocrd_page import MetadataItemType, LabelType, LabelsType
 
 # XXX imports must remain for backwards-compatibilty
 from .helpers import run_cli, run_processor, generate_processor_help # pylint: disable=unused-import
-
-log = getLogger('ocrd.processor')
 
 class Processor():
     """

--- a/ocrd/ocrd/processor/builtin/dummy_processor.py
+++ b/ocrd/ocrd/processor/builtin/dummy_processor.py
@@ -19,14 +19,13 @@ from ocrd_modelfactory import page_from_file
 
 OCRD_TOOL = parse_json_string_with_comments(resource_string(__name__, 'dummy/ocrd-tool.json').decode('utf8'))
 
-LOG = getLogger('ocrd.dummy')
-
 class DummyProcessor(Processor):
     """
     Bare-bones processor that copies mets:file from input group to output group.
     """
 
     def process(self):
+        LOG = getLogger('ocrd.dummy')
         assert_file_grp_cardinality(self.input_file_grp, 1)
         assert_file_grp_cardinality(self.output_file_grp, 1)
         for input_file in self.input_files:

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -14,8 +14,6 @@ __all__ = [
     'run_processor'
 ]
 
-log = getLogger('ocrd.processor')
-
 def _get_workspace(workspace=None, resolver=None, mets_url=None, working_dir=None):
     if workspace is None:
         if resolver is None:
@@ -51,6 +49,7 @@ def run_processor(
         mets_url,
         working_dir
     )
+    log = getLogger('ocrd.processor.helpers.run_processor')
     log.debug("Running processor %s", processorClass)
     processor = processorClass(
         workspace,
@@ -116,6 +115,7 @@ def run_cli(
         args += ['--parameter', parameter]
     if overwrite:
         args += ['--overwrite']
+    log = getLogger('ocrd.processor.helpers.run_cli')
     log.debug("Running subprocess '%s'", ' '.join(args))
     result = run(args, check=False, stdout=PIPE, stderr=PIPE)
     return result.returncode, result.stdout.decode('utf-8'), result.stderr.decode('utf-8')

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -16,8 +16,6 @@ from ocrd_models import OcrdMets
 from ocrd_models.constants import NAMESPACES as NS
 from ocrd_models.utils import handle_oai_response
 
-log = getLogger('ocrd.resolver')
-
 class Resolver():
     """
     Handle Uploads, Downloads, Repository access and manage temporary directories
@@ -121,6 +119,7 @@ class Resolver():
         Returns:
             Workspace
         """
+        log = getLogger('ocrd.resolver.workspace_from_url')
 
         if mets_url is None:
             raise ValueError("Must pass 'mets_url' workspace_from_url")
@@ -168,6 +167,7 @@ class Resolver():
         """
         Create an empty workspace.
         """
+        log = getLogger('ocrd.resolver.workspace_from_nothing')
         if directory is None:
             directory = tempfile.mkdtemp(prefix=TMP_PREFIX)
         Path(directory).mkdir(parents=True, exist_ok=True)

--- a/ocrd/ocrd/workspace_bagger.py
+++ b/ocrd/ocrd/workspace_bagger.py
@@ -26,7 +26,6 @@ from ocrd_models.ocrd_page import to_xml
 from .workspace import Workspace
 
 tempfile.tempdir = '/tmp' # TODO hard-coded
-log = getLogger('ocrd.workspace_bagger')
 
 BACKUPDIR = join('/tmp', TMP_BAGIT_PREFIX + 'backup')
 
@@ -54,6 +53,7 @@ class WorkspaceBagger():
             rmtree(bagdir)
 
     def _log_or_raise(self, msg):
+        log = getLogger('ocrd.workspace_bagger')
         if self.strict:
             raise(Exception(msg))
         else:
@@ -63,6 +63,7 @@ class WorkspaceBagger():
         mets = workspace.mets
         changed_urls = {}
 
+        log = getLogger('ocrd.workspace_bagger')
         # TODO allow filtering by fileGrp@USE and such
         with pushd_popd(workspace.directory):
             # URLs of the files before changing
@@ -183,6 +184,7 @@ class WorkspaceBagger():
             else:
                 dest = '%s.ocrd' % workspace.directory
 
+        log = getLogger('ocrd.workspace_bagger')
         log.info("Bagging %s to %s (temp dir %s)", workspace.directory, '(in-place)' if in_place else dest, bagdir)
 
         # create data dir
@@ -221,7 +223,7 @@ class WorkspaceBagger():
             src (string): Path to OCRD-ZIP
             dest (string): Path to directory to unpack data folder to
         """
-        #  print(dest)
+        log = getLogger('ocrd.workspace_bagger')
 
         if exists(dest) and not isdir(dest):
             raise Exception("Not a directory: %s" % dest)

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -27,7 +27,6 @@ from .ocrd_xml_base import OcrdXmlDocument, ET
 from .ocrd_file import OcrdFile
 from .ocrd_agent import OcrdAgent
 
-log = getLogger('ocrd_models.ocrd_mets')
 REGEX_PREFIX_LEN = len(REGEX_PREFIX)
 
 class OcrdMets(OcrdXmlDocument):
@@ -213,6 +212,7 @@ class OcrdMets(OcrdXmlDocument):
             recursive (boolean): Whether to recursively delete all files in the group
             force (boolean): Do not raise an exception if file group doesn't exist
         """
+        log = getLogger('ocrd_models.ocrd_mets.remove_file_group')
         el_fileSec = self._tree.getroot().find('mets:fileSec', NS)
         if el_fileSec is None:
             raise Exception("No fileSec!")
@@ -294,6 +294,7 @@ class OcrdMets(OcrdXmlDocument):
         """
         Delete a `OcrdFile </../../ocrd_models/ocrd_models.ocrd_file.html>`_.
         """
+        log = getLogger('ocrd_models.ocrd_mets.remove_one_file')
         log.info("remove_one_file(%s)" % ID)
         if isinstance(ID, OcrdFile):
             ocrd_file = ID

--- a/ocrd_models/ocrd_models/utils.py
+++ b/ocrd_models/ocrd_models/utils.py
@@ -13,8 +13,6 @@ __all__ = [
     'extract_mets_from_oai_content'
 ]
 
-log = getLogger('ocrd_models.utils')
-
 def xmllint_format(xml):
     """
     Pretty-print XML like ``xmllint`` does.
@@ -22,6 +20,7 @@ def xmllint_format(xml):
     Arguments:
         xml (string): Serialized XML
     """
+    log = getLogger('ocrd_models.utils.xmllint_format')
     parser = ET.XMLParser(resolve_entities=False, strip_cdata=False, remove_blank_text=True)
     document = ET.fromstring(xml, parser)
     return ('%s\n%s' % ('<?xml version="1.0" encoding="UTF-8"?>',
@@ -31,6 +30,7 @@ def handle_oai_response(response):
     """
     In case of a valid OAI-Response, extract first METS-Entry-Data
     """
+    log = getLogger('ocrd_models.utils.handle_oai_response')
     content_type = response.headers['Content-Type']
     if 'xml' in content_type or 'text' in content_type:
         content = response.content
@@ -46,6 +46,7 @@ def is_oai_content(data):
     """
     Return True if data is an OAI-PMH request/response
     """
+    log = getLogger('ocrd_models.utils.is_oai_content')
     xml_root = ET.fromstring(data)
     root_tag = xml_root.tag
     log.info("response data root.tag: '%s'" % root_tag)

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -117,11 +117,13 @@ from .introspect import (
     membername)
 
 from .logging import (
-    logging,
-    getLogger,
+    disableLogging,
     getLevelName,
+    getLogger,
     initLogging,
-    setOverrideLogLevel)
+    logging,
+    setOverrideLogLevel,
+    )
 
 from .os import (
     abspath,

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -115,6 +115,7 @@ def initLogging(reinit=False):
     if _initialized_flag and not reinit:
         raise Exception("initLogging called multiple times")
 
+    logging.disable(logging.NOTSET)
     for handler in logging.root.handlers[:]:
         logging.root.removeHandler(handler)
 
@@ -151,6 +152,7 @@ def disableLogging():
     global _overrideLogLevel # pylint: disable=global-statement
     _overrideLogLevel = None
     logging.basicConfig(level=logging.CRITICAL)
+    logging.disable(logging.CRITICAL)
 
 # Initializing stream handlers at module level
 # would cause message output in all runtime contexts,

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -151,7 +151,7 @@ def disableLogging():
     global _overrideLogLevel # pylint: disable=global-statement
     _overrideLogLevel = None
     logging.basicConfig(level=logging.CRITICAL)
-    logging.disable(logging.CRITICAL)
+    logging.disable(logging.ERROR)
 
 # Initializing stream handlers at module level
 # would cause message output in all runtime contexts,

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -93,12 +93,10 @@ def getLogger(*args, **kwargs):
     """
     logger = logging.getLogger(*args, **kwargs)
     if not _initialized_flag:
-        raise Exception("No initLogging() before getLogger()")
         # initLogging()
+        raise Exception("No initLogging() before getLogger()")
     if _overrideLogLevel:
         logger.setLevel(logging.NOTSET)
-    with open('/tmp/debug.log', 'a') as f:
-        f.write('getLogger(%s) level=%s\n' % (args[0], logger.level))
     return logger
 
 # Default logging config
@@ -119,28 +117,28 @@ def initLogging(reinit=False):
         os.path.join(os.path.expanduser('~')),
         '/etc',
     ]
-    for p in CONFIG_PATHS:
-        config_file = os.path.join(p, 'ocrd_logging.conf')
-        if os.path.exists(config_file):
-            logging.info("Picked up logging config at %s" % config_file)
-            logging.config.fileConfig(config_file)
-            return
-
-    logging.basicConfig(
-        level=logging.INFO,
-        format=LOG_FORMAT,
-        datefmt=LOG_TIMEFMT)
-    logging.getLogger('').setLevel(logging.INFO)
-    #  logging.getLogger('ocrd.resolver').setLevel(logging.INFO)
-    #  logging.getLogger('ocrd.resolver.download_to_directory').setLevel(logging.INFO)
-    #  logging.getLogger('ocrd.resolver.add_files_to_mets').setLevel(logging.INFO)
-    logging.getLogger('PIL').setLevel(logging.INFO)
-    # To cut back on the `Self-intersection at or near point` INFO messages
-    logging.getLogger('shapely.geos').setLevel(logging.ERROR)
+    config_file = next((f for f \
+            in [os.path.join(p, 'ocrd_logging.conf') for p in CONFIG_PATHS] \
+            if os.path.exists(f)),
+            None)
+    if config_file:
+        logging.info("Picked up logging config at %s" % config_file)
+        logging.config.fileConfig(config_file)
+    else:
+        logging.basicConfig(
+            level=logging.INFO,
+            format=LOG_FORMAT,
+            datefmt=LOG_TIMEFMT)
+        logging.getLogger('').setLevel(logging.INFO)
+        #  logging.getLogger('ocrd.resolver').setLevel(logging.INFO)
+        #  logging.getLogger('ocrd.resolver.download_to_directory').setLevel(logging.INFO)
+        #  logging.getLogger('ocrd.resolver.add_files_to_mets').setLevel(logging.INFO)
+        logging.getLogger('PIL').setLevel(logging.INFO)
+        # To cut back on the `Self-intersection at or near point` INFO messages
+        logging.getLogger('shapely.geos').setLevel(logging.ERROR)
 
     if _overrideLogLevel:
         setOverrideLogLevel(_overrideLogLevel)
-
     _initialized_flag = True
 
 def disableLogging():

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -139,6 +139,7 @@ def initLogging(reinit=False):
         logging.getLogger('PIL').setLevel(logging.INFO)
         # To cut back on the `Self-intersection at or near point` INFO messages
         logging.getLogger('shapely.geos').setLevel(logging.ERROR)
+        logging.getLogger('tensorflow').setLevel(logging.ERROR)
 
     if _overrideLogLevel:
         setOverrideLogLevel(_overrideLogLevel)

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -92,6 +92,9 @@ def getLogger(*args, **kwargs):
     Wrapper around ``logging.getLogger`` that respects `overrideLogLevel <#setOverrideLogLevel>`_.
     """
     logger = logging.getLogger(*args, **kwargs)
+    if not _initialized_flag:
+        raise Exception("No initLogging() before getLogger()")
+        # initLogging()
     if _overrideLogLevel:
         logger.setLevel(logging.NOTSET)
     with open('/tmp/debug.log', 'a') as f:

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -126,8 +126,8 @@ def initLogging():
             if os.path.exists(f)),
             None)
     if config_file:
-        logging.info("Picked up logging config at %s" % config_file)
         logging.config.fileConfig(config_file)
+        logging.getLogger('ocrd.logging').debug("Picked up logging config at %s" % config_file)
     else:
         # Default logging config
         logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, datefmt=LOG_TIMEFMT)

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -94,11 +94,9 @@ def getLogger(*args, **kwargs):
     if not _initialized_flag:
         # XXX logger.exception may only be called in an except clause
         initLogging()
-        logging.getLogger('').critical('*** getLogger was called before initLogging ***')
-        logging.getLogger('').critical('*** If you encounter this when running a processor, open an issue about it in the resp. project on GitHub ***')
-        for x in format_stack(limit=2):
-            for y in x.split('\n'):
-                logging.getLogger('').critical(y)
+        logging.getLogger('').critical('getLogger was called before initLogging. Source of the call:')
+        for line in [x for x in format_stack(limit=2)[0].split('\n') if x]:
+            logging.getLogger('').critical(line)
     name = args[0]
     logger = logging.getLogger(*args, **kwargs)
     if _overrideLogLevel and name:
@@ -111,7 +109,7 @@ def initLogging(reinit=False):
     """
     Reset root logger, read logging configuration if exists, otherwise use basicConfig
     """
-    global _initialized_flag
+    global _initialized_flag # pylint: disable=global-statement
     if _initialized_flag and not reinit:
         raise Exception("initLogging called multiple times")
 
@@ -142,8 +140,6 @@ def initLogging(reinit=False):
         logging.getLogger('shapely.geos').setLevel(logging.ERROR)
         logging.getLogger('tensorflow').setLevel(logging.ERROR)
 
-    if _overrideLogLevel:
-        setOverrideLogLevel(_overrideLogLevel)
     _initialized_flag = True
 
 def disableLogging():

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -14,6 +14,7 @@ These files will be executed in the context of ocrd/ocrd_logging.py, with `loggi
 # pylint: disable=no-member
 
 from __future__ import absolute_import
+from traceback import format_stack
 
 import logging
 import logging.config
@@ -91,7 +92,13 @@ def getLogger(*args, **kwargs):
     Wrapper around ``logging.getLogger`` that respects `overrideLogLevel <#setOverrideLogLevel>`_.
     """
     if not _initialized_flag:
-        raise Exception("No initLogging() before getLogger()")
+        # XXX logger.exception may only be called in an except clause
+        initLogging()
+        logging.getLogger('').critical('*** getLogger was called before initLogging ***')
+        logging.getLogger('').critical('*** If you encounter this when running a processor, open an issue about it in the resp. project on GitHub ***')
+        for x in format_stack(limit=2):
+            for y in x.split('\n'):
+                logging.getLogger('').critical(y)
     name = args[0]
     logger = logging.getLogger(*args, **kwargs)
     if _overrideLogLevel and name:

--- a/ocrd_validators/ocrd_validators/ocrd_zip_validator.py
+++ b/ocrd_validators/ocrd_validators/ocrd_zip_validator.py
@@ -14,8 +14,6 @@ from bagit_profile import Profile, ProfileValidationError # pylint: disable=no-n
 from .constants import OCRD_BAGIT_PROFILE, OCRD_BAGIT_PROFILE_URL, TMP_BAGIT_PREFIX
 from ocrd_models import ValidationReport
 
-log = getLogger('ocrd.ocrd_zip_validator')
-
 #
 # -------------------------------------------------
 #
@@ -58,6 +56,7 @@ class OcrdZipValidator():
         except BagValidationError as e:
             failed = e
             #  for d in e.details:
+            #      log = getLogger('ocrd.ocrd_zip_validator')
             #      if isinstance(d, ChecksumMismatch):
             #          log.error("Validation Error: expected %s to have %s checksum of %s but found %s", d.path, d.algorithm, d.expected, d.found)
             #      else:

--- a/ocrd_validators/ocrd_validators/page_validator.py
+++ b/ocrd_validators/ocrd_validators/page_validator.py
@@ -31,7 +31,6 @@ from ocrd_models.ocrd_page_generateds import (
 )
 from ocrd_models import ValidationReport
 
-log = getLogger('ocrd.page_validator')
 
 _HIERARCHY = [
     # page can contain different types of regions
@@ -233,6 +232,7 @@ def validate_consistency(node, page_textequiv_consistency, page_textequiv_strate
     Check whether the text results on an element is consistent with its child element text results,
     and whether the coordinates of an element are fully within its parent element coordinates.
     """
+    log = getLogger('ocrd.page_validator.validate_consistency')
     if isinstance(node, PcGtsType):
         # top-level (start recursion)
         node_id = node.get_pcGtsId()
@@ -372,6 +372,7 @@ def get_text(node, page_textequiv_strategy='first'):
     If there are no scores/indexes, use the first result.
     If there are no results, return the empty string.
     """
+    log = getLogger('ocrd.page_validator.get_text')
     textEquivs = node.get_TextEquiv()
     if not textEquivs:
         log.debug("No text results on %s %s", node, node.id)
@@ -455,6 +456,7 @@ class PageValidator():
         Returns:
             report (:class:`ValidationReport`) Report on the validity
         """
+        log = getLogger('ocrd.page_validator.validate')
         if ocrd_page:
             page = ocrd_page
             file_id = ocrd_page.get_pcGtsId()

--- a/ocrd_validators/ocrd_validators/workspace_validator.py
+++ b/ocrd_validators/ocrd_validators/workspace_validator.py
@@ -14,8 +14,6 @@ from .page_validator import PageValidator
 from .xsd_page_validator import XsdPageValidator
 from .xsd_mets_validator import XsdMetsValidator
 
-log = getLogger('ocrd.workspace_validator')
-
 #
 # -------------------------------------------------
 #
@@ -46,6 +44,7 @@ class WorkspaceValidator():
         if page_id and isinstance(page_id, str):
             page_id = page_id.split(',')
 
+        log = getLogger('ocrd.workspace_validator')
         log.debug("input_file_grp=%s output_file_grp=%s" % (input_file_grp, output_file_grp))
         if input_file_grp:
             for grp in input_file_grp:
@@ -78,6 +77,7 @@ class WorkspaceValidator():
         """
         self.report = ValidationReport()
         self.skip = skip if skip else []
+        log = getLogger('ocrd.workspace_validator')
         log.debug('resolver=%s mets_url=%s src_dir=%s', resolver, mets_url, src_dir)
         self.resolver = resolver
         if mets_url is None and src_dir is not None:
@@ -113,6 +113,7 @@ class WorkspaceValidator():
         """
         Actual validation.
         """
+        log = getLogger('ocrd.workspace_validator')
         try:
             self._resolve_workspace()
         except Exception as e: # pylint: disable=broad-except
@@ -287,6 +288,7 @@ class WorkspaceValidator():
         """
         Validate all PAGE-XML files against PAGE XSD schema
         """
+        log = getLogger('ocrd.workspace_validator')
         log.debug("Validating all PAGE-XML files against XSD")
         for ocrd_file in self.mets.find_files(mimetype=MIMETYPE_PAGE):
             self.workspace.download_file(ocrd_file)
@@ -298,6 +300,7 @@ class WorkspaceValidator():
         """
         Validate METS against METS XSD schema
         """
+        log = getLogger('ocrd.workspace_validator')
         log.debug("Validating METS %s against XSD" % self.workspace.mets_target)
         for err in XsdMetsValidator.validate(Path(self.workspace.mets_target)).errors:
             self.report.add_error("%s: %s" % (self.workspace.mets_target, err))

--- a/tests/base.py
+++ b/tests/base.py
@@ -8,7 +8,7 @@ import io
 import collections
 from unittest import TestCase as VanillaTestCase, skip, main as unittests_main
 import pytest
-from ocrd_utils import initLogging
+from ocrd_utils import disableLogging, initLogging
 
 from tests.assets import assets, copy_of_directory
 
@@ -26,8 +26,11 @@ class TestCase(VanillaTestCase):
     def setUpClass(cls):
         chdir(dirname(realpath(__file__)) + '/..')
 
-    def tearDown(self):
-        initLogging()
+    def setUp(self):
+        initLogging(True)
+
+    # def tearDown(self):
+    #     disableLogging()
 
 class CapturingTestCase(TestCase):
     """

--- a/tests/base.py
+++ b/tests/base.py
@@ -27,10 +27,8 @@ class TestCase(VanillaTestCase):
         chdir(dirname(realpath(__file__)) + '/..')
 
     def setUp(self):
-        initLogging(True)
-
-    # def tearDown(self):
-    #     disableLogging()
+        disableLogging()
+        initLogging()
 
 class CapturingTestCase(TestCase):
     """

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -20,7 +20,7 @@ class TestLogCli(TestCase):
         disableLogging()
         code, out, err = self.invoke_cli(mock_ocrd_cli, args)
         print(code, out, err)
-        return err
+        return out + err
 
     def tearDown(self):
         if 'OCRD_TOOL_NAME' in ENV:

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -1,5 +1,4 @@
 import click
-from click.testing import CliRunner
 from ocrd.cli import log_cli
 from os import environ as ENV
 
@@ -7,7 +6,7 @@ from os import environ as ENV
 from tests.base import CapturingTestCase as TestCase, main, assets, copy_of_directory
 
 from ocrd.decorators import ocrd_loglevel
-from ocrd_utils import initLogging
+from ocrd_utils import initLogging, setOverrideLogLevel, logging, disableLogging
 
 @click.group()
 @ocrd_loglevel
@@ -17,46 +16,47 @@ mock_ocrd_cli.add_command(log_cli)
 
 class TestLogCli(TestCase):
 
-    def setUp(self):
-        self.runner = CliRunner(mix_stderr=False)
-        initLogging()
+    # def setUp(self):
+    #     initLogging()
+    #     setOverrideLogLevel('DEBUG')
 
-    def test_loglevel(self):
-        _, _, err = self.invoke_cli(mock_ocrd_cli, ['log', 'debug', 'foo'])
-        self.assertNotIn(' DEBUG root - foo', err)
-        _, _, err = self.invoke_cli(mock_ocrd_cli, ['-l', 'DEBUG', 'log', 'debug', 'foo'])
-        self.assertIn(' DEBUG root - foo', err)
+    def _get_log_output(self, *args):
+        disableLogging()
+        _, _, err = self.invoke_cli(mock_ocrd_cli, args)
+        return err
 
     def tearDown(self):
         if 'OCRD_TOOL_NAME' in ENV:
             del(ENV['OCRD_TOOL_NAME'])
 
+    def test_loglevel(self):
+        assert ' DEBUG root - foo' not in self._get_log_output('log', 'debug', 'foo')
+        assert ' DEBUG root - foo' in self._get_log_output('-l', 'DEBUG', 'log', 'debug', 'foo')
+
     def test_log_basic(self):
-        exit_code, out, err = self.invoke_cli(log_cli, ['info', 'foo bar'])
-        self.assertIn('INFO root - foo bar', err)
+        assert 'INFO root - foo bar' in self._get_log_output('log', 'info', 'foo bar')
 
     def test_log_name_param(self):
-        exit_code, out, err = self.invoke_cli(log_cli, ['--name', 'boo.far', 'info', 'foo bar'])
-        self.assertIn('INFO boo.far - foo bar', err)
+        assert 'INFO boo.far - foo bar' in self._get_log_output('log', '--name', 'boo.far', 'info', 'foo bar')
 
     def test_log_name_envvar(self):
         ENV['OCRD_TOOL_NAME'] = 'boo.far'
-        exit_code, out, err  = self.invoke_cli(log_cli, ['info', 'foo bar'])
-        self.assertIn('INFO boo.far - foo bar', err)
+        assert 'INFO boo.far - foo bar' in self._get_log_output('log', 'info', 'foo bar')
 
     def test_log_name_levels(self):
         ENV['OCRD_TOOL_NAME'] = 'ocrd.foo'
-        self.assertIn('DEBUG ocrd.foo - foo', self.invoke_cli(mock_ocrd_cli, ['-l', 'DEBUG', 'log', 'debug', 'foo'])[2])
-        self.assertIn('DEBUG ocrd.foo - foo', self.invoke_cli(log_cli, ['trace', 'foo'])[2])
-        self.assertIn('INFO ocrd.foo - foo', self.invoke_cli(log_cli, ['info', 'foo'])[2])
-        self.assertIn('WARNING ocrd.foo - foo', self.invoke_cli(log_cli, ['warning', 'foo'])[2])
-        self.assertIn('ERROR ocrd.foo - foo', self.invoke_cli(log_cli, ['error', 'foo'])[2])
-        self.assertIn('CRITICAL ocrd.foo - foo', self.invoke_cli(log_cli, ['critical', 'foo'])[2])
+        assert 'DEBUG ocrd.foo - foo' in self._get_log_output('-l', 'DEBUG', 'log', 'debug', 'foo')
+        assert 'DEBUG ocrd.foo - foo' in self._get_log_output('-l', 'DEBUG', 'log', 'trace', 'foo')
+        assert 'INFO ocrd.foo - foo' in  self._get_log_output('log', 'info', 'foo')
+        assert 'WARNING ocrd.foo - foo' in  self._get_log_output('log', 'warning', 'foo')
+        assert 'ERROR ocrd.foo - foo' in  self._get_log_output('log', 'error', 'foo')
+        assert 'CRITICAL ocrd.foo - foo' in  self._get_log_output('log', 'critical', 'foo')
 
     def test_log_error(self):
-        code, out, err  = self.invoke_cli(log_cli, ['-n', 'foo',  'info', 'foo bar', 'foo bar'])
-        print('code=%s out=%s err=%s' % (code, out, err))
-        assert 'Logging error' not in err
+        assert 'Logging error' not in self._get_log_output('log', '-n', 'foo',  'info', 'foo bar', 'foo bar')
+
+    def test_log_override(self):
+        assert 'DEBUG' not in self._get_log_output('-l', 'INFO', 'log', 'debug', 'foo')
 
 
 if __name__ == '__main__':

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -22,7 +22,8 @@ class TestLogCli(TestCase):
 
     def _get_log_output(self, *args):
         disableLogging()
-        _, _, err = self.invoke_cli(mock_ocrd_cli, args)
+        code, out, err = self.invoke_cli(mock_ocrd_cli, args)
+        print(code, out, err)
         return err
 
     def tearDown(self):

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -16,10 +16,6 @@ mock_ocrd_cli.add_command(log_cli)
 
 class TestLogCli(TestCase):
 
-    # def setUp(self):
-    #     initLogging()
-    #     setOverrideLogLevel('DEBUG')
-
     def _get_log_output(self, *args):
         disableLogging()
         code, out, err = self.invoke_cli(mock_ocrd_cli, args)

--- a/tests/cli/test_process.py
+++ b/tests/cli/test_process.py
@@ -1,0 +1,16 @@
+from ocrd.cli import process_cli
+from ocrd_utils import pushd_popd, disableLogging
+
+from tests.base import CapturingTestCase as TestCase, main, assets, copy_of_directory
+
+class TestLogCli(TestCase):
+
+    def test_cli_process_smoke(self):
+        disableLogging()
+        with copy_of_directory(assets.path_to('kant_aufklaerung_1784/data')) as wsdir:
+            with pushd_popd(wsdir):
+                with self.assertRaisesRegex(Exception, "Executable not found in PATH: ocrd-foo"):
+                    self.invoke_cli(process_cli, ['foo'])
+
+if __name__ == '__main__':
+    main(__file__)

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -51,57 +51,52 @@ OCRD_TOOL = '''
 # inherit from TestTaskSequence for the setUp/tearDown methods
 class TestCli(TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super(TestCli, self).__init__(*args, **kwargs)
-        self.runner = CliRunner()
-
     def test_validate_ocrd_tool(self):
         with TemporaryDirectory() as tempdir:
             json_path = Path(tempdir, 'ocrd-tool.json')
             json_path.write_text(OCRD_TOOL)
 
             # normal call
-            result = self.runner.invoke(validate_cli, ['tool-json', str(json_path)])
-            self.assertEqual(result.exit_code, 0)
+            code, _, _ = self.invoke_cli(validate_cli, ['tool-json', str(json_path)])
+            self.assertEqual(code, 0)
             # relative path
             with pushd_popd(tempdir):
-                result = self.runner.invoke(validate_cli, ['tool-json', 'ocrd-tool.json'])
-                self.assertEqual(result.exit_code, 0)
+                code, _, _ = self.invoke_cli(validate_cli, ['tool-json', 'ocrd-tool.json'])
+                self.assertEqual(code, 0)
             # default path
             with pushd_popd(tempdir):
-                result = self.runner.invoke(validate_cli, ['tool-json'])
-                self.assertEqual(result.exit_code, 0)
+                code, _, _ = self.invoke_cli(validate_cli, ['tool-json'])
+                self.assertEqual(code, 0)
 
     def test_validate_parameter(self):
         with TemporaryDirectory() as tempdir:
             json_path = Path(tempdir, 'ocrd-tool.json')
             json_path.write_text(OCRD_TOOL)
             with pushd_popd(tempdir):
-                result = self.runner.invoke(validate_cli, ['parameters', 'ocrd-tool.json', 'ocrd-xyz', dumps({"baz": "foo"})])
-                self.assertEqual(result.exit_code, 0)
+                code, _, _ = self.invoke_cli(validate_cli, ['parameters', 'ocrd-tool.json', 'ocrd-xyz', dumps({"baz": "foo"})])
+                self.assertEqual(code, 0)
 
     def test_validate_page(self):
         page_path = assets.path_to('glyph-consistency/data/OCR-D-GT-PAGE/FAULTY_GLYPHS.xml')
-        result = self.runner.invoke(validate_cli, ['page', page_path])
-        self.assertEqual(result.exit_code, 1)
-        self.assertIn('<report valid="false">', result.stdout)
+        code, out, _ = self.invoke_cli(validate_cli, ['page', page_path])
+        self.assertEqual(code, 1)
+        self.assertIn('<report valid="false">', out)
 
     def test_validate_tasks(self):
         # simple
-        result = self.runner.invoke(validate_cli, ['tasks',
+        code, _, _ = self.invoke_cli(validate_cli, ['tasks',
             "sample-processor-required-param -I FOO -O OUT1 -p '{\"param1\": true}'",
             "sample-processor-required-param -I FOO -O OUT2 -p '{\"param1\": true}'",
         ])
-        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(code, 0)
 
         # with workspace
-        result = self.runner.invoke(validate_cli, ['tasks', '--workspace', assets.path_to('kant_aufklaerung_1784/data'),
+        code, out, err = self.invoke_cli(validate_cli, ['tasks', '--workspace', assets.path_to('kant_aufklaerung_1784/data'),
             "sample-processor-required-param -I OCR-D-IMG,OCR-D-GT-PAGE -O OUT1 -p '{\"param1\": true}'",
             "sample-processor-required-param -I OCR-D-IMG,OCR-D-GT-PAGE -O OUT2 -p '{\"param1\": true}'",
         ])
-        print(result)
-        print(result.stdout)
-        self.assertEqual(result.exit_code, 0)
+        print('code=%s out=%s err=%s' % (code, out, err))
+        self.assertEqual(code, 0)
 
 
 if __name__ == '__main__':

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -16,9 +16,9 @@ from ocrd import Resolver
 class TestCli(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.maxDiff = None
         self.resolver = Resolver()
-        initLogging()
         self.runner = CliRunner(mix_stderr=False)
 
     def test_add(self):

--- a/tests/data/wf_testcase.py
+++ b/tests/data/wf_testcase.py
@@ -5,7 +5,7 @@ from os.path import join
 from shutil import rmtree
 from pathlib import Path
 
-from tests.base import TestCase as BaseTestCase
+from tests.base import CapturingTestCase as BaseTestCase
 
 SAMPLE_NAME = 'ocrd-sample-processor'
 SAMPLE_OCRD_TOOL_JSON = '''{
@@ -40,6 +40,7 @@ class TestCase(BaseTestCase):
         rmtree(self.tempdir)
 
     def setUp(self):
+        super().setUp()
         self.tempdir = mkdtemp(prefix='ocrd-task-sequence-')
         self.param_fname = join(self.tempdir, 'params.json')
         with open(self.param_fname, 'w') as f:

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -3,7 +3,6 @@ from os.path import join
 from tests.base import TestCase, main, assets, copy_of_directory
 
 from ocrd_utils import (
-    initLogging,
     VERSION,
     MIMETYPE_PAGE
 )
@@ -13,8 +12,8 @@ from ocrd_models import OcrdMets
 class TestOcrdMets(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.mets = OcrdMets(filename=assets.url_of('SBB0000F29300010000/data/mets.xml'))
-        initLogging()
 
     def test_unique_identifier(self):
         self.assertEqual(self.mets.unique_identifier, 'http://resolver.staatsbibliothek-berlin.de/SBB0000F29300010000', 'Right identifier')
@@ -233,4 +232,4 @@ class TestOcrdMets(TestCase):
             self.assertEqual(len(mets.find_files()), 31)
 
 if __name__ == '__main__':
-    main()
+    main(__file__)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -195,7 +195,7 @@ class TestLogging(TestCase):
                     ''')
             # this will call logging.config.fileConfig with disable_existing_loggers=True,
             # so the defaults from the import-time initLogging should be invalided
-            initLogging(True)
+            initLogging()
             # ensure log level is set from temporary config file
             self.assertEqual(logging.getLogger('').getEffectiveLevel(), logging.ERROR)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -72,6 +72,8 @@ class TestLogging(TestCase):
 
         root_str = root_capture.getvalue()
         parent_str = parent_capture.getvalue()
+        print('root_str=%s' % root_str)
+        print('parent_str=%s' % parent_str)
 
         self.assertEqual(root_str.count('\n'), 0)
         self.assertEqual(parent_str.count('\n'), 1)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -38,14 +38,23 @@ class TestLogging(TestCase):
         setOverrideLogLevel('INFO')
         somelogger = getLogger('foo.bar')
 
+    def test_multiple_initLogging(self):
+        disableLogging()
+        initLogging()
+        self.capture_out_err()
+        initLogging()
+        out = '\n'.join(self.capture_out_err())
+        assert 'initLogging was called multiple times' in out
+        assert __file__ in out
+
     def test_getLogger_before_initLogging(self):
+        disableLogging()
         self.capture_out_err()
         getLogger('foo')
-        _, err = self.capture_out_err()
-        print(err)
-        assert 'getLogger was called before initLogging' in err
-        assert __file__ in err
-        assert len(err.split('\n')) == 4
+        out = '\n'.join(self.capture_out_err())
+        print(out)
+        assert 'getLogger was called before initLogging' in out
+        assert __file__ in out
 
     def test_getLevelName(self):
         self.assertEqual(getLevelName('ERROR'), logging.ERROR)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,7 +2,7 @@ import logging
 from re import match
 from tempfile import TemporaryDirectory
 
-from tests.base import TestCase, main, FIFOIO, assets
+from tests.base import CapturingTestCase as TestCase, main, FIFOIO, assets
 from tests.data import DummyProcessor
 from ocrd import Resolver, run_processor
 
@@ -37,6 +37,15 @@ class TestLogging(TestCase):
         self.assertEqual(notherlogger.getEffectiveLevel(), logging.ERROR)
         setOverrideLogLevel('INFO')
         somelogger = getLogger('foo.bar')
+
+    def test_getLogger_before_initLogging(self):
+        self.capture_out_err()
+        getLogger('foo')
+        _, err = self.capture_out_err()
+        print(err)
+        assert 'getLogger was called before initLogging' in err
+        assert __file__ in err
+        assert len(err.split('\n')) == 4
 
     def test_getLevelName(self):
         self.assertEqual(getLevelName('ERROR'), logging.ERROR)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,6 +10,7 @@ from ocrd_utils import (
     pushd_popd,
     getLevelName,
     setOverrideLogLevel,
+    disableLogging,
     initLogging,
     getLogger,
     LOG_FORMAT,
@@ -22,7 +23,7 @@ TIMEFMT_RE = r'\d\d:\d\d:\d\d\.(\d+)? '
 class TestLogging(TestCase):
 
     def setUp(self):
-        initLogging()
+        disableLogging()
 
     def test_setOverrideLogLevel(self):
         rootLogger = logging.getLogger('')
@@ -175,9 +176,9 @@ class TestLoggingConfiguration(TestCase):
                         ''')
                 # this will call logging.config.fileConfig with disable_existing_loggers=True,
                 # so the defaults from the import-time initLogging should be invalided
-                initLogging()
+                initLogging(True)
                 # ensure log level is set from temporary config file
                 self.assertEqual(logging.getLogger('').getEffectiveLevel(), logging.ERROR)
 
 if __name__ == '__main__':
-    main()
+    main(__file__)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -17,7 +17,7 @@ FOLDER_KANT = assets.path_to('kant_aufklaerung_1784')
 class TestResolver(TestCase):
 
     def setUp(self):
-        initLogging(True)
+        initLogging()
         self.resolver = Resolver()
 
     def test_workspace_from_url_bad(self):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -7,7 +7,7 @@ from tempfile import TemporaryDirectory
 from tests.base import TestCase, assets, main, copy_of_directory
 
 from ocrd.resolver import Resolver
-from ocrd_utils import pushd_popd
+from ocrd_utils import pushd_popd, initLogging
 
 METS_HEROLD = assets.url_of('SBB0000F29300010000/data/mets.xml')
 FOLDER_KANT = assets.path_to('kant_aufklaerung_1784')
@@ -17,6 +17,7 @@ FOLDER_KANT = assets.path_to('kant_aufklaerung_1784')
 class TestResolver(TestCase):
 
     def setUp(self):
+        initLogging(True)
         self.resolver = Resolver()
 
     def test_workspace_from_url_bad(self):

--- a/tests/test_resolver_oai.py
+++ b/tests/test_resolver_oai.py
@@ -52,7 +52,7 @@ def test_handle_response_mets(plain_xml_response_content):
 @mock.patch("requests.get")
 def test_handle_common_oai_response(mock_get, response_dir, oai_response_content):
     """Base use case with valid OAI Response data"""
-    initLogging(True)
+    initLogging()
 
     # arrange
     url = 'http://digital.bibliothek.uni-halle.de/hd/oai/?verb=GetRecord&metadataPrefix=mets&mode=xml&identifier=9049'
@@ -81,7 +81,7 @@ def test_handle_response_for_invalid_content(mock_get, response_dir):
     headers = {'Content-Type': 'text/plain'}
     mock_get.return_value.headers = headers
     resolver = Resolver()
-    initLogging(True)
+    initLogging()
 
     # capture log
     log = getLogger('ocrd_models.utils.handle_oai_response')

--- a/tests/test_resolver_oai.py
+++ b/tests/test_resolver_oai.py
@@ -1,12 +1,14 @@
 from unittest import mock
 from pytest import fixture
 from shutil import copy
+from logging import StreamHandler, Formatter
 from os.path import join, dirname
 
-from tests.base import main
+from tests.base import main, FIFOIO
 
 from ocrd.resolver import Resolver
 from ocrd_models.utils import extract_mets_from_oai_content
+from ocrd_utils import getLogger, initLogging, LOG_FORMAT
 
 @fixture(name="response_dir")
 def fixture_response_dir(tmpdir):
@@ -50,6 +52,7 @@ def test_handle_response_mets(plain_xml_response_content):
 @mock.patch("requests.get")
 def test_handle_common_oai_response(mock_get, response_dir, oai_response_content):
     """Base use case with valid OAI Response data"""
+    initLogging(True)
 
     # arrange
     url = 'http://digital.bibliothek.uni-halle.de/hd/oai/?verb=GetRecord&metadataPrefix=mets&mode=xml&identifier=9049'
@@ -68,8 +71,7 @@ def test_handle_common_oai_response(mock_get, response_dir, oai_response_content
 
 
 @mock.patch("requests.get")
-@mock.patch("ocrd_models.utils.log.warning")
-def test_handle_response_for_invalid_content(mock_log_warning, mock_get, response_dir):
+def test_handle_response_for_invalid_content(mock_get, response_dir):
     """If invalid content is returned, store warning log entry"""
 
     # arrange
@@ -79,13 +81,22 @@ def test_handle_response_for_invalid_content(mock_log_warning, mock_get, respons
     headers = {'Content-Type': 'text/plain'}
     mock_get.return_value.headers = headers
     resolver = Resolver()
+    initLogging(True)
+
+    # capture log
+    log = getLogger('ocrd_models.utils.handle_oai_response')
+    capt = FIFOIO(256)
+    sh = StreamHandler(capt)
+    sh.setFormatter(Formatter(LOG_FORMAT))
+    log.addHandler(sh)
 
     # act
     resolver.download_to_directory(response_dir, url)
 
     # assert behavior
     mock_get.assert_called_once_with(url)
-    assert mock_log_warning.call_count == 1
+    log_output = capt.getvalue()
+    assert 'WARNING ocrd_models.utils.handle_oai_response' in log_output
 
 if __name__ == '__main__':
     main(__file__)

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -13,6 +13,7 @@ from tests.base import TestCase, assets, main, copy_of_directory # pylint: disab
 class TestWorkspaceValidator(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.resolver = Resolver()
 
     def test_check_file_grp_basic(self):


### PR DESCRIPTION
This PR is an attempt to fix a lot of code smell related to logging.

* <del>`getLogger` will raise an exception if `initLogging` was never called before</del> <ins>`getLogger` before `initLogging` will emit CRITICAL log messages about that fact and the file/line where it originated</ins>
* `setOverrideLogLevel` can now happen before `initLogging` (#597)
* new method `disableLogging` which requires a new `initLogging` call and resets override loglevel
* no longer set the loglevel of the root logger to `logging.NOTSET`
* no more module-level loggers - use method-specific loggers (which can re-use the same name of course)
* use the first config file found xor the builtin config. `setOverrideLoglevel` should take precedent over either.

Since logging happens in many places, PR is probably better digestable commit-by-commit.