### PR TITLE
Get all alternative images

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Fri Nov 27 15:25:12 2020 by generateDS.py version 2.35.20.
+# Generated Mon Jan  4 12:53:00 2021 by generateDS.py version 2.35.20.
 # Python 3.6.9 (default, Oct  8 2020, 12:12:24)  [GCC 8.4.0]
 #
 # Command line options:
@@ -3047,6 +3047,34 @@ class PageType(GeneratedsSuper):
                 else:
                     ret = in_reading_order + [r for r in ret if r not in in_reading_order]
         return ret
+    def get_AllAlternativeImages(self, page=True, region=True, line=True, word=True, glyph=True):
+        """
+        Get all the pc:AlternativeImage in a document
+    
+    
+        page (boolean): Get pc:Page level images
+        region (boolean): Get images on pc:*Region level
+        line (boolean) Get images on pc:TextLine level
+        word (boolean) Get images on pc:Word level
+        glyph (boolean) Get images on pc:Glyph level
+        """
+        ret = []
+        if page:
+            ret += self.get_AlternativeImage()
+        for this_region in self.get_AllRegions(['Text']):
+            if region:
+                ret += this_region.get_AlternativeImage()
+            for this_line in this_region.get_TextLine():
+                if line:
+                    ret += this_line.get_AlternativeImage()
+                for this_word in this_line.get_Word():
+                    if word:
+                        ret += this_word.get_AlternativeImage()
+                    for this_glyph in this_word.get_Glyph():
+                        if glyph:
+                            ret += this_glyph.get_AlternativeImage()
+        return ret
+    
     def invalidate_AlternativeImage(self, feature_selector=None):
         """
         Remove derived images from this segment (due to changed coordinates).

--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Fri Nov 27 15:25:12 2020 by generateDS.py version 2.35.20.
+# Generated Mon Jan  4 12:33:41 2021 by generateDS.py version 2.35.20.
 # Python 3.6.9 (default, Oct  8 2020, 12:12:24)  [GCC 8.4.0]
 #
 # Command line options:
@@ -1216,7 +1216,7 @@ class PcGtsType(GeneratedsSuper):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
-    def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True):
+    def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True, return_elems=False):
         """
         Get all the pc:AlternativeImage/@filename paths referenced in the PAGE-XML document.
     
@@ -1226,6 +1226,7 @@ class PcGtsType(GeneratedsSuper):
         line (boolean) Get images on pc:TextLine level
         word (boolean) Get images on pc:Word level
         glyph (boolean) Get images on pc:Glyph level
+        return_elems (boolean) Return not the paths but the AlternativeImage elements
         """
         from .constants import NAMESPACES, PAGE_REGION_TYPES # pylint: disable=relative-beyond-top-level,import-outside-toplevel
         from io import StringIO  # pylint: disable=import-outside-toplevel
@@ -1245,21 +1246,24 @@ class PcGtsType(GeneratedsSuper):
                     NAMESPACES['page']
                 ))
         doc = parsexmlstring_(sio.getvalue())  # pylint: disable=undefined-variable
+        xpath_suffix = 'page:AlternativeImage'
+        if not return_elems:
+            xpath_suffix += '/@filename'
         # shortcut
         if page and region and line and word and glyph:
-            ret += doc.xpath('//page:AlternativeImage/@filename', namespaces=NAMESPACES)
+            ret += doc.xpath('//%s' % xpath_suffix, namespaces=NAMESPACES)
         else:
             if page:
-                ret += doc.xpath('/page:PcGts/page:Page/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+                ret += doc.xpath('/page:PcGts/page:Page/%s' % xpath_suffix, namespaces=NAMESPACES)
             if region:
                 for class_ in PAGE_REGION_TYPES:
-                    ret += doc.xpath('//page:%sRegion/page:AlternativeImage/@filename' % class_, namespaces=NAMESPACES)
+                    ret += doc.xpath('//page:%sRegion/%s' % (class_, xpath_suffix), namespaces=NAMESPACES)
             if line:
-                ret += doc.xpath('//page:TextLine/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
             if word:
-                ret += doc.xpath('//page:Word/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
             if glyph:
-                ret += doc.xpath('//page:Glyph/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
     
         return ret
     def prune_ReadingOrder(self):

--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Jan  4 12:33:41 2021 by generateDS.py version 2.35.20.
+# Generated Fri Nov 27 15:25:12 2020 by generateDS.py version 2.35.20.
 # Python 3.6.9 (default, Oct  8 2020, 12:12:24)  [GCC 8.4.0]
 #
 # Command line options:
@@ -1216,7 +1216,7 @@ class PcGtsType(GeneratedsSuper):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
-    def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True, return_elems=False):
+    def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True):
         """
         Get all the pc:AlternativeImage/@filename paths referenced in the PAGE-XML document.
     
