### PR TITLE
logging: set non-root logger to NOTSET also when loading from config file

### DIFF
--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -141,6 +141,10 @@ def initLogging():
         logging.getLogger('tensorflow').setLevel(logging.ERROR)
 
     if _overrideLogLevel:
+        # for existing loggers that won't have getLogger do this
+        # (because they were instantiated through logging.getLogger
+        #  instead of ours, or come from logging.config.fileConfig),
+        # unset log levels so the global override can apply:
         for loggerName in logging.Logger.manager.loggerDict:
             logger = logging.Logger.manager.loggerDict[loggerName]
             if isinstance(logger, logging.PlaceHolder):

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -141,6 +141,11 @@ def initLogging():
         logging.getLogger('tensorflow').setLevel(logging.ERROR)
 
     if _overrideLogLevel:
+        for loggerName in logging.Logger.manager.loggerDict:
+            logger = logging.Logger.manager.loggerDict[loggerName]
+            if isinstance(logger, logging.PlaceHolder):
+                continue
+            logger.setLevel(logging.NOTSET)
         logging.getLogger('').setLevel(_overrideLogLevel)
 
     _initialized_flag = True


### PR DESCRIPTION
@bertsky This was why I originally had `setOverrideLoglevel` as part of `intiLogging` in #599: When loading from config file and setting the root logger to the override loglevel, all existing loggers must be set to `NOTSET`.