### PR TITLE
auto-invalidate derived images when changing coords

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Sat Oct 31 00:47:39 2020 by generateDS.py version 2.35.20.
+# Generated Sat Oct 31 00:59:08 2020 by generateDS.py version 2.35.20.
 # Python 3.6.7 (default, Oct 22 2018, 11:32:17)  [GCC 8.2.0]
 #
 # Command line options:
@@ -3067,6 +3067,15 @@ class PageType(GeneratedsSuper):
         for image in removed_images:
             self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
                 image.get_comments() or '', name))
+    def set_Border(self, Border):
+        """
+        Set coordinate polygon by given object.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been cropped with a bbox
+         of the previous polygon).
+        """
+        self.invalidate_AlternativeImage(feature_selector='cropped')
+        self.Border = Border
     def set_orientation(self, orientation):
         """
         Set deskewing angle to given number.

--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Sep 21 14:00:49 2020 by generateDS.py version 2.35.20.
-# Python 3.6.9 (default, Jul 17 2020, 12:50:27)  [GCC 8.4.0]
+# Generated Sat Oct 31 00:32:57 2020 by generateDS.py version 2.35.20.
+# Python 3.6.7 (default, Oct 22 2018, 11:32:17)  [GCC 8.2.0]
 #
 # Command line options:
 #   ('-f', '')
@@ -16,7 +16,7 @@
 #   ocrd_validators/ocrd_validators/page.xsd
 #
 # Command line:
-#   /home/kba/build/github.com/OCR-D/monorepo/ocrd_all/venv/bin/generateDS -f --root-element="PcGts" -o "ocrd_models/ocrd_models/ocrd_page_generateds.py" --disable-generatedssuper-lookup --user-methods="ocrd_models/ocrd_page_user_methods.py" ocrd_validators/ocrd_validators/page.xsd
+#   generateDS -f --root-element="PcGts" -o "ocrd_models/ocrd_models/ocrd_page_generateds.py" --disable-generatedssuper-lookup --user-methods="ocrd_models/ocrd_page_user_methods.py" ocrd_validators/ocrd_validators/page.xsd
 #
 # Current working directory (os.getcwd()):
 #   core
@@ -3036,6 +3036,37 @@ class PageType(GeneratedsSuper):
                 else:
                     ret = in_reading_order + [r for r in ret if r not in in_reading_order]
         return ret
+    def invalidate_AlternativeImage(self, feature_selector=None):
+        """
+        Remove derived images from this segment (due to changed coordinates).
+    
+        If ``feature_selector`` is not none, remove only images with
+        matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
+        """
+        existing_images = self.AlternativeImage or []
+        removed_images = []
+        if feature_selector:
+            new_images = []
+            for image in existing_images:
+                features = image.get_comments() or ''
+                if any(feature in features.split(',')
+                       for feature in feature_selector.split(',') if feature):
+                    removed_images.append(image)
+                else:
+                    new_images.append(image)
+            self.AlternativeImage = new_images
+        else:
+            removed_images = existing_images
+            self.AlternativeImage = []
+        if hasattr(self, 'id'):
+            name = self.id
+        elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'pcGtsId'):
+            name = self.parent_object_.pcGtsId
+        else:
+            name = ''
+        for image in removed_images:
+            self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
+                image.get_comments() or '', name))
 # end class PageType
 
 
@@ -3633,6 +3664,37 @@ class TextLineType(GeneratedsSuper):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def invalidate_AlternativeImage(self, feature_selector=None):
+        """
+        Remove derived images from this segment (due to changed coordinates).
+    
+        If ``feature_selector`` is not none, remove only images with
+        matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
+        """
+        existing_images = self.AlternativeImage or []
+        removed_images = []
+        if feature_selector:
+            new_images = []
+            for image in existing_images:
+                features = image.get_comments() or ''
+                if any(feature in features.split(',')
+                       for feature in feature_selector.split(',') if feature):
+                    removed_images.append(image)
+                else:
+                    new_images.append(image)
+            self.AlternativeImage = new_images
+        else:
+            removed_images = existing_images
+            self.AlternativeImage = []
+        if hasattr(self, 'id'):
+            name = self.id
+        elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'pcGtsId'):
+            name = self.parent_object_.pcGtsId
+        else:
+            name = ''
+        for image in removed_images:
+            self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
+                image.get_comments() or '', name))
 # end class TextLineType
 
 
@@ -4047,6 +4109,37 @@ class WordType(GeneratedsSuper):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def invalidate_AlternativeImage(self, feature_selector=None):
+        """
+        Remove derived images from this segment (due to changed coordinates).
+    
+        If ``feature_selector`` is not none, remove only images with
+        matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
+        """
+        existing_images = self.AlternativeImage or []
+        removed_images = []
+        if feature_selector:
+            new_images = []
+            for image in existing_images:
+                features = image.get_comments() or ''
+                if any(feature in features.split(',')
+                       for feature in feature_selector.split(',') if feature):
+                    removed_images.append(image)
+                else:
+                    new_images.append(image)
+            self.AlternativeImage = new_images
+        else:
+            removed_images = existing_images
+            self.AlternativeImage = []
+        if hasattr(self, 'id'):
+            name = self.id
+        elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'pcGtsId'):
+            name = self.parent_object_.pcGtsId
+        else:
+            name = ''
+        for image in removed_images:
+            self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
+                image.get_comments() or '', name))
 # end class WordType
 
 
@@ -4414,6 +4507,37 @@ class GlyphType(GeneratedsSuper):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def invalidate_AlternativeImage(self, feature_selector=None):
+        """
+        Remove derived images from this segment (due to changed coordinates).
+    
+        If ``feature_selector`` is not none, remove only images with
+        matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
+        """
+        existing_images = self.AlternativeImage or []
+        removed_images = []
+        if feature_selector:
+            new_images = []
+            for image in existing_images:
+                features = image.get_comments() or ''
+                if any(feature in features.split(',')
+                       for feature in feature_selector.split(',') if feature):
+                    removed_images.append(image)
+                else:
+                    new_images.append(image)
+            self.AlternativeImage = new_images
+        else:
+            removed_images = existing_images
+            self.AlternativeImage = []
+        if hasattr(self, 'id'):
+            name = self.id
+        elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'pcGtsId'):
+            name = self.parent_object_.pcGtsId
+        else:
+            name = ''
+        for image in removed_images:
+            self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
+                image.get_comments() or '', name))
 # end class GlyphType
 
 
@@ -8867,6 +8991,37 @@ class RegionType(GeneratedsSuper):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def invalidate_AlternativeImage(self, feature_selector=None):
+        """
+        Remove derived images from this segment (due to changed coordinates).
+    
+        If ``feature_selector`` is not none, remove only images with
+        matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
+        """
+        existing_images = self.AlternativeImage or []
+        removed_images = []
+        if feature_selector:
+            new_images = []
+            for image in existing_images:
+                features = image.get_comments() or ''
+                if any(feature in features.split(',')
+                       for feature in feature_selector.split(',') if feature):
+                    removed_images.append(image)
+                else:
+                    new_images.append(image)
+            self.AlternativeImage = new_images
+        else:
+            removed_images = existing_images
+            self.AlternativeImage = []
+        if hasattr(self, 'id'):
+            name = self.id
+        elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'pcGtsId'):
+            name = self.parent_object_.pcGtsId
+        else:
+            name = ''
+        for image in removed_images:
+            self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
+                image.get_comments() or '', name))
 # end class RegionType
 
 

--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Sat Oct 31 00:32:57 2020 by generateDS.py version 2.35.20.
+# Generated Sat Oct 31 00:47:39 2020 by generateDS.py version 2.35.20.
 # Python 3.6.7 (default, Oct 22 2018, 11:32:17)  [GCC 8.2.0]
 #
 # Command line options:
@@ -3067,6 +3067,17 @@ class PageType(GeneratedsSuper):
         for image in removed_images:
             self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
                 image.get_comments() or '', name))
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class PageType
 
 
@@ -3218,6 +3229,22 @@ class CoordsType(GeneratedsSuper):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_points(self, points):
+        """
+        Set coordinate polygon by given string.
+        Moreover, invalidate the parent's AlternativeImages
+        (because they will have been cropped with a bbox
+         of the previous polygon).
+        """
+        if hasattr(self, 'parent_object_'):
+            parent = self.parent_object_
+            if hasattr(parent, 'invalidate_AlternativeImage'):
+                # RegionType, TextLineType, WordType, GlyphType:
+                parent.invalidate_AlternativeImage()
+            elif hasattr(parent, 'parent_object_') and hasattr(parent.parent_object_, 'invalidate_AlternativeImage'):
+                # BorderType:
+                parent.parent_object_.invalidate_AlternativeImage(feature_selector='cropped')
+        self.points = points
 # end class CoordsType
 
 
@@ -3695,6 +3722,20 @@ class TextLineType(GeneratedsSuper):
         for image in removed_images:
             self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
                 image.get_comments() or '', name))
+    def set_Coords(self, Coords):
+        """
+        Set coordinate polygon by given object.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been cropped with a bbox
+         of the previous polygon).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # RegionType, TextLineType, WordType, GlyphType:
+            self.invalidate_AlternativeImage()
+        elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'invalidate_AlternativeImage'):
+            # BorderType:
+            self.parent_object_.invalidate_AlternativeImage(feature_selector='cropped')
+        self.Coords = Coords
 # end class TextLineType
 
 
