### PR TITLE
Rename group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Fixed:
 
   * `run_cli`: don't reference undefined vars in error handler, #651
 
+Added:
+
+  * `Workspace.rename_file_group` with CLI `ocrd workspace rename-group` to rename file groups, #646
+
 ## [2.21.0] - 2020-11-27
 
 Changed:

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -388,6 +388,21 @@ def workspace_remove_file(ctx, id, force, keep_file):  # pylint: disable=redefin
 
 
 # ----------------------------------------------------------------------
+# ocrd workspace rename-group
+# ----------------------------------------------------------------------
+
+@workspace_cli.command('rename-group')
+@click.argument('OLD', nargs=1)
+@click.argument('NEW', nargs=1)
+@pass_workspace
+def rename_group(ctx, old, new):
+    """
+    Rename fileGrp (USE attribute ``NEW`` to ``OLD``).
+    """
+    workspace = Workspace(ctx.resolver, directory=ctx.directory, mets_basename=basename(ctx.mets_url))
+    workspace.rename_file_group(old, new)
+
+# ----------------------------------------------------------------------
 # ocrd workspace remove-group
 # ----------------------------------------------------------------------
 

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -401,6 +401,7 @@ def rename_group(ctx, old, new):
     """
     workspace = Workspace(ctx.resolver, directory=ctx.directory, mets_basename=basename(ctx.mets_url))
     workspace.rename_file_group(old, new)
+    workspace.save_mets()
 
 # ----------------------------------------------------------------------
 # ocrd workspace remove-group

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -209,14 +209,13 @@ class Workspace():
                         Path(file_dir).rmdir()
 
 
-    def rename_file_group(self, old, new, keep_files=False):
+    def rename_file_group(self, old, new):
         """
         Rename a fileGrp.
 
         Arguments:
             old (string): USE attribute of the fileGrp to rename
             new (string): USE attribute of the fileGrp to rename as
-            keep_files (boolean): Keep files on disk (copy them)
         """
         log = getLogger('ocrd.workspace.rename_file_group')
 

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -232,7 +232,7 @@ class Workspace():
             url_replacements = {}
             log.info("Moving files")
             for mets_file in self.mets.find_files(fileGrp=old, local_only=True):
-                new_url = sub(rf'^{old}/', f'{new}/', mets_file.url)
+                new_url = sub(r'^%s/' % old, '%s/' % new, mets_file.url)
                 url_replacements[mets_file.url] = new_url
                 # move file from ``old`` to ``new``
                 move(mets_file.url, new_url)

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -212,6 +212,15 @@ class OcrdMets(OcrdXmlDocument):
             el_fileGrp.set('USE', fileGrp)
         return el_fileGrp
 
+    def rename_file_group(self, old, new):
+        """
+        Rename a filegroup by changing the ``USE`` attribute from ``old`` to ``new``.
+        """
+        el_fileGrp = self._tree.getroot().find('mets:fileSec/mets:fileGrp[@USE="%s"]' % old, NS)
+        if el_fileGrp is None:
+            raise FileNotFoundError("No such fileGrp '%s'" % old)
+        el_fileGrp.set('USE', new)
+
     def remove_file_group(self, USE, recursive=False, force=False):
         """
         Remove a fileGrp (fixed ``USE``) or fileGrps (regex ``USE``)

--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Fri Nov 27 15:25:12 2020 by generateDS.py version 2.35.20.
+# Generated Mon Jan  4 12:53:00 2021 by generateDS.py version 2.35.20.
 # Python 3.6.9 (default, Oct  8 2020, 12:12:24)  [GCC 8.4.0]
 #
 # Command line options:
@@ -3047,6 +3047,34 @@ class PageType(GeneratedsSuper):
                 else:
                     ret = in_reading_order + [r for r in ret if r not in in_reading_order]
         return ret