@@ -1226,7 +1226,6 @@ class PcGtsType(GeneratedsSuper):
         line (boolean) Get images on pc:TextLine level
         word (boolean) Get images on pc:Word level
         glyph (boolean) Get images on pc:Glyph level
-        return_elems (boolean) Return not the paths but the AlternativeImage elements
         """
         from .constants import NAMESPACES, PAGE_REGION_TYPES # pylint: disable=relative-beyond-top-level,import-outside-toplevel
         from io import StringIO  # pylint: disable=import-outside-toplevel
@@ -1246,24 +1245,21 @@ class PcGtsType(GeneratedsSuper):
                     NAMESPACES['page']
                 ))
         doc = parsexmlstring_(sio.getvalue())  # pylint: disable=undefined-variable
-        xpath_suffix = 'page:AlternativeImage'
-        if not return_elems:
-            xpath_suffix += '/@filename'
         # shortcut
         if page and region and line and word and glyph:
-            ret += doc.xpath('//%s' % xpath_suffix, namespaces=NAMESPACES)
+            ret += doc.xpath('//page:AlternativeImage/@filename', namespaces=NAMESPACES)
         else:
             if page:
-                ret += doc.xpath('/page:PcGts/page:Page/%s' % xpath_suffix, namespaces=NAMESPACES)
+                ret += doc.xpath('/page:PcGts/page:Page/page:AlternativeImage/@filename', namespaces=NAMESPACES)
             if region:
                 for class_ in PAGE_REGION_TYPES:
-                    ret += doc.xpath('//page:%sRegion/%s' % (class_, xpath_suffix), namespaces=NAMESPACES)
+                    ret += doc.xpath('//page:%sRegion/page:AlternativeImage/@filename' % class_, namespaces=NAMESPACES)
             if line:
-                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+                ret += doc.xpath('//page:TextLine/page:AlternativeImage/@filename', namespaces=NAMESPACES)
             if word:
-                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+                ret += doc.xpath('//page:Word/page:AlternativeImage/@filename', namespaces=NAMESPACES)
             if glyph:
-                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+                ret += doc.xpath('//page:Glyph/page:AlternativeImage/@filename', namespaces=NAMESPACES)
     
         return ret
     def prune_ReadingOrder(self):

--- a/ocrd_models/ocrd_page_user_methods.py
+++ b/ocrd_models/ocrd_page_user_methods.py
@@ -108,6 +108,7 @@ METHOD_SPECS = (
     _add_method(r'^(UnorderedGroupType|UnorderedGroupIndexedType)$', 'get_UnorderedGroupChildren'),
     _add_method(r'^(PageType)$', 'get_AllRegions'),
     _add_method(r'^(PcGtsType)$', 'get_AllAlternativeImagePaths'),
+    _add_method(r'^(PageType)$', 'get_AllAlternativeImages'),
     _add_method(r'^(PcGtsType)$', 'prune_ReadingOrder'),
     _add_method(r'^(PageType|RegionType|TextLineType|WordType|GlyphType)$', 'invalidate_AlternativeImage'),
     _add_method(r'^(BorderType|RegionType|TextLineType|WordType|GlyphType)$', 'set_Coords'),

--- a/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImagePaths.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImagePaths.py
@@ -1,4 +1,4 @@
-def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True, return_elems=False):
+def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True):
     """
     Get all the pc:AlternativeImage/@filename paths referenced in the PAGE-XML document.
 
@@ -8,7 +8,6 @@ def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=T
     line (boolean) Get images on pc:TextLine level
     word (boolean) Get images on pc:Word level
     glyph (boolean) Get images on pc:Glyph level
