### PR TITLE
TaskSequence.parse: instantiate given class

### DIFF
--- a/ocrd/ocrd/task_sequence.py
+++ b/ocrd/ocrd/task_sequence.py
@@ -36,7 +36,7 @@ class ProcessorTask():
                 tokens = tokens[3:]
             else:
                 raise Exception("Failed parsing task description '%s' with tokens remaining: '%s'" % (argstr, tokens))
-        return ProcessorTask(executable, input_file_grps, output_file_grps, parameters)
+        return cls(executable, input_file_grps, output_file_grps, parameters)
 
     def __init__(self, executable, input_file_grps, output_file_grps, parameters):
         self.executable = executable


### PR DESCRIPTION
I am doing a proof of concept for a workflow server – outside of core, just importing from it – and found this error: the class method should instantiate the passed class, not a fixed one, so subclasses can override properly.