+    def get_AllAlternativeImages(self, page=True, region=True, line=True, word=True, glyph=True):
+        """
+        Get all the pc:AlternativeImage in a document
+    
+    
+        page (boolean): Get pc:Page level images
+        region (boolean): Get images on pc:*Region level
+        line (boolean) Get images on pc:TextLine level
+        word (boolean) Get images on pc:Word level
+        glyph (boolean) Get images on pc:Glyph level
+        """
+        ret = []
+        if page:
+            ret += self.get_AlternativeImage()
+        for this_region in self.get_AllRegions(['Text']):
+            if region:
+                ret += this_region.get_AlternativeImage()
+            for this_line in this_region.get_TextLine():
+                if line:
+                    ret += this_line.get_AlternativeImage()
+                for this_word in this_line.get_Word():
+                    if word:
+                        ret += this_word.get_AlternativeImage()
+                    for this_glyph in this_word.get_Glyph():
+                        if glyph:
+                            ret += this_glyph.get_AlternativeImage()
+        return ret
+    
     def invalidate_AlternativeImage(self, feature_selector=None):
         """
         Remove derived images from this segment (due to changed coordinates).

--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Fri Nov 27 15:25:12 2020 by generateDS.py version 2.35.20.
+# Generated Mon Jan  4 12:33:41 2021 by generateDS.py version 2.35.20.
 # Python 3.6.9 (default, Oct  8 2020, 12:12:24)  [GCC 8.4.0]
 #
 # Command line options:
@@ -1216,7 +1216,7 @@ class PcGtsType(GeneratedsSuper):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
-    def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True):
+    def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True, return_elems=False):
         """
         Get all the pc:AlternativeImage/@filename paths referenced in the PAGE-XML document.
     
@@ -1226,6 +1226,7 @@ class PcGtsType(GeneratedsSuper):
         line (boolean) Get images on pc:TextLine level
         word (boolean) Get images on pc:Word level
         glyph (boolean) Get images on pc:Glyph level
+        return_elems (boolean) Return not the paths but the AlternativeImage elements
         """
         from .constants import NAMESPACES, PAGE_REGION_TYPES # pylint: disable=relative-beyond-top-level,import-outside-toplevel
         from io import StringIO  # pylint: disable=import-outside-toplevel
@@ -1245,21 +1246,24 @@ class PcGtsType(GeneratedsSuper):
                     NAMESPACES['page']
                 ))
         doc = parsexmlstring_(sio.getvalue())  # pylint: disable=undefined-variable
+        xpath_suffix = 'page:AlternativeImage'
+        if not return_elems:
+            xpath_suffix += '/@filename'
         # shortcut
         if page and region and line and word and glyph:
-            ret += doc.xpath('//page:AlternativeImage/@filename', namespaces=NAMESPACES)
+            ret += doc.xpath('//%s' % xpath_suffix, namespaces=NAMESPACES)
         else:
             if page:
-                ret += doc.xpath('/page:PcGts/page:Page/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+                ret += doc.xpath('/page:PcGts/page:Page/%s' % xpath_suffix, namespaces=NAMESPACES)
             if region:
                 for class_ in PAGE_REGION_TYPES:
-                    ret += doc.xpath('//page:%sRegion/page:AlternativeImage/@filename' % class_, namespaces=NAMESPACES)
+                    ret += doc.xpath('//page:%sRegion/%s' % (class_, xpath_suffix), namespaces=NAMESPACES)
             if line:
-                ret += doc.xpath('//page:TextLine/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
             if word:
-                ret += doc.xpath('//page:Word/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
             if glyph:
-                ret += doc.xpath('//page:Glyph/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
     
         return ret
     def prune_ReadingOrder(self):

--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Jan  4 12:53:00 2021 by generateDS.py version 2.35.20.
+# Generated Mon Jan  4 13:58:35 2021 by generateDS.py version 2.35.20.
 # Python 3.6.9 (default, Oct  8 2020, 12:12:24)  [GCC 8.4.0]
 #
 # Command line options:

--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Jan  4 12:33:41 2021 by generateDS.py version 2.35.20.
+# Generated Fri Nov 27 15:25:12 2020 by generateDS.py version 2.35.20.
 # Python 3.6.9 (default, Oct  8 2020, 12:12:24)  [GCC 8.4.0]
 #
 # Command line options:
@@ -1216,7 +1216,7 @@ class PcGtsType(GeneratedsSuper):
         else:
             raise ValueError("Cannot hash %s" % self)
         return hash(val)
-    def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True, return_elems=False):
+    def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True):
         """
         Get all the pc:AlternativeImage/@filename paths referenced in the PAGE-XML document.
     
@@ -1226,7 +1226,6 @@ class PcGtsType(GeneratedsSuper):
         line (boolean) Get images on pc:TextLine level
         word (boolean) Get images on pc:Word level
         glyph (boolean) Get images on pc:Glyph level