@@ -4140,6 +4181,20 @@ class WordType(GeneratedsSuper):
         for image in removed_images:
             self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
                 image.get_comments() or '', name))
+    def set_Coords(self, Coords):
+        """
+        Set coordinate polygon by given object.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been cropped with a bbox
+         of the previous polygon).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # RegionType, TextLineType, WordType, GlyphType:
+            self.invalidate_AlternativeImage()
+        elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'invalidate_AlternativeImage'):
+            # BorderType:
+            self.parent_object_.invalidate_AlternativeImage(feature_selector='cropped')
+        self.Coords = Coords
 # end class WordType
 
 
@@ -4538,6 +4593,20 @@ class GlyphType(GeneratedsSuper):
         for image in removed_images:
             self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
                 image.get_comments() or '', name))
+    def set_Coords(self, Coords):
+        """
+        Set coordinate polygon by given object.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been cropped with a bbox
+         of the previous polygon).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # RegionType, TextLineType, WordType, GlyphType:
+            self.invalidate_AlternativeImage()
+        elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'invalidate_AlternativeImage'):
+            # BorderType:
+            self.parent_object_.invalidate_AlternativeImage(feature_selector='cropped')
+        self.Coords = Coords
 # end class GlyphType
 
 
@@ -7153,6 +7222,20 @@ class BorderType(GeneratedsSuper):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_Coords(self, Coords):
+        """
+        Set coordinate polygon by given object.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been cropped with a bbox
+         of the previous polygon).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # RegionType, TextLineType, WordType, GlyphType:
+            self.invalidate_AlternativeImage()
+        elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'invalidate_AlternativeImage'):
+            # BorderType:
+            self.parent_object_.invalidate_AlternativeImage(feature_selector='cropped')
+        self.Coords = Coords
 # end class BorderType
 
 
@@ -9022,6 +9105,20 @@ class RegionType(GeneratedsSuper):
         for image in removed_images:
             self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
                 image.get_comments() or '', name))
+    def set_Coords(self, Coords):
+        """
+        Set coordinate polygon by given object.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been cropped with a bbox
+         of the previous polygon).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # RegionType, TextLineType, WordType, GlyphType:
+            self.invalidate_AlternativeImage()
+        elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'invalidate_AlternativeImage'):
+            # BorderType:
+            self.parent_object_.invalidate_AlternativeImage(feature_selector='cropped')
+        self.Coords = Coords
 # end class RegionType
 
 