-    return_elems (boolean) Return not the paths but the AlternativeImage elements
     """
     from .constants import NAMESPACES, PAGE_REGION_TYPES # pylint: disable=relative-beyond-top-level,import-outside-toplevel
     from io import StringIO  # pylint: disable=import-outside-toplevel
@@ -28,23 +27,20 @@ def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=T
                 NAMESPACES['page']
             ))
     doc = parsexmlstring_(sio.getvalue())  # pylint: disable=undefined-variable
-    xpath_suffix = 'page:AlternativeImage'
-    if not return_elems:
-        xpath_suffix += '/@filename'
     # shortcut
     if page and region and line and word and glyph:
-        ret += doc.xpath('//%s' % xpath_suffix, namespaces=NAMESPACES)
+        ret += doc.xpath('//page:AlternativeImage/@filename', namespaces=NAMESPACES)
     else:
         if page:
-            ret += doc.xpath('/page:PcGts/page:Page/%s' % xpath_suffix, namespaces=NAMESPACES)
+            ret += doc.xpath('/page:PcGts/page:Page/page:AlternativeImage/@filename', namespaces=NAMESPACES)
         if region:
             for class_ in PAGE_REGION_TYPES:
-                ret += doc.xpath('//page:%sRegion/%s' % (class_, xpath_suffix), namespaces=NAMESPACES)
+                ret += doc.xpath('//page:%sRegion/page:AlternativeImage/@filename' % class_, namespaces=NAMESPACES)
         if line:
-            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+            ret += doc.xpath('//page:TextLine/page:AlternativeImage/@filename', namespaces=NAMESPACES)
         if word:
-            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+            ret += doc.xpath('//page:Word/page:AlternativeImage/@filename', namespaces=NAMESPACES)
         if glyph:
-            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+            ret += doc.xpath('//page:Glyph/page:AlternativeImage/@filename', namespaces=NAMESPACES)
 
     return ret

--- a/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImagePaths.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImagePaths.py
@@ -1,4 +1,4 @@
-def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True):
+def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True, return_elems=False):
     """
     Get all the pc:AlternativeImage/@filename paths referenced in the PAGE-XML document.
 
@@ -8,6 +8,7 @@ def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=T
     line (boolean) Get images on pc:TextLine level
     word (boolean) Get images on pc:Word level
     glyph (boolean) Get images on pc:Glyph level
+    return_elems (boolean) Return not the paths but the AlternativeImage elements
     """
     from .constants import NAMESPACES, PAGE_REGION_TYPES # pylint: disable=relative-beyond-top-level,import-outside-toplevel
     from io import StringIO  # pylint: disable=import-outside-toplevel
@@ -27,20 +28,23 @@ def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=T
                 NAMESPACES['page']
             ))
     doc = parsexmlstring_(sio.getvalue())  # pylint: disable=undefined-variable
+    xpath_suffix = 'page:AlternativeImage'
+    if not return_elems:
+        xpath_suffix += '/@filename'
     # shortcut
     if page and region and line and word and glyph:
-        ret += doc.xpath('//page:AlternativeImage/@filename', namespaces=NAMESPACES)
+        ret += doc.xpath('//%s' % xpath_suffix, namespaces=NAMESPACES)
     else:
         if page:
-            ret += doc.xpath('/page:PcGts/page:Page/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+            ret += doc.xpath('/page:PcGts/page:Page/%s' % xpath_suffix, namespaces=NAMESPACES)
         if region:
             for class_ in PAGE_REGION_TYPES:
-                ret += doc.xpath('//page:%sRegion/page:AlternativeImage/@filename' % class_, namespaces=NAMESPACES)
+                ret += doc.xpath('//page:%sRegion/%s' % (class_, xpath_suffix), namespaces=NAMESPACES)
         if line:
-            ret += doc.xpath('//page:TextLine/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
         if word:
-            ret += doc.xpath('//page:Word/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
         if glyph:
-            ret += doc.xpath('//page:Glyph/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
 
     return ret

--- a/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImages.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImages.py
@@ -1,0 +1,28 @@
+def get_AllAlternativeImages(self, page=True, region=True, line=True, word=True, glyph=True):
+    """
+    Get all the pc:AlternativeImage in a document
+
+
+    page (boolean): Get pc:Page level images
+    region (boolean): Get images on pc:*Region level
+    line (boolean) Get images on pc:TextLine level
+    word (boolean) Get images on pc:Word level
+    glyph (boolean) Get images on pc:Glyph level
+    """
+    ret = []
+    if page:
+        ret += self.get_AlternativeImage()
+    for this_region in self.get_AllRegions(['Text']):
+        if region:
+            ret += this_region.get_AlternativeImage()
+        for this_line in this_region.get_TextLine():
+            if line:
+                ret += this_line.get_AlternativeImage()
+            for this_word in this_line.get_Word():
+                if word:
+                    ret += this_word.get_AlternativeImage()
+                for this_glyph in this_word.get_Glyph():
+                    if glyph:
+                        ret += this_glyph.get_AlternativeImage()
+    return ret
+

--- a/tests/model/test_ocrd_page.py
+++ b/tests/model/test_ocrd_page.py
@@ -279,26 +279,19 @@ class TestOcrdPage(TestCase):
     def test_get_AllAlternativeImagePaths(self):
         with open(assets.path_to('kant_aufklaerung_1784-complex/data/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP_0001.xml'), 'r') as f:
             pcgts = parseString(f.read().encode('utf8'), silence=True)
-            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=False, region=False, line=False, word=False, glyph=False), [])
-            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=True, region=False, line=False, word=False, glyph=False), [
+            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=False, region=False, line=False), [])
+            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=True, region=False, line=False), [
                 'OCR-D-IMG-BIN/OCR-D-IMG-BINPAGE-sauvola_0001-BIN_sauvola-ms-split.png',
                 'OCR-D-IMG-CROP/OCR-D-IMG-CROP_0001.png',
                 'OCR-D-IMG-BIN/INPUT_0017-BIN_sauvola-ms-split.png',
                 'OCR-D-IMG-DESPECK/OCR-D-IMG-DESPECK_0001.png',
                 'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png',
                 'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png'])
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False, word=False, glyph=False)), 12)
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False, word=False, glyph=False)), 12)
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, word=False, glyph=False)), 36)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False)), 12)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False)), 12)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True)), 36)
             # TODO: Test with word/glyph-level AlternativeImages
             # self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(word=False)), 37)
-
-    def test_get_AllAlternativeImagePathsElems(self):
-        with open(assets.path_to('kant_aufklaerung_1784-complex/data/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP_0001.xml'), 'r') as f:
-            pcgts = parseString(f.read().encode('utf8'), silence=True)
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, return_elems=True)), 36)
-            elem = pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, return_elems=True)[0]
-            assert hasattr(elem, 'filename')
 
     def test_serialize_no_empty_readingorder(self):
         """