-        return_elems (boolean) Return not the paths but the AlternativeImage elements
         """
         from .constants import NAMESPACES, PAGE_REGION_TYPES # pylint: disable=relative-beyond-top-level,import-outside-toplevel
         from io import StringIO  # pylint: disable=import-outside-toplevel
@@ -1246,24 +1245,21 @@ class PcGtsType(GeneratedsSuper):
                     NAMESPACES['page']
                 ))
         doc = parsexmlstring_(sio.getvalue())  # pylint: disable=undefined-variable
-        xpath_suffix = 'page:AlternativeImage'
-        if not return_elems:
-            xpath_suffix += '/@filename'
         # shortcut
         if page and region and line and word and glyph:
-            ret += doc.xpath('//%s' % xpath_suffix, namespaces=NAMESPACES)
+            ret += doc.xpath('//page:AlternativeImage/@filename', namespaces=NAMESPACES)
         else:
             if page:
-                ret += doc.xpath('/page:PcGts/page:Page/%s' % xpath_suffix, namespaces=NAMESPACES)
+                ret += doc.xpath('/page:PcGts/page:Page/page:AlternativeImage/@filename', namespaces=NAMESPACES)
             if region:
                 for class_ in PAGE_REGION_TYPES:
-                    ret += doc.xpath('//page:%sRegion/%s' % (class_, xpath_suffix), namespaces=NAMESPACES)
+                    ret += doc.xpath('//page:%sRegion/page:AlternativeImage/@filename' % class_, namespaces=NAMESPACES)
             if line:
-                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+                ret += doc.xpath('//page:TextLine/page:AlternativeImage/@filename', namespaces=NAMESPACES)
             if word:
-                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+                ret += doc.xpath('//page:Word/page:AlternativeImage/@filename', namespaces=NAMESPACES)
             if glyph:
-                ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+                ret += doc.xpath('//page:Glyph/page:AlternativeImage/@filename', namespaces=NAMESPACES)
     
         return ret
     def prune_ReadingOrder(self):

--- a/ocrd_models/ocrd_page_user_methods.py
+++ b/ocrd_models/ocrd_page_user_methods.py
@@ -108,6 +108,7 @@ METHOD_SPECS = (
     _add_method(r'^(UnorderedGroupType|UnorderedGroupIndexedType)$', 'get_UnorderedGroupChildren'),
     _add_method(r'^(PageType)$', 'get_AllRegions'),
     _add_method(r'^(PcGtsType)$', 'get_AllAlternativeImagePaths'),
+    _add_method(r'^(PageType)$', 'get_AllAlternativeImages'),
     _add_method(r'^(PcGtsType)$', 'prune_ReadingOrder'),
     _add_method(r'^(PageType|RegionType|TextLineType|WordType|GlyphType)$', 'invalidate_AlternativeImage'),
     _add_method(r'^(BorderType|RegionType|TextLineType|WordType|GlyphType)$', 'set_Coords'),

--- a/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImagePaths.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImagePaths.py
@@ -1,4 +1,4 @@
-def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True, return_elems=False):
+def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True):
     """
     Get all the pc:AlternativeImage/@filename paths referenced in the PAGE-XML document.
 
@@ -8,7 +8,6 @@ def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=T
     line (boolean) Get images on pc:TextLine level
     word (boolean) Get images on pc:Word level
     glyph (boolean) Get images on pc:Glyph level
