### PR TITLE
ocrd.processor.base: add property zip_input_files

### DIFF
--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -6,7 +6,7 @@ __all__ = ['Processor', 'generate_processor_help', 'run_cli', 'run_processor']
 
 import os
 import json
-from ocrd_utils import VERSION as OCRD_VERSION, MIMETYPE_PAGE
+from ocrd_utils import VERSION as OCRD_VERSION, MIMETYPE_PAGE, getLogger
 from ocrd_validators import ParameterValidator
 from ocrd_models.ocrd_page import MetadataItemType, LabelType, LabelsType
 
@@ -15,9 +15,11 @@ from .helpers import run_cli, run_processor, generate_processor_help # pylint: d
 
 class Processor():
     """
-    A processor runs an algorithm based on the workspace, the mets.xml in the
-    workspace (and the input files defined therein) as well as optional
-    parameter.
+    A processor is an OCR-D compliant command-line-interface for executing
+    a single workflow step on the workspace (represented by local METS). It
+    reads input files for all or requested physical pages of the input fileGrp(s),
+    and writes output files for them into the output fileGrp(s). It may take 
+    a number of optional or mandatory parameters.
     """
 
     def __init__(
@@ -123,3 +125,48 @@ class Processor():
                 self.input_file_grp
                 ))
         return ret
+
+    @property
+    def zip_input_files(self, require_first=True):
+        """
+        List tuples of input files (for multiple input file groups).
+
+        Processors that expect/need multiple input file groups,
+        cannot use ``input_files``. They must align (zip) input files
+        across pages. This includes the case where not all pages
+        are equally present in all file groups.
+
+        This function does not make much sense for non-PAGE fileGrps,
+        so it uses a fixed MIME type filter for PAGE-XML.
+
+        Args:
+             require_first (bool): If true, then skip a page entirely
+             whenever it is not available in the first input fileGrp.
+        """
+
+        LOG = getLogger('ocrd.processor.base')
+        ifgs = self.input_file_grp.split(",")
+        # Iterating over all files repeatedly may seem inefficient at first sight,
+        # but the unnecessary OcrdFile instantiations for posterior fileGrp filtering
+        # can actually be much more costly than traversing the ltree.
+        # This might depend on the number of pages vs number of fileGrps.
+
+        pages = dict()
+        for i, ifg in enumerate(ifgs):
+            for file_ in self.workspace.mets.find_all_files(
+                    pageId=self.page_id, fileGrp=ifg, mimetype=MIMETYPE_PAGE):
+                if not file_.pageId:
+                    continue
+                LOG.debug("adding page %s to input file group %s", file_.pageId, ifg)
+                ift = pages.setdefault(file_.pageId, [None]*len(ifgs))
+                ift[i] = file_
+        ifts = list()
+        for page, ifiles in pages.items():
+            for i, ifg in enumerate(ifgs):
+                if not ifiles[i]:
+                    # other fallback options?
+                    LOG.error('found no page %s in file group %s',
+                              page, ifg)
+            if ifiles[0] or not require_first:
+                ifts.append(tuple(ifiles))
+        return ifts

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -126,7 +126,7 @@ class Processor():
                 ))
         return ret
 
-    def zip_input_files(self, require_first=True):
+    def zip_input_files(self, require_first=True, mimetype=MIMETYPE_PAGE):
         """
         List tuples of input files (for multiple input file groups).
 
@@ -153,7 +153,7 @@ class Processor():
         pages = dict()
         for i, ifg in enumerate(ifgs):
             for file_ in self.workspace.mets.find_all_files(
-                    pageId=self.page_id, fileGrp=ifg, mimetype=MIMETYPE_PAGE):
+                    pageId=self.page_id, fileGrp=ifg, mimetype=mimetype):
                 if not file_.pageId:
                     continue
                 LOG.debug("adding page %s to input file group %s", file_.pageId, ifg)

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -126,7 +126,6 @@ class Processor():
                 ))
         return ret
 
-    @property
     def zip_input_files(self, require_first=True):
         """
         List tuples of input files (for multiple input file groups).

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -266,6 +266,9 @@ class Workspace():
         Return
             :class:`OcrdExif`
         """
+        if not image_url:
+            # avoid "finding" just any file
+            raise Exception("Cannot resolve empty image path")
         f = next(self.mets.find_files(url=image_url), OcrdFile(None, url=image_url))
         image_filename = self.download_file(f).local_filename
         ocrd_exif = exif_from_filename(image_filename)
@@ -286,6 +289,9 @@ class Workspace():
             Image or region in image as PIL.Image
 
         """
