### PR TITLE
Workflow server

### DIFF
--- a/ocrd/ocrd/cli/__init__.py
+++ b/ocrd/ocrd/cli/__init__.py
@@ -16,6 +16,7 @@ def command_with_replaced_help(*replacements):
 from ocrd.cli.ocrd_tool import ocrd_tool_cli
 from ocrd.cli.workspace import workspace_cli
 from ocrd.cli.process import process_cli
+from ocrd.cli.workflow import workflow_cli
 from ocrd.cli.bashlib import bashlib_cli
 from ocrd.cli.validate import validate_cli
 from ocrd.decorators import ocrd_loglevel
@@ -33,6 +34,7 @@ def cli(**kwargs): # pylint: disable=unused-argument
 cli.add_command(ocrd_tool_cli)
 cli.add_command(workspace_cli)
 cli.add_command(process_cli)
+cli.add_command(workflow_cli)
 cli.add_command(bashlib_cli)
 cli.add_command(zip_cli)
 cli.add_command(validate_cli)

--- a/ocrd/ocrd/cli/process.py
+++ b/ocrd/ocrd/cli/process.py
@@ -4,7 +4,7 @@ CLI for task_sequence
 import click
 
 from ocrd_utils import getLogger, initLogging
-from ocrd.task_sequence import run_tasks
+from ocrd.task_sequence import run_tasks, parse_tasks
 
 from ..decorators import ocrd_loglevel
 
@@ -19,9 +19,10 @@ from ..decorators import ocrd_loglevel
 @click.argument('tasks', nargs=-1, required=True)
 def process_cli(log_level, mets, page_id, tasks, overwrite):
     """
-    Process a series of tasks
+    Run processor CLIs in a series of tasks
     """
     initLogging()
     log = getLogger('ocrd.cli.process')
+    tasks = parse_tasks(tasks)
     run_tasks(mets, log_level, page_id, tasks, overwrite)
     log.info("Finished")