-    return_elems (boolean) Return not the paths but the AlternativeImage elements
     """
     from .constants import NAMESPACES, PAGE_REGION_TYPES # pylint: disable=relative-beyond-top-level,import-outside-toplevel
     from io import StringIO  # pylint: disable=import-outside-toplevel
@@ -28,23 +27,20 @@ def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=T
                 NAMESPACES['page']
             ))
     doc = parsexmlstring_(sio.getvalue())  # pylint: disable=undefined-variable
-    xpath_suffix = 'page:AlternativeImage'
-    if not return_elems:
-        xpath_suffix += '/@filename'
     # shortcut
     if page and region and line and word and glyph:
-        ret += doc.xpath('//%s' % xpath_suffix, namespaces=NAMESPACES)
+        ret += doc.xpath('//page:AlternativeImage/@filename', namespaces=NAMESPACES)
     else:
         if page:
-            ret += doc.xpath('/page:PcGts/page:Page/%s' % xpath_suffix, namespaces=NAMESPACES)
+            ret += doc.xpath('/page:PcGts/page:Page/page:AlternativeImage/@filename', namespaces=NAMESPACES)
         if region:
             for class_ in PAGE_REGION_TYPES:
-                ret += doc.xpath('//page:%sRegion/%s' % (class_, xpath_suffix), namespaces=NAMESPACES)
+                ret += doc.xpath('//page:%sRegion/page:AlternativeImage/@filename' % class_, namespaces=NAMESPACES)
         if line:
-            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+            ret += doc.xpath('//page:TextLine/page:AlternativeImage/@filename', namespaces=NAMESPACES)
         if word:
-            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+            ret += doc.xpath('//page:Word/page:AlternativeImage/@filename', namespaces=NAMESPACES)
         if glyph:
-            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
+            ret += doc.xpath('//page:Glyph/page:AlternativeImage/@filename', namespaces=NAMESPACES)
 
     return ret

--- a/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImagePaths.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImagePaths.py
@@ -1,4 +1,4 @@
-def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True):
+def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True, return_elems=False):
     """
     Get all the pc:AlternativeImage/@filename paths referenced in the PAGE-XML document.
 
@@ -8,6 +8,7 @@ def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=T
     line (boolean) Get images on pc:TextLine level
     word (boolean) Get images on pc:Word level
     glyph (boolean) Get images on pc:Glyph level
+    return_elems (boolean) Return not the paths but the AlternativeImage elements
     """
     from .constants import NAMESPACES, PAGE_REGION_TYPES # pylint: disable=relative-beyond-top-level,import-outside-toplevel
     from io import StringIO  # pylint: disable=import-outside-toplevel
@@ -27,20 +28,23 @@ def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=T
                 NAMESPACES['page']
             ))
     doc = parsexmlstring_(sio.getvalue())  # pylint: disable=undefined-variable
+    xpath_suffix = 'page:AlternativeImage'
+    if not return_elems:
+        xpath_suffix += '/@filename'
     # shortcut
     if page and region and line and word and glyph:
-        ret += doc.xpath('//page:AlternativeImage/@filename', namespaces=NAMESPACES)
+        ret += doc.xpath('//%s' % xpath_suffix, namespaces=NAMESPACES)
     else:
         if page:
-            ret += doc.xpath('/page:PcGts/page:Page/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+            ret += doc.xpath('/page:PcGts/page:Page/%s' % xpath_suffix, namespaces=NAMESPACES)
         if region:
             for class_ in PAGE_REGION_TYPES:
-                ret += doc.xpath('//page:%sRegion/page:AlternativeImage/@filename' % class_, namespaces=NAMESPACES)
+                ret += doc.xpath('//page:%sRegion/%s' % (class_, xpath_suffix), namespaces=NAMESPACES)
         if line:
-            ret += doc.xpath('//page:TextLine/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
         if word:
-            ret += doc.xpath('//page:Word/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
         if glyph:
-            ret += doc.xpath('//page:Glyph/page:AlternativeImage/@filename', namespaces=NAMESPACES)
+            ret += doc.xpath('//page:TextLine/%s' % xpath_suffix, namespaces=NAMESPACES)
 
     return ret

--- a/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImages.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImages.py
@@ -1,0 +1,28 @@
+def get_AllAlternativeImages(self, page=True, region=True, line=True, word=True, glyph=True):
+    """
+    Get all the pc:AlternativeImage in a document
+
+
+    page (boolean): Get pc:Page level images
+    region (boolean): Get images on pc:*Region level
+    line (boolean) Get images on pc:TextLine level
+    word (boolean) Get images on pc:Word level
+    glyph (boolean) Get images on pc:Glyph level
+    """
+    ret = []
+    if page:
+        ret += self.get_AlternativeImage()
+    for this_region in self.get_AllRegions(['Text']):
+        if region:
+            ret += this_region.get_AlternativeImage()
+        for this_line in this_region.get_TextLine():
+            if line:
+                ret += this_line.get_AlternativeImage()
+            for this_word in this_line.get_Word():
+                if word:
+                    ret += this_word.get_AlternativeImage()
+                for this_glyph in this_word.get_Glyph():
+                    if glyph:
+                        ret += this_glyph.get_AlternativeImage()
+    return ret
+

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -202,6 +202,16 @@ class TestOcrdMets(TestCase):
             mets.remove_file('//FILE_0005.*')
             self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002'])
 
+    def test_rename_file_group0(self):
+        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
+            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
+            with self.assertRaisesRegex(FileNotFoundError, "No such fileGrp 'FOOBAR'"):
+                mets.rename_file_group('FOOBAR', 'FOOBAR')
+            assert 'FOOBAR' not in mets.file_groups
+            mets.rename_file_group('OCR-D-GT-PAGE', 'FOOBAR')
+            assert 'OCR-D-GT-PAGE' not in mets.file_groups
+            assert 'FOOBAR' in mets.file_groups
+
     def test_remove_file_group0(self):
         """
         Test removal of filegrp