--- a/tests/model/test_ocrd_page.py
+++ b/tests/model/test_ocrd_page.py
@@ -279,19 +279,26 @@ class TestOcrdPage(TestCase):
     def test_get_AllAlternativeImagePaths(self):
         with open(assets.path_to('kant_aufklaerung_1784-complex/data/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP_0001.xml'), 'r') as f:
             pcgts = parseString(f.read().encode('utf8'), silence=True)
-            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=False, region=False, line=False), [])
-            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=True, region=False, line=False), [
+            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=False, region=False, line=False, word=False, glyph=False), [])
+            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=True, region=False, line=False, word=False, glyph=False), [
                 'OCR-D-IMG-BIN/OCR-D-IMG-BINPAGE-sauvola_0001-BIN_sauvola-ms-split.png',
                 'OCR-D-IMG-CROP/OCR-D-IMG-CROP_0001.png',
                 'OCR-D-IMG-BIN/INPUT_0017-BIN_sauvola-ms-split.png',
                 'OCR-D-IMG-DESPECK/OCR-D-IMG-DESPECK_0001.png',
                 'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png',
                 'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png'])
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False)), 12)
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False)), 12)
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True)), 36)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False, word=False, glyph=False)), 12)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False, word=False, glyph=False)), 12)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, word=False, glyph=False)), 36)
             # TODO: Test with word/glyph-level AlternativeImages
             # self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(word=False)), 37)
+
+    def test_get_AllAlternativeImagePathsElems(self):
+        with open(assets.path_to('kant_aufklaerung_1784-complex/data/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP_0001.xml'), 'r') as f:
+            pcgts = parseString(f.read().encode('utf8'), silence=True)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, return_elems=True)), 36)
+            elem = pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, return_elems=True)[0]
+            assert hasattr(elem, 'filename')
 
     def test_serialize_no_empty_readingorder(self):
         """

--- a/tests/model/test_ocrd_page.py
+++ b/tests/model/test_ocrd_page.py
@@ -293,6 +293,20 @@ class TestOcrdPage(TestCase):
             # TODO: Test with word/glyph-level AlternativeImages
             # self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(word=False)), 37)
 
+    def test_get_AllAlternativeImages(self):
+        with open(assets.path_to('kant_aufklaerung_1784-complex/data/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP_0001.xml'), 'r') as f:
+            pcgts = parseString(f.read().encode('utf8'), silence=True)
+            page = pcgts.get_Page()
+            self.assertEqual(page.get_AllAlternativeImages(page=False, region=False, line=False), [])
+            self.assertEqual([x.filename for x in page.get_AllAlternativeImages(page=True, region=False, line=False)], [
+                'OCR-D-IMG-BIN/OCR-D-IMG-BINPAGE-sauvola_0001-BIN_sauvola-ms-split.png',
+                'OCR-D-IMG-CROP/OCR-D-IMG-CROP_0001.png',
+                'OCR-D-IMG-BIN/INPUT_0017-BIN_sauvola-ms-split.png',
+                'OCR-D-IMG-DESPECK/OCR-D-IMG-DESPECK_0001.png',
+                'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png',
+                'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png'])
+            assert isinstance(page.get_AllAlternativeImages()[0], AlternativeImageType)
+
     def test_serialize_no_empty_readingorder(self):
         """
         https://github.com/OCR-D/core/issues/602


### PR DESCRIPTION
`get_AllAlternativeImage` as an alternative to `get_AllAlternativeImagePaths` that iterates elemens, so is slower but offers access to the underlying AlternativeImages, not just their `@filename`.