### PR TITLE
Require numpy<1.19.0 to satisfy requirements of tensorflow

### DIFF
--- a/ocrd_utils/requirements.txt
+++ b/ocrd_utils/requirements.txt
@@ -1,2 +1,4 @@
 Pillow >= 7.2.0
-numpy >= 1.17.0
+# All current versions of TensorFlow require numpy < 1.19.0,
+# so make sure that now newer version is installed here.
+numpy >= 1.17.0, < 1.19.0


### PR DESCRIPTION
Signed-off-by: Stefan Weil <sw@weilnetz.de>