--- a/ocrd/ocrd/cli/workflow.py
+++ b/ocrd/ocrd/cli/workflow.py
@@ -1,0 +1,104 @@
+"""
+CLI for task_sequence
+"""
+import click
+import flask
+
+from ocrd_utils import getLogger, initLogging
+from ocrd.task_sequence import run_tasks, parse_tasks
+
+from ..decorators import ocrd_loglevel
+from .process import process_cli
+
+@click.group("workflow")
+def workflow_cli():
+    """
+    Process a series of tasks
+    """
+    initLogging()
+
+# ----------------------------------------------------------------------
+# ocrd workflow process
+# ----------------------------------------------------------------------
+@workflow_cli.command('process')
+@ocrd_loglevel
+@click.option('-m', '--mets', help="METS to process", default="mets.xml")
+@click.option('-g', '--page-id', help="ID(s) of the pages to process")
+@click.option('--overwrite', is_flag=True, default=False, help="Remove output pages/images if they already exist")
+@click.argument('tasks', nargs=-1, required=True)
+def process_cli_alias(log_level, mets, page_id, tasks, overwrite):
+    """
+    Run processor CLIs in a series of tasks
+
+    (alias for ``ocrd process``)
+    """
+    process_cli(log_level, mets, page_id, tasks, overwrite)
+
+# ----------------------------------------------------------------------
+# ocrd workflow server
+# ----------------------------------------------------------------------
+@workflow_cli.command('server')
+@ocrd_loglevel
+@click.option('-h', '--host', help="host name/IP to listen at", default='127.0.0.1')
+@click.option('-p', '--port', help="TCP port to listen at", default=5000, type=click.IntRange(min=1024))
+@click.argument('tasks', nargs=-1, required=True)
+def server_cli(log_level, host, port, tasks):
+    """
+    Start server for a series of tasks to run processor CLIs or APIs on workspaces
+
+    Parse the given tasks and try to instantiate all Pythonic
+    processors among them with the given parameters.
+    Open a web server that listens on the given host and port
+    for GET requests named ``process`` with the following
+    (URL-encoded) arguments:
+
+        mets (string): Path name (relative to the server's CWD,
+                       or absolute) of the workspace to process
+
+        page_id (string): Comma-separated list of page IDs to process
+
+        overwrite (bool): Remove output pages/images if they already exist
+
+    The server will handle each request by running the tasks
+    on the given workspace. Pythonic processors will be run via API
+    (on those same instances).  Non-Pythonic processors (or those
+    not directly accessible in the current venv) will be run via CLI
+    normally, instantiating each time.
+    Also, between each contiguous chain of Pythonic tasks in the overall
+    series, no METS de/serialization will be performed.
+
+    Stop the server by sending SIGINT (e.g. via ctrl+c
+    on the terminal), or sending a GET request named ``shutdown``.
+    """
+    log = getLogger('ocrd.workflow.server')
+    log.debug("Parsing and instantiating %d tasks", len(tasks))
+    tasks = parse_tasks(tasks)
+    app = flask.Flask(__name__)
+    @app.route('/process')
+    def process(): # pylint: disable=unused-variable
+        if flask.request.args.get("mets"):
+            mets = flask.request.args["mets"]
+        else:
+            return 'Error: No METS'
+        if flask.request.args.get('page_id'):
+            page_id = flask.request.args["page_id"]
+        else:
+            page_id = ''
+        if flask.request.args.get('overwrite'):
+            overwrite = flask.request.args["overwrite"] in ["True", "true", "1"]
+        else:
+            overwrite = False
+        try:
+            run_tasks(mets, log_level, page_id, tasks, overwrite)
+        except Exception as e:
+            log.exception("Request '%s' failed", str(flask.request.args))
+            return 'Failed: %s' % str(e)
+        return 'Finished'
+    @app.route('/shutdown')
+    def shutdown(): # pylint: disable=unused-variable
+        fun = flask.request.environ.get('werkzeug.server.shutdown')
+        if fun is None:
+            raise RuntimeError('Not running with the Werkzeug Server')
+        fun()
+    log.debug("Running server on http://%s:%d", host, port)
+    app.run(host=host, port=port)

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -11,7 +11,7 @@ from ocrd_validators import ParameterValidator
 from ocrd_models.ocrd_page import MetadataItemType, LabelType, LabelsType
 
 # XXX imports must remain for backwards-compatibilty