--- a/tests/model/test_ocrd_page.py
+++ b/tests/model/test_ocrd_page.py
@@ -279,26 +279,19 @@ class TestOcrdPage(TestCase):
     def test_get_AllAlternativeImagePaths(self):
         with open(assets.path_to('kant_aufklaerung_1784-complex/data/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP_0001.xml'), 'r') as f:
             pcgts = parseString(f.read().encode('utf8'), silence=True)
-            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=False, region=False, line=False, word=False, glyph=False), [])
-            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=True, region=False, line=False, word=False, glyph=False), [
+            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=False, region=False, line=False), [])
+            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=True, region=False, line=False), [
                 'OCR-D-IMG-BIN/OCR-D-IMG-BINPAGE-sauvola_0001-BIN_sauvola-ms-split.png',
                 'OCR-D-IMG-CROP/OCR-D-IMG-CROP_0001.png',
                 'OCR-D-IMG-BIN/INPUT_0017-BIN_sauvola-ms-split.png',
                 'OCR-D-IMG-DESPECK/OCR-D-IMG-DESPECK_0001.png',
                 'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png',
                 'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png'])
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False, word=False, glyph=False)), 12)
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False, word=False, glyph=False)), 12)
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, word=False, glyph=False)), 36)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False)), 12)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False)), 12)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True)), 36)
             # TODO: Test with word/glyph-level AlternativeImages
             # self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(word=False)), 37)
-
-    def test_get_AllAlternativeImagePathsElems(self):
-        with open(assets.path_to('kant_aufklaerung_1784-complex/data/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP_0001.xml'), 'r') as f:
-            pcgts = parseString(f.read().encode('utf8'), silence=True)
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, return_elems=True)), 36)
-            elem = pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, return_elems=True)[0]
-            assert hasattr(elem, 'filename')
 
     def test_serialize_no_empty_readingorder(self):
         """

--- a/tests/model/test_ocrd_page.py
+++ b/tests/model/test_ocrd_page.py
@@ -279,19 +279,26 @@ class TestOcrdPage(TestCase):
     def test_get_AllAlternativeImagePaths(self):
         with open(assets.path_to('kant_aufklaerung_1784-complex/data/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP_0001.xml'), 'r') as f:
             pcgts = parseString(f.read().encode('utf8'), silence=True)
-            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=False, region=False, line=False), [])
-            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=True, region=False, line=False), [
+            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=False, region=False, line=False, word=False, glyph=False), [])
+            self.assertEqual(pcgts.get_AllAlternativeImagePaths(page=True, region=False, line=False, word=False, glyph=False), [
                 'OCR-D-IMG-BIN/OCR-D-IMG-BINPAGE-sauvola_0001-BIN_sauvola-ms-split.png',
                 'OCR-D-IMG-CROP/OCR-D-IMG-CROP_0001.png',
                 'OCR-D-IMG-BIN/INPUT_0017-BIN_sauvola-ms-split.png',
                 'OCR-D-IMG-DESPECK/OCR-D-IMG-DESPECK_0001.png',
                 'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png',
                 'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png'])
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False)), 12)
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False)), 12)
-            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True)), 36)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False, word=False, glyph=False)), 12)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=False, word=False, glyph=False)), 12)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, word=False, glyph=False)), 36)
             # TODO: Test with word/glyph-level AlternativeImages
             # self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(word=False)), 37)
+
+    def test_get_AllAlternativeImagePathsElems(self):
+        with open(assets.path_to('kant_aufklaerung_1784-complex/data/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP_0001.xml'), 'r') as f:
+            pcgts = parseString(f.read().encode('utf8'), silence=True)
+            self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, return_elems=True)), 36)
+            elem = pcgts.get_AllAlternativeImagePaths(page=True, region=True, line=True, return_elems=True)[0]
+            assert hasattr(elem, 'filename')
 
     def test_serialize_no_empty_readingorder(self):
         """

--- a/tests/model/test_ocrd_page.py
+++ b/tests/model/test_ocrd_page.py
@@ -293,6 +293,20 @@ class TestOcrdPage(TestCase):
             # TODO: Test with word/glyph-level AlternativeImages
             # self.assertEqual(len(pcgts.get_AllAlternativeImagePaths(word=False)), 37)
 
+    def test_get_AllAlternativeImages(self):
+        with open(assets.path_to('kant_aufklaerung_1784-complex/data/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP/OCR-D-OCR-OCRO-fraktur-SEG-LINE-tesseract-ocropy-DEWARP_0001.xml'), 'r') as f:
+            pcgts = parseString(f.read().encode('utf8'), silence=True)
+            page = pcgts.get_Page()
+            self.assertEqual(page.get_AllAlternativeImages(page=False, region=False, line=False), [])
+            self.assertEqual([x.filename for x in page.get_AllAlternativeImages(page=True, region=False, line=False)], [
+                'OCR-D-IMG-BIN/OCR-D-IMG-BINPAGE-sauvola_0001-BIN_sauvola-ms-split.png',
+                'OCR-D-IMG-CROP/OCR-D-IMG-CROP_0001.png',
+                'OCR-D-IMG-BIN/INPUT_0017-BIN_sauvola-ms-split.png',
+                'OCR-D-IMG-DESPECK/OCR-D-IMG-DESPECK_0001.png',
+                'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png',
+                'OCR-D-IMG-DESKEW/OCR-D-IMG-DESKEW_0001.png'])
+            assert isinstance(page.get_AllAlternativeImages()[0], AlternativeImageType)
+
     def test_serialize_no_empty_readingorder(self):
         """
         https://github.com/OCR-D/core/issues/602

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -12,7 +12,8 @@ from PIL import Image
 from tests.base import TestCase, assets, main, copy_of_directory
 
 from ocrd_models.ocrd_page import parseString
-from ocrd_utils import pushd_popd, initLogging
+from ocrd_utils import pushd_popd, initLogging, MIMETYPE_PAGE
+from ocrd_modelfactory import page_from_file
 from ocrd.resolver import Resolver
 from ocrd.workspace import Workspace
 
@@ -173,6 +174,21 @@ class TestWorkspace(TestCase):
             # should also succeed
             ws.overwrite_mode = True
             ws.remove_file('page1_img', force=False)
+
+    def test_rename_file_group(self):
+        with copy_of_directory(assets.path_to('kant_aufklaerung_1784-page-region-line-word_glyph/data')) as tempdir:
+            workspace = Workspace(self.resolver, directory=tempdir)
+            with pushd_popd(tempdir):
+                pcgts_before = page_from_file(next(workspace.mets.find_files(ID='OCR-D-GT-SEG-WORD_0001')))
+                assert pcgts_before.get_Page().imageFilename == 'OCR-D-IMG/OCR-D-IMG_0001.tif'
+                # from os import system
+                # print(system('find'))
+                workspace.rename_file_group('OCR-D-IMG', 'FOOBAR')
+                # print(system('find'))
+                pcgts_after = page_from_file(next(workspace.mets.find_files(ID='OCR-D-GT-SEG-WORD_0001')))
+                assert pcgts_after.get_Page().imageFilename == 'FOOBAR/OCR-D-IMG_0001.tif'
+                assert Path('FOOBAR/OCR-D-IMG_0001.tif').exists()
+                assert not Path('OCR-D-IMG/OCR-D-IMG_0001.tif').exists()
 
     def test_remove_file_group_force(self):
         with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:


### PR DESCRIPTION
With `ocrd workspacec rename-group OLD NEW`, the files (if locally available) in `OLD/` are moved to `NEW/`, the resp. `mets:file` adapted and all image references in the PAGE updated accordingly.