### PR TITLE
ocrd_utils: drop numpy version range, #642

### DIFF
--- a/ocrd_utils/requirements.txt
+++ b/ocrd_utils/requirements.txt
@@ -1,5 +1,5 @@
 Pillow >= 7.2.0
-# All current versions of TensorFlow require numpy < 1.19.0,
-# so make sure that now newer version is installed here.
-numpy >= 1.17.0, < 1.19.0
+# XXX explicitly do not restrict the numpy version because different
+# tensorflow versions might require different versions
+numpy
 atomicwrites >= 1.3.0


### PR DESCRIPTION
I have tested this within ocrd_all with sbb_binarization (tf1), anybaseocr (tf21) and the new ocrd_calamari 1.0 (tf24) and have not run into numpy VersionConflicts anymore.