### PR TITLE
bashlib: align non-arg-help behavior with python core

### DIFF
--- a/ocrd/bashlib/src/parse_argv.bash
+++ b/ocrd/bashlib/src/parse_argv.bash
@@ -18,7 +18,13 @@ ocrd__parse_argv () {
         ocrd__raise "Must set \$params (declare -A params)"
     fi
 
+    if [[ $# = 0 ]];then
+        ocrd__usage
+        exit 1
+    fi
+
     ocrd__argv[overwrite]=false
+    ocrd__argv[mets_file]="$PWD/mets.xml"
 
     local __parameters=()
     local __parameter_overrides=()
@@ -42,9 +48,8 @@ ocrd__parse_argv () {
         shift
     done
 
-    if [[ ! -r "${ocrd__argv[mets_file]:=$PWD/mets.xml}" ]];then
-        ocrd__usage
-        exit 1
+    if [[ ! -e "${ocrd__argv[mets_file]}" ]];then
+        ocrd__raise "METS file '${ocrd__argv[mets_file]}' not found"
     fi
 
     if [[ ! -d "${ocrd__argv[working_dir]:=$(dirname "${ocrd__argv[mets_file]}")}" ]];then

--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -106,7 +106,13 @@ ocrd__parse_argv () {
         ocrd__raise "Must set \$params (declare -A params)"
     fi
 
+    if [[ $# = 0 ]];then
+        ocrd__usage
+        exit 1
+    fi
+
     ocrd__argv[overwrite]=false
+    ocrd__argv[mets_file]="$PWD/mets.xml"
 
     local __parameters=()
     local __parameter_overrides=()
@@ -130,9 +136,8 @@ ocrd__parse_argv () {
         shift
     done
 
-    if [[ ! -r "${ocrd__argv[mets_file]:=$PWD/mets.xml}" ]];then
-        ocrd__usage
-        exit 1
+    if [[ ! -e "${ocrd__argv[mets_file]}" ]];then
+        ocrd__raise "METS file '${ocrd__argv[mets_file]}' not found"
     fi
 
     if [[ ! -d "${ocrd__argv[working_dir]:=$(dirname "${ocrd__argv[mets_file]}")}" ]];then


### PR DESCRIPTION
Makes bashlib behave the same as the Python processor implementations wrt #586, i.e. show help and exit 1 iff no arguments at all.