### PR TITLE
add_metadata: add version info

### DIFF
--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -94,8 +94,16 @@ class Processor():
                         externalModel="ocrd-tool",
                         externalId="parameters",
                         Label=[LabelType(type_=name,
-                            value=self.parameter[name])
-                            for name in self.parameter.keys()])]))
+                                         value=self.parameter[name])
+                               for name in self.parameter.keys()]),
+                            LabelsType(
+                        externalModel="ocrd-tool",
+                        externalId="version",
+                        Label=[LabelType(type_=self.ocrd_tool['executable'],
+                                         value=self.version),
+                               LabelType(type_='ocrd/core',
+                                         value=OCRD_VERSION)])
+                    ]))
 
     @property
     def input_files(self):


### PR DESCRIPTION
I think it would be useful to annotate version info directly in the PAGE metadata besides the parameters, example:
```xml
            <pc:Labels externalModel="ocrd-tool" externalId="version">
                <pc:Label value="0.10.0" type="ocrd-tesserocr-recognize"/>
                <pc:Label value="2.19.0" type="ocrd/core"/>
            </pc:Labels>
```

I know we have `mets:agent/mets:name` already, but that does not show exactly which file(Grp) came from which version (one can only guess by the order of `mets:agent` entries and the dates of the files.

This is useful especially for GT production where workspaces have a longer digital life, and one sometimes needs to touch and reconstruct previous steps.