@@ -10877,6 +10974,17 @@ class AdvertRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class AdvertRegionType
 
 
@@ -11018,6 +11126,17 @@ class MusicRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class MusicRegionType
 
 
@@ -11131,6 +11250,17 @@ class MapRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class MapRegionType
 
 
@@ -11273,6 +11403,17 @@ class ChemRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class ChemRegionType
 
 
@@ -11415,6 +11556,17 @@ class MathsRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class MathsRegionType
 
 
@@ -11558,6 +11710,17 @@ class SeparatorRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class SeparatorRegionType
 
 
@@ -11766,6 +11929,17 @@ class ChartRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class ChartRegionType
 
 
@@ -12015,6 +12189,17 @@ class TableRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class TableRegionType
 
 
@@ -12194,6 +12379,17 @@ class GraphicRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class GraphicRegionType
 
 
@@ -12373,6 +12569,17 @@ class LineDrawingRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class LineDrawingRegionType
 
 
@@ -12565,6 +12772,17 @@ class ImageRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class ImageRegionType
 
 
@@ -13045,6 +13263,17 @@ class TextRegionType(RegionType):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
+    def set_orientation(self, orientation):
+        """
+        Set deskewing angle to given number.
+        Moreover, invalidate self's AlternativeImages
+        (because they will have been rotated and enlarged
+         with the angle of the previous value).
+        """
+        if hasattr(self, 'invalidate_AlternativeImage'):
+            # PageType, RegionType:
+            self.invalidate_AlternativeImage(feature_selector='deskewed')
+        self.orientation = orientation
 # end class TextRegionType
 
 