-from .helpers import run_cli, run_processor, generate_processor_help # pylint: disable=unused-import
+from .helpers import run_api, run_cli, run_processor, generate_processor_help # pylint: disable=unused-import
 
 class Processor():
     """

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -27,11 +27,8 @@ class Processor():
             workspace,
             ocrd_tool=None,
             parameter=None,
-            # TODO OCR-D/core#274
-            # input_file_grp=None,
-            # output_file_grp=None,
-            input_file_grp="INPUT",
-            output_file_grp="OUTPUT",
+            input_file_grp=None,
+            output_file_grp=None,
             page_id=None,
             show_help=False,
             show_version=False,

--- a/ocrd/ocrd/task_sequence.py
+++ b/ocrd/ocrd/task_sequence.py
@@ -1,14 +1,27 @@
 import json
+import re
+import sys
 from shlex import split as shlex_split
 from distutils.spawn import find_executable as which # pylint: disable=import-error,no-name-in-module
 from subprocess import run, PIPE
 
-from ocrd_utils import getLogger, parse_json_string_or_file, set_json_key_value_overrides
+# workaround venvs created for Python>=3.8
+from pkg_resources import load_entry_point # pylint: disable=unused-import
+
+from ocrd_utils import (
+    getLogger,
+    setOverrideLogLevel,
+    parse_json_string_or_file,
+    set_json_key_value_overrides
+)
 # from collections import Counter
-from ocrd.processor.base import run_cli
+from ocrd import decorators
+from ocrd.processor.base import run_cli, run_api
 from ocrd.resolver import Resolver
 from ocrd_validators import ParameterValidator, WorkspaceValidator
 from ocrd_models import ValidationReport
+
+_processor_class = None # for exec in ProcessorTask.instantiate
 
 class ProcessorTask():
 
@@ -44,6 +57,7 @@ class ProcessorTask():
         self.output_file_grps = output_file_grps
         self.parameters = parameters
         self._ocrd_tool_json = None
+        self.instance = None # for API (instead of CLI) integration
 
     @property
     def ocrd_tool_json(self):
@@ -77,6 +91,59 @@ class ProcessorTask():
         if 'output_file_grp' in self.ocrd_tool_json and not self.output_file_grps:
             raise Exception("Processor requires output_file_grp but none was provided.")
         return report
+
+    def instantiate(self):
+        logger = getLogger('ocrd.task_sequence.ProcessorTask')
+        program = which(self.executable)
+        if not program:
+            logger.warning("Cannot find processor '%s' in PATH", self.executable)
+            return False
+        # run CLI merely to do imports and fetch class
+        with open(program) as f:
+            # check shebang in first line of CLI file for Python
+            line = f.readline().strip()
+            if not re.fullmatch('[#][!].*/python[0-9.]*', line):
+                logger.info("Non-Pythonic processor '%s' breaks the chain", self.executable)
+                return False
+            # compile Python processor from CLI file
+            try:
+                code = compile(f.read(), program, 'exec')
+            except (TypeError, SyntaxError, ValueError) as e:
+                logger.warning("Cannot compile and instantiate processor '%s': %s",
+                               self.executable, str(e))
+                return False
+        # temporarily monkey-patch entry point and sys.exit/sys.argv
+        def ignore(anything): # pylint: disable=unused-argument
+            return
+        global _processor_class
+        _processor_class = None
+        def get_processor_class(cls, **kwargs):
+            global _processor_class
+            _processor_class = cls
+        wrap_processor = decorators.ocrd_cli_wrap_processor
+        decorators.ocrd_cli_wrap_processor = get_processor_class
+        sys_exit = sys.exit
+        sys.exit = ignore
+        sys_argv = sys.argv
+        sys.argv = [self.executable]
+        # run Python processor from CLI file
+        __name__ = '__main__'
+        try:
+            exec(code)
+            logger.info("Instantiating %s for processor '%s'",
+                        _processor_class.__name__, self.executable)
+            # instantiate processor without workspace
+            self.instance = _processor_class(None, parameter=self.parameters)
+            # circumvent calling CLI to get .ocrd_tool_json
+            self._ocrd_tool_json = self.instance.ocrd_tool
+        except Exception as e:
+            logger.warning("Cannot exec and instantiate processor '%s': %s",
+                           self.executable, str(e))
+        # reset modules
+        sys.argv = sys_argv
+        sys.exit = sys_exit
+        decorators.ocrd_cli_wrap_processor = wrap_processor
+        return bool(self.instance)
 
     def __str__(self):
         ret = '%s -I %s -O %s' % (
@@ -117,43 +184,76 @@ def validate_tasks(tasks, workspace, page_id=None, overwrite=False):
     return report
 
 
-def run_tasks(mets, log_level, page_id, task_strs, overwrite=False):
+def parse_tasks(task_strs):
+    return [ProcessorTask.parse(task_str) for task_str in task_strs]
+
+def run_tasks(mets, log_level, page_id, tasks, overwrite=False):
     resolver = Resolver()
     workspace = resolver.workspace_from_url(mets)
+    if overwrite:
+        workspace.overwrite_mode = True
     log = getLogger('ocrd.task_sequence.run_tasks')
-    tasks = [ProcessorTask.parse(task_str) for task_str in task_strs]
+    if log_level:
+        setOverrideLogLevel(log_level)
 
     validate_tasks(tasks, workspace, page_id, overwrite)
 
     # Run the tasks
+    is_first = True
+    last_is_instance = False
     for task in tasks:
 
-        log.info("Start processing task '%s'", task)
+        is_instance = bool(task.instance)
+        log.info("Start processing %s task '%s'",
+                 "API" if is_instance else "CLI", task)
 
-        # execute cli
-        returncode = run_cli(
-            task.executable,
-            mets,
-            resolver,
-            workspace,
-            log_level=log_level,
-            page_id=page_id,
-            overwrite=overwrite,
-            input_file_grp=','.join(task.input_file_grps),
-            output_file_grp=','.join(task.output_file_grps),
-            parameter=json.dumps(task.parameters)
-        )
+        if (not is_first and
+            not is_instance and
+            last_is_instance):
+            workspace.save_mets()
 
-        # check return code
-        if returncode != 0:
-            raise Exception("%s exited with non-zero return value %s." % (task.executable, returncode))
+        if is_instance:
+            # execute API
+            error = run_api(
+                task.instance,
+                workspace,
+                page_id=page_id,
+                input_file_grp=','.join(task.input_file_grps),
+                output_file_grp=','.join(task.output_file_grps)
+            )
 
-        log.info("Finished processing task '%s'", task)
+            if error:
+                raise error
+        else:
+            # execute cli
+            returncode = run_cli(
+                task.executable,
+                mets,
+                resolver,
+                workspace,
+                log_level=log_level,
+                page_id=page_id,
+                overwrite=overwrite,
+                input_file_grp=','.join(task.input_file_grps),
+                output_file_grp=','.join(task.output_file_grps),
+                parameter=json.dumps(task.parameters)
+            )
 
-        # reload mets
-        workspace.reload_mets()
+            # check return code
+            if returncode != 0:
+                raise Exception("%s exited with non-zero return value %s." % (task.executable, returncode))
+
+            workspace.reload_mets()
 
         # check output file groups are in mets
         for output_file_grp in task.output_file_grps:
             if not output_file_grp in workspace.mets.file_groups:
                 raise Exception("Invalid state: expected output file group '%s' not in METS (despite processor success)" % output_file_grp)
+
+        log.info("Finished processing task '%s'", task)
+
+        is_first = False
+        last_is_instance = is_instance
+
+    if last_is_instance:
+        workspace.save_mets()

--- a/tests/test_task_sequence.py
+++ b/tests/test_task_sequence.py
@@ -12,7 +12,7 @@ from tests.data.wf_testcase import (
 
 from ocrd_utils import pushd_popd, MIMETYPE_PAGE
 from ocrd.resolver import Resolver
-from ocrd.task_sequence import run_tasks, validate_tasks, ProcessorTask
+from ocrd.task_sequence import parse_tasks, run_tasks, validate_tasks, ProcessorTask
 
 class TestOcrdWfStep(TestCase):
 
@@ -141,10 +141,11 @@ class TestOcrdWfStep(TestCase):
                 ws.add_file('GRP0', content='', local_filename='GRP0/foo', ID='file0', mimetype=MIMETYPE_PAGE, pageId=None)
                 ws.save_mets()
                 files_before = len(ws.mets.find_all_files())
-                run_tasks('mets.xml', 'DEBUG', None, [
+                tasks = parse_tasks([
                     "dummy -I OCR-D-IMG -O GRP1",
                     "dummy -I GRP1 -O GRP2",
                 ])
+                run_tasks('mets.xml', 'DEBUG', None, tasks)
                 ws.reload_mets()
                 # step 1: 2 images in OCR-D-IMG -> 2 images 2 PAGEXML in GRP1
                 # step 2: 2 images and 2 PAGEXML in GRP1 -> process just the PAGEXML


### PR DESCRIPTION
Implementation of the [workflow server](https://hackmd.io/23-JzLp_Q96cb6T0ttoFIA).

    ocrd --help

```
Commands:
  bashlib    Work with bash library
  log        Logging
  ocrd-tool  Work with ocrd-tool.json JSON_FILE
  validate   All the validation in one CLI
  process    Run processor CLIs in a series of tasks
  workflow   Process a series of tasks
  workspace  Working with workspace
  zip        Bag/Spill/Validate OCRD-ZIP bags
```

    ocrd workflow --help

```
Usage: ocrd workflow [OPTIONS] COMMAND [ARGS]...

  Process a series of tasks

Options:
  --help  Show this message and exit.

Commands:
  process  Run processor CLIs in a series of tasks alias for ``ocrd...
  server   Start server for a series of tasks to run processor CLIs or APIs...
```

    ocrd workflow server --help

```
Usage: ocrd workflow server [OPTIONS] TASKS...

  Start server for a series of tasks to run processor CLIs or APIs on
  workspaces

  Parse the given tasks and try to instantiate all Pythonic processors among
  them with the given parameters. Open a web server that listens on the
  given host and port for GET requests named ``process`` with the following
  (URL-encoded) arguments:

      mets (string): Path name (relative to the server's CWD,
      or absolute) of the workspace to process

      page_id (string): Comma-separated list of page IDs to process

      overwrite (bool): Remove output pages/images if they already exist

  The server will handle each request by running the tasks on the given
  workspace. Pythonic processors will be run via API (on those same
  instances).  Non-Pythonic processors (or those not directly accessible in
  the current venv) will be run via CLI normally, instantiating each time.
  Also, between each contiguous chain of Pythonic tasks in the overall
  series, no METS de/serialization will be performed.

  Stop the server by sending SIGINT (e.g. via ctrl+c on the terminal), or
  sending a GET request named ``shutdown``.

Options:
  -l, --log-level [OFF|ERROR|WARN|INFO|DEBUG|TRACE]
                                  Log level
  -h, --host TEXT                 host name/IP to listen at
  -p, --port INTEGER RANGE        TCP port to listen at
  --help                          Show this message and exit.
```

Example:

    ocrd workflow server -p 5000 'olena-binarize -P impl sauvola-ms-split -I OCR-D-IMG -O OCR-D-IMG-BINPAGE-sauvola' 'anybaseocr-crop -I OCR-D-IMG-BINPAGE-sauvola -O OCR-D-IMG-BINPAGE-sauvola-CROP' 'cis-ocropy-denoise -P noise_maxsize 3.0 -P level-of-operation page -I OCR-D-IMG-BINPAGE-sauvola-CROP -O OCR-D-IMG-BINPAGE-sauvola-CROP-DEN' 'tesserocr-deskew -P operation_level page -I OCR-D-IMG-BINPAGE-sauvola-CROP-DEN -O OCR-D-IMG-BINPAGE-sauvola-CROP-DEN-DESK-tesseract' 'cis-ocropy-deskew -P level-of-operation page -I OCR-D-IMG-BINPAGE-sauvola-CROP-DEN-DESK-tesseract -O OCR-D-IMG-BINPAGE-sauvola-CROP-DEN-DESK-tesseract-DESK-ocropy' 'tesserocr-recognize -P segmentation_level region -P model deu -I OCR-D-IMG-BINPAGE-sauvola-CROP-DEN-DESK-tesseract-DESK-ocropy -O OCR-D-IMG-BINPAGE-sauvola-CROP-DEN-DESK-tesseract-DESK-ocropy-OCR-tesseract-deu'

    curl -G -d mets=../kant_aufklaerung_1784/data/mets.xml -d overwrite=True -d page_id=PHYS_0017,PHYS_0020 http://127.0.0.1:5000/process
    curl -G -d mets=../blumenbach_anatomie_1805/mets.xml http://127.0.0.1:5000/process
    curl -G http://127.0.0.1:5000/shutdown

Please note that (as already explained [here](https://gist.github.com/bertsky/9cd1a6ed9c2f3925a5339ed52f9be458#gistcomment-3544628)) this only inreases efficiency for Python processors in the current venv, so bashlib processors or sub-venv processors will still be run via CLI. So you might want to group them differently in ocrd_all, or cascade workflows across sub-venvs.