### PR TITLE
Use nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04 as the base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ docker docker-cuda:
 	docker build -t $(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_BASE_IMAGE) $(DOCKER_ARGS) .
 
 # Build docker GPU / CUDA image
-docker-cuda: DOCKER_BASE_IMAGE = nvidia/cuda:11.0-runtime-ubuntu18.04
+docker-cuda: DOCKER_BASE_IMAGE = nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04
 docker-cuda: DOCKER_TAG = ocrd/core-cuda
 
 #


### PR DESCRIPTION
As discussed in https://github.com/OCR-D/ocrd_calamari/issues/46, `calamari-predict` takes [more than 1/3 of the duration](https://github.com/OCR-D/ocrd_calamari/issues/46#issuecomment-710028497) of [the recommended workflow](https://ocr-d.de/en/workflows#best-results-for-selected-pages) on the CPU. Therefore, the `ocrd/all:*-cuda` images should above all support `calamari-predict`, so that it can use GPUs.

Currently, the `ocrd/all:*-cuda` images are based on the `nvidia/cuda:11.0-runtime-ubuntu18.04` image, whereas `calamari-predict` [uses Tensorflow 1.15](https://github.com/OCR-D/ocrd_calamari/blob/master/requirements.txt#L1), which [requires CUDA Toolkit 10.0](https://www.tensorflow.org/install/source#gpu) and the CUDNN7 dynamic library.

This pull request changes the base image to `nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04`, so `calamari-predict` can use GPUs.