--- a/ocrd_models/ocrd_page_user_methods.py
+++ b/ocrd_models/ocrd_page_user_methods.py
@@ -110,6 +110,10 @@ METHOD_SPECS = (
     _add_method(r'^(PcGtsType)$', 'get_AllAlternativeImagePaths'),
     _add_method(r'^(PcGtsType)$', 'prune_ReadingOrder'),
     _add_method(r'^(PageType|RegionType|TextLineType|WordType|GlyphType)$', 'invalidate_AlternativeImage'),
+    _add_method(r'^(BorderType|RegionType|TextLineType|WordType|GlyphType)$', 'set_Coords'),
+    _add_method(r'^(CoordsType)$', 'set_points'),
+    # for some reason, pagecontent.xsd does not declare @orientation at the abstract/base RegionType:
+    _add_method(r'^(PageType|AdvertRegionType|MusicRegionType|MapRegionType|ChemRegionType|MathsRegionType|SeparatorRegionType|ChartRegionType|TableRegionType|GraphicRegionType|LineDrawingRegionType|ImageRegionType|TextRegionType)$', 'set_orientation'),
     )
 
 

--- a/ocrd_models/ocrd_page_user_methods.py
+++ b/ocrd_models/ocrd_page_user_methods.py
@@ -109,6 +109,7 @@ METHOD_SPECS = (
     _add_method(r'^(PageType)$', 'get_AllRegions'),
     _add_method(r'^(PcGtsType)$', 'get_AllAlternativeImagePaths'),
     _add_method(r'^(PcGtsType)$', 'prune_ReadingOrder'),
+    _add_method(r'^(PageType|RegionType|TextLineType|WordType|GlyphType)$', 'invalidate_AlternativeImage'),
     )
 
 

--- a/ocrd_models/ocrd_page_user_methods.py
+++ b/ocrd_models/ocrd_page_user_methods.py
@@ -111,6 +111,7 @@ METHOD_SPECS = (
     _add_method(r'^(PcGtsType)$', 'prune_ReadingOrder'),
     _add_method(r'^(PageType|RegionType|TextLineType|WordType|GlyphType)$', 'invalidate_AlternativeImage'),
     _add_method(r'^(BorderType|RegionType|TextLineType|WordType|GlyphType)$', 'set_Coords'),
+    _add_method(r'^(PageType)$', 'set_Border'),
     _add_method(r'^(CoordsType)$', 'set_points'),
     # for some reason, pagecontent.xsd does not declare @orientation at the abstract/base RegionType:
     _add_method(r'^(PageType|AdvertRegionType|MusicRegionType|MapRegionType|ChemRegionType|MathsRegionType|SeparatorRegionType|ChartRegionType|TableRegionType|GraphicRegionType|LineDrawingRegionType|ImageRegionType|TextRegionType)$', 'set_orientation'),

--- a/ocrd_models/ocrd_page_user_methods/invalidate_AlternativeImage.py
+++ b/ocrd_models/ocrd_page_user_methods/invalidate_AlternativeImage.py
@@ -1,0 +1,31 @@
+def invalidate_AlternativeImage(self, feature_selector=None):
+    """
+    Remove derived images from this segment (due to changed coordinates).
+
+    If ``feature_selector`` is not none, remove only images with
+    matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
+    """
+    existing_images = self.AlternativeImage or []
+    removed_images = []
+    if feature_selector:
+        new_images = []
+        for image in existing_images:
+            features = image.get_comments() or ''
+            if any(feature in features.split(',')
+                   for feature in feature_selector.split(',') if feature):
+                removed_images.append(image)
+            else:
+                new_images.append(image)
+        self.AlternativeImage = new_images
+    else:
+        removed_images = existing_images
+        self.AlternativeImage = []
+    if hasattr(self, 'id'):
+        name = self.id
+    elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'pcGtsId'):
+        name = self.parent_object_.pcGtsId
+    else:
+        name = ''
+    for image in removed_images:
+        self.gds_collector_.add_message('Removing AlternativeImage %s from "%s"' % (
+            image.get_comments() or '', name))