+        if not image_url:
+            # avoid "finding" just any file
+            raise Exception("Cannot resolve empty image path")
         log = getLogger('ocrd.workspace._resolve_image_as_pil')
         f = next(self.mets.find_files(url=image_url), OcrdFile(None, url=image_url))
         image_filename = self.download_file(f).local_filename

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -12,6 +12,7 @@ from ocrd.processor.base import Processor, run_processor, run_cli
 class TestProcessor(TestCase):
 
     def setUp(self):
+        initLogging()
         self.resolver = Resolver()
         self.workspace = self.resolver.workspace_from_url(assets.url_of('SBB0000F29300010000/data/mets.xml'))
 
@@ -98,12 +99,46 @@ class TestProcessor(TestCase):
             ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar3', pageId='phys_0002')
             ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar4', pageId='phys_0002')
             proc = ZipTestProcessor(workspace=ws, input_file_grp='GRP1,GRP2')
+            tuples = [(one.ID, two.ID) for one, two in proc.zip_input_files()]
+            assert ('foobar1', 'foobar2') in tuples
+            assert ('foobar3', 'foobar4') in tuples
+            tuples = [(one.ID, two) for one, two in proc.zip_input_files(mimetype=MIMETYPE_PAGE)]
+            assert ('foobar1', None) in tuples
             tuples = [(one.ID, two.ID) for one, two in proc.zip_input_files(mimetype=r'//application/(vnd.prima.page|alto)\+xml')]
             assert ('foobar1', 'foobar2') in tuples
             assert ('foobar3', 'foobar4') in tuples
 
+    def test_zip_input_files_multi_mixed(self):
+        class ZipTestProcessor(Processor): pass
+        with pushd_popd(tempdir=True) as tempdir:
+            ws = self.resolver.workspace_from_nothing(directory=tempdir)
+            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar1', pageId='phys_0001')
+            ws.add_file('GRP1', mimetype='image/png', ID='foobar1img1', pageId='phys_0001')
+            ws.add_file('GRP1', mimetype='image/png', ID='foobar1img2', pageId='phys_0001')
+            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar2', pageId='phys_0001')
+            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar3', pageId='phys_0002')
+            ws.add_file('GRP2', mimetype='image/tiff', ID='foobar4', pageId='phys_0002')
+            proc = ZipTestProcessor(workspace=ws, input_file_grp='GRP1,GRP2')
+            tuples = [(one.ID, two.ID) for one, two in proc.zip_input_files()]
+            assert ('foobar1', 'foobar2') in tuples
+            assert ('foobar3', 'foobar4') in tuples
+            tuples = [(one.ID, two) for one, two in proc.zip_input_files(mimetype=MIMETYPE_PAGE)]
+            assert ('foobar3', None) in tuples
+            ws.add_file('GRP2', mimetype='image/tiff', ID='foobar4dup', pageId='phys_0002')
+            proc = ZipTestProcessor(workspace=ws, input_file_grp='GRP1,GRP2')
+            tuples = [(one.ID, two.ID) for one, two in proc.zip_input_files(on_error='first')]
+            assert ('foobar1', 'foobar2') in tuples
+            assert ('foobar3', 'foobar4') in tuples
+            tuples = [(one.ID, two) for one, two in proc.zip_input_files(on_error='skip')]
+            assert ('foobar3', None) in tuples
+            with self.assertRaisesRegex(Exception, "No PAGE-XML for page .* in fileGrp .* but multiple matches."):
+                tuples = proc.zip_input_files(on_error='abort')
+            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar2dup', pageId='phys_0001')
+            proc = ZipTestProcessor(workspace=ws, input_file_grp='GRP1,GRP2')
+            with self.assertRaisesRegex(Exception, "Multiple PAGE-XML matches for page"):
+                tuples = proc.zip_input_files()
+
     def test_zip_input_files_require_first(self):
