### PR TITLE
ocrd_validators.page_validator: cope with empty RO

### DIFF
--- a/ocrd_validators/ocrd_validators/page_validator.py
+++ b/ocrd_validators/ocrd_validators/page_validator.py
@@ -182,6 +182,7 @@ def page_get_reading_order(ro, rogroup):
     and an object ``rogroup`` with additional ReadingOrder element objects,
     add all references to the dict, traversing the group recursively.
     """
+    regionrefs = list()
     if isinstance(rogroup, (OrderedGroupType, OrderedGroupIndexedType)):
         regionrefs = (rogroup.get_RegionRefIndexed() +
                       rogroup.get_OrderedGroupIndexed() +


### PR DESCRIPTION
This fixes a crash in case `ReadingOrder` is empty (which is not allowed in PAGE, but does happen on the input side).