--- a/ocrd_models/ocrd_page_user_methods/set_Border.py
+++ b/ocrd_models/ocrd_page_user_methods/set_Border.py
@@ -1,0 +1,9 @@
+def set_Border(self, Border):
+    """
+    Set coordinate polygon by given object.
+    Moreover, invalidate self's AlternativeImages
+    (because they will have been cropped with a bbox
+     of the previous polygon).
+    """
+    self.invalidate_AlternativeImage(feature_selector='cropped')
+    self.Border = Border

--- a/ocrd_models/ocrd_page_user_methods/set_Coords.py
+++ b/ocrd_models/ocrd_page_user_methods/set_Coords.py
@@ -1,0 +1,14 @@
+def set_Coords(self, Coords):
+    """
+    Set coordinate polygon by given object.
+    Moreover, invalidate self's AlternativeImages
+    (because they will have been cropped with a bbox
+     of the previous polygon).
+    """
+    if hasattr(self, 'invalidate_AlternativeImage'):
+        # RegionType, TextLineType, WordType, GlyphType:
+        self.invalidate_AlternativeImage()
+    elif hasattr(self, 'parent_object_') and hasattr(self.parent_object_, 'invalidate_AlternativeImage'):
+        # BorderType:
+        self.parent_object_.invalidate_AlternativeImage(feature_selector='cropped')
+    self.Coords = Coords

--- a/ocrd_models/ocrd_page_user_methods/set_orientation.py
+++ b/ocrd_models/ocrd_page_user_methods/set_orientation.py
@@ -1,0 +1,11 @@
+def set_orientation(self, orientation):
+    """
+    Set deskewing angle to given number.
+    Moreover, invalidate self's AlternativeImages
+    (because they will have been rotated and enlarged
+     with the angle of the previous value).
+    """
+    if hasattr(self, 'invalidate_AlternativeImage'):
+        # PageType, RegionType:
+        self.invalidate_AlternativeImage(feature_selector='deskewed')
+    self.orientation = orientation

--- a/ocrd_models/ocrd_page_user_methods/set_points.py
+++ b/ocrd_models/ocrd_page_user_methods/set_points.py
@@ -1,0 +1,16 @@
+def set_points(self, points):
+    """
+    Set coordinate polygon by given string.
+    Moreover, invalidate the parent's AlternativeImages
+    (because they will have been cropped with a bbox
+     of the previous polygon).
+    """
+    if hasattr(self, 'parent_object_'):
+        parent = self.parent_object_
+        if hasattr(parent, 'invalidate_AlternativeImage'):
+            # RegionType, TextLineType, WordType, GlyphType:
+            parent.invalidate_AlternativeImage()
+        elif hasattr(parent, 'parent_object_') and hasattr(parent.parent_object_, 'invalidate_AlternativeImage'):
+            # BorderType:
+            parent.parent_object_.invalidate_AlternativeImage(feature_selector='cropped')
+    self.points = points


### PR DESCRIPTION
Fixes the issue described in [chat](https://gitter.im/OCR-D/Lobby?at=5f9c00a4dc70b5159adff92a) for all processors based on core Python. (Not sure about bashlib processors...)

(I added a warning to the default `GdsCollector` about the `AlternativeImage` removal. If and when #576 lands, these should appear in OCR-D logging somehow. :crossed_fingers:)

Thus, some workflows will work, while others will need to be re-defined.

As I said above, this still does not expose _all_ bad workflows, as it depends whether processors make their image requirements explicit (`feature_selector` and `feature_filter`) or not. If they do, we'll at least get exceptions `Found no AlternativeImage that satisfies all requirements` when running invalid workflows. But if they don't, there might be strange errors (like when 3-dim integer arrays from raw RGB images are passed to algorithms that need 1-dim boolean arrays from binarization) or no errors at all (like when implicit internal binarization happens or denoising is simply missing).