-        initLogging()
         class ZipTestProcessor(Processor): pass
         self.capture_out_err()
         with pushd_popd(tempdir=True) as tempdir:

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -94,11 +94,11 @@ class TestProcessor(TestCase):
         with pushd_popd(tempdir=True) as tempdir:
             ws = self.resolver.workspace_from_nothing(directory=tempdir)
             ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar1', pageId='phys_0001')
-            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar2', pageId='phys_0001')
+            ws.add_file('GRP2', mimetype='application/alto+xml', ID='foobar2', pageId='phys_0001')
             ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar3', pageId='phys_0002')
             ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar4', pageId='phys_0002')
             proc = ZipTestProcessor(workspace=ws, input_file_grp='GRP1,GRP2')
-            tuples = [(one.ID, two.ID) for one, two in proc.zip_input_files()]
+            tuples = [(one.ID, two.ID) for one, two in proc.zip_input_files(mimetype=r'//application/(vnd.prima.page|alto)\+xml')]
             assert ('foobar1', 'foobar2') in tuples
             assert ('foobar3', 'foobar4') in tuples
 

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -30,9 +30,19 @@ class TestProcessor(TestCase):
         with self.assertRaisesRegex(Exception, 'pass mets_url to create a workspace'):
             run_processor(DummyProcessor, resolver=self.resolver)
 
+    def test_no_input_file_grp(self):
+        processor = run_processor(DummyProcessor,
+                                  resolver=self.resolver,
+                                  mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml'))
+        with self.assertRaisesRegex(Exception, 'Processor is missing input fileGrp'):
+            _ = processor.input_files
+
     def test_with_mets_url_input_files(self):
-        processor = run_processor(DummyProcessor, resolver=self.resolver, mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml'))
-        self.assertEqual(len(processor.input_files), 20)
+        processor = run_processor(DummyProcessor,
+                                  input_file_grp='OCR-D-SEG-PAGE',
+                                  resolver=self.resolver,
+                                  mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml'))
+        self.assertEqual(len(processor.input_files), 2)
         self.assertTrue(all([f.mimetype == MIMETYPE_PAGE for f in processor.input_files]))
 
     def test_parameter(self):
@@ -44,10 +54,11 @@ class TestProcessor(TestCase):
                 processor = run_processor(
                     DummyProcessor,
                     parameter=json.load(f),
+                    input_file_grp="OCR-D-IMG",
                     resolver=self.resolver,
                     mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml')
                 )
-            self.assertEqual(len(processor.input_files), 20)
+            self.assertEqual(len(processor.input_files), 3)
 
     def test_verify(self):
         proc = DummyProcessor(self.workspace)


### PR DESCRIPTION
AFAICS this would already be useful for:
- [ocrd-cor-asv-ann-evaluate](https://github.com/ASVLeipzig/cor-asv-ann/blob/master/ocrd_cor_asv_ann/wrapper/evaluate.py) (where I drafted it)
- [ocrd-cis-align](https://github.com/cisocrgroup/ocrd_cis/blob/master/ocrd_cis/align/cli.py) (original implementation)
- [ocrd-dinglehopper](https://github.com/qurator-spk/dinglehopper/blob/master/qurator/dinglehopper/ocrd_cli.py)
- [ocrd-segment-evaluate](https://github.com/OCR-D/ocrd_segment/blob/master/ocrd_segment/evaluate.py)
- [ocrd-segment-from-masks](https://github.com/OCR-D/ocrd_segment/blob/master/ocrd_segment/import_image_segmentation.py)
- [ocrd-segment-replace-page](https://github.com/OCR-D/ocrd_segment/blob/maskrcnn-cli/ocrd_segment/replace_page.py)

Most of these recently broke with the `ocrd_mets.find_files` generator change.