### PR TITLE
resmgr: --location cwd means cwd, no subdirs, #663

### DIFF
--- a/ocrd/ocrd/cli/resmgr.py
+++ b/ocrd/ocrd/cli/resmgr.py
@@ -1,6 +1,4 @@
 import sys
-from os import getcwd
-from os.path import join
 from pathlib import Path
 from distutils.spawn import find_executable as which
 
@@ -12,7 +10,6 @@ from ocrd_utils import (
     getLogger,
     RESOURCE_LOCATIONS
 )
-from ocrd_validators import OcrdZipValidator
 
 from ..resource_manager import OcrdResourceManager
 
@@ -109,6 +106,7 @@ def download(any_url, allow_uninstalled, overwrite, location, executable, url_or
                     url_or_name,
                     overwrite=overwrite,
                     basedir=basedir,
+                    no_subdir=location == 'cwd',
                     progress_cb=lambda delta: bar.update(delta))
             log.info("%s resource '%s' (%s) not a known resource, creating stub in %s'" % (executable, fpath.name, url_or_name, resmgr.user_list))
             resmgr.add_to_user_database(executable, fpath, url_or_name)
@@ -133,6 +131,7 @@ def download(any_url, allow_uninstalled, overwrite, location, executable, url_or
                     resource_type=resdict['type'],
                     path_in_archive=resdict.get('path_in_archive', '.'),
                     overwrite=overwrite,
+                    no_subdir=location == 'cwd',
                     basedir=basedir,
                     progress_cb=lambda delta: bar.update(delta)
                 )

--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -65,7 +65,7 @@ def list_resource_candidates(executable, fname, cwd=getcwd(), is_file=False, is_
     https://ocr-d.de/en/spec/ocrd_tool#file-parameters (except python-bundled)
     """
     candidates = []
-    candidates.append(join(cwd, 'ocrd-resources', executable, fname))
+    candidates.append(join(cwd, fname))
     processor_path_var = '%s_PATH' % executable.replace('-', '_').upper()
     if processor_path_var in environ:
         candidates += [join(x, fname) for x in environ[processor_path_var].split(':')]
@@ -83,9 +83,10 @@ def list_all_resources(executable):
     https://ocr-d.de/en/spec/ocrd_tool#file-parameters (except python-bundled)
     """
     candidates = []
-    cwd_candidate = join(getcwd(), 'ocrd-resources', executable)
-    if Path(cwd_candidate).exists():
-        candidates.append(cwd_candidate)
+    # XXX cwd would list too many false positives
+    # cwd_candidate = join(getcwd(), 'ocrd-resources', executable)
+    # if Path(cwd_candidate).exists():
+    #     candidates.append(cwd_candidate)
     processor_path_var = '%s_PATH' % executable.replace('-', '_').upper()
     if processor_path_var in environ:
         for processor_path in environ[processor_path_var].split(':'):

--- a/tests/utils/test_os.py
+++ b/tests/utils/test_os.py
@@ -27,7 +27,7 @@ class TestOsUtils(TestCase):
         cands = [dehomify(x) for x in cands]
         print(cands)
         self.assertEqual(cands, [join(x, fname) for x in [
-            dehomify(join(getcwd(), 'ocrd-resources', 'ocrd-dummy')),
+            dehomify(join(getcwd())),
             dehomify(self.tempdir_path),
             '$HOME/.local/share/ocrd-resources/ocrd-dummy',
             '/usr/local/share/ocrd-resources/ocrd-dummy',


### PR DESCRIPTION
`ocrd resmgr --location cwd download ...` will now download resource `<res>` to `$PWD/<res>`, not `$PWD/ocrd-resources/<executable>/<res>` as per the spec.

One minor drawback is that `ocrd resmgr list-installed` will no longer pick up resources in `$PWD` because there would be too many false positives, files that are not resources.