### PR TITLE
implement value range with .. operator for pageId

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -141,6 +141,10 @@ class OcrdMets(OcrdXmlDocument):
         and candidates are matched against the regex with `re.fullmatch`. If it is
         a literal string, comparison is done with string equality.
 
+        The ``pageId`` parameter supports the numeric range operator ``..``. For
+        example, to find all files in pages ``PHYS_0001`` to ``PHYS_0003``, 
+        ``PHYS_0001..PHYS_0003`` will be expanded to ``PHYS_0001,PHYS_0002,PHYS_0003``.
+
         Keyword Args:
             ID (string) : `@ID` of the `mets:file`
             fileGrp (string) : `@USE` of the `mets:fileGrp` to list files of

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -2,10 +2,17 @@
 API to METS
 """
 from datetime import datetime
-from re import fullmatch
+from re import fullmatch, search
 from lxml import etree as ET
 
-from ocrd_utils import is_local_filename, getLogger, VERSION, REGEX_PREFIX, REGEX_FILE_ID
+from ocrd_utils import (
+    is_local_filename,
+    getLogger,
+    generate_range,
+    VERSION,
+    REGEX_PREFIX,
+    REGEX_FILE_ID
+)
 
 from .constants import (
     NAMESPACES as NS,
@@ -150,6 +157,11 @@ class OcrdMets(OcrdXmlDocument):
             if pageId.startswith(REGEX_PREFIX):
                 raise Exception("find_files does not support regex search for pageId")
             pageIds, pageId = pageId.split(','), list()
+            pageIds_expanded = []
+            for pageId_ in pageIds:
+                if '..' in pageId_:
+                    pageIds_expanded += generate_range(*pageId_.split('..', 2))
+            pageIds += pageIds_expanded
             for page in self._tree.getroot().xpath(
                 '//mets:div[@TYPE="page"]', namespaces=NS):
                 if page.get('ID') in pageIds:

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -78,6 +78,7 @@ Utility functions and constants usable in various circumstances.
   :py:func:`set_json_key_value_overrides`,
   :py:func:`assert_file_grp_cardinality`,
   :py:func:`make_file_id`
+  :py:func:`generate_range`
 
     String and OOP utilities
 
@@ -173,6 +174,7 @@ from .os import (
 from .str import (
     assert_file_grp_cardinality,
     concat_padded,
+    generate_range,
     get_local_filename,
     is_local_filename,
     is_string,

--- a/ocrd_utils/ocrd_utils/str.py
+++ b/ocrd_utils/ocrd_utils/str.py
@@ -5,7 +5,6 @@ Utility functions for strings, paths and URL.
 import re
 import json
 from .constants import REGEX_FILE_ID
-from .logging import getLogger
 
 __all__ = [
     'assert_file_grp_cardinality',
@@ -184,10 +183,9 @@ def generate_range(start, end):
     Generate a list of strings by incrementing the number part of ``start`` until including ``end``.
     """
     ret = []
-    start_num, end_num = re.search('\d+', start), re.search('\d+', end)
+    start_num, end_num = re.search(r'\d+', start), re.search(r'\d+', end)
     if not (start_num and end_num):
-        getLogger('ocrd_utils.generate_range').error("Unable to generate range %s .. %s, could not detect number part" % (start, end))
-        return [start, end]
+        raise ValueError("Unable to generate range %s .. %s, could not detect number part" % (start, end))
     start_num, end_num = start_num.group(0), end_num.group(0)
     for i in range(int(start_num), int(end_num) + 1):
         ret.append(start.replace(start_num, str(i).zfill(len(start_num))))

--- a/ocrd_utils/ocrd_utils/str.py
+++ b/ocrd_utils/ocrd_utils/str.py
@@ -5,6 +5,7 @@ Utility functions for strings, paths and URL.
 import re
 import json
 from .constants import REGEX_FILE_ID
+from .logging import getLogger
 
 __all__ = [
     'assert_file_grp_cardinality',
@@ -176,4 +177,19 @@ def safe_filename(url):
     """
     ret = re.sub('[^A-Za-z0-9]+', '.', url)
     #  print('safe filename: %s -> %s' % (url, ret))
+    return ret
+
+def generate_range(start, end):
+    """
+    Generate a list of strings by incrementing the number part of ``start`` until including ``end``.
+    """
+    ret = []
+    start_num, end_num = re.search('\d+', start), re.search('\d+', end)
+    if not start_num and end_num:
+        getLogger('ocrd_utils.generate_range').error("Unable to parse generate range %s .. %s" % (start, end))
+        return [start, end]
+    start_num, end_num = start_num.group(0), end_num.group(0)
+    start_num_len = len(start_num)
+    for i in range(int(start_num), int(end_num)):
+        ret.append(start.replace(start_num, str(i).zfill(start_num_len)))
     return ret

--- a/ocrd_utils/ocrd_utils/str.py
+++ b/ocrd_utils/ocrd_utils/str.py
@@ -185,11 +185,10 @@ def generate_range(start, end):
     """
     ret = []
     start_num, end_num = re.search('\d+', start), re.search('\d+', end)
-    if not start_num and end_num:
-        getLogger('ocrd_utils.generate_range').error("Unable to parse generate range %s .. %s" % (start, end))
+    if not (start_num and end_num):
+        getLogger('ocrd_utils.generate_range').error("Unable to generate range %s .. %s, could not detect number part" % (start, end))
         return [start, end]
     start_num, end_num = start_num.group(0), end_num.group(0)
-    start_num_len = len(start_num)
-    for i in range(int(start_num), int(end_num)):
-        ret.append(start.replace(start_num, str(i).zfill(start_num_len)))
+    for i in range(int(start_num), int(end_num) + 1):
+        ret.append(start.replace(start_num, str(i).zfill(len(start_num))))
     return ret

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -58,7 +58,7 @@ class TestOcrdMets(TestCase):
         self.assertEqual(len(self.mets.find_all_files(mimetype='//application/.*')), 22, '22 application/.*')
         self.assertEqual(len(self.mets.find_all_files(mimetype=MIMETYPE_PAGE)), 20, '20 ' + MIMETYPE_PAGE)
         self.assertEqual(len(self.mets.find_all_files(url='OCR-D-IMG/FILE_0005_IMAGE.tif')), 1, '1 xlink:href="OCR-D-IMG/FILE_0005_IMAGE.tif"')
-        self.assertEqual(len(self.mets.find_all_files(pageId='PHYS_0001..PHYS_0005')), 34, '34 files for page "PHYS_0001..PHYS_0005"')
+        self.assertEqual(len(self.mets.find_all_files(pageId='PHYS_0001..PHYS_0005')), 35, '35 files for page "PHYS_0001..PHYS_0005"')
 
     def test_find_all_files_no_regex_for_pageid(self):
         with self.assertRaisesRegex(Exception, "not support regex search for pageId"):

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -58,6 +58,7 @@ class TestOcrdMets(TestCase):
         self.assertEqual(len(self.mets.find_all_files(mimetype='//application/.*')), 22, '22 application/.*')
         self.assertEqual(len(self.mets.find_all_files(mimetype=MIMETYPE_PAGE)), 20, '20 ' + MIMETYPE_PAGE)
         self.assertEqual(len(self.mets.find_all_files(url='OCR-D-IMG/FILE_0005_IMAGE.tif')), 1, '1 xlink:href="OCR-D-IMG/FILE_0005_IMAGE.tif"')
+        self.assertEqual(len(self.mets.find_all_files(pageId='PHYS_0001..PHYS_0005')), 34, '34 files for page "PHYS_0001..PHYS_0005"')
 
     def test_find_all_files_no_regex_for_pageid(self):
         with self.assertRaisesRegex(Exception, "not support regex search for pageId"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -299,7 +299,8 @@ class TestUtils(TestCase):
         self.assertEqual(make_file_id(f, '2:!GRP'), 'id_2_GRP_0002')
 
     def test_generate_range(self):
-        assert generate_range('PHYS_0001', 'PHYS_0005') == ['PHYS_0001', 'PHYS_0002', 'PHYS_0003', 'PHYS_0004']
+        assert generate_range('PHYS_0001', 'PHYS_0005') == ['PHYS_0001', 'PHYS_0002', 'PHYS_0003', 'PHYS_0004', 'PHYS_0005']
+        assert generate_range('NONUMBER', 'ALSO_NONUMBER') == ['NONUMBER', 'ALSO_NONUMBER']
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -300,7 +300,8 @@ class TestUtils(TestCase):
 
     def test_generate_range(self):
         assert generate_range('PHYS_0001', 'PHYS_0005') == ['PHYS_0001', 'PHYS_0002', 'PHYS_0003', 'PHYS_0004', 'PHYS_0005']
-        assert generate_range('NONUMBER', 'ALSO_NONUMBER') == ['NONUMBER', 'ALSO_NONUMBER']
+        with self.assertRaisesRegex(ValueError, 'Unable to generate range'):
+            generate_range('NONUMBER', 'ALSO_NONUMBER')
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,7 @@ from ocrd_utils import (
     get_local_filename,
     is_string,
     membername,
+    generate_range,
 
     nth_url_segment,
     remove_non_path_from_url,
@@ -296,6 +297,10 @@ class TestUtils(TestCase):
         f = mets.add_file('1:!GRP', ID='FOO_0001', pageId='phys0001')
         f = mets.add_file('2:!GRP', ID='FOO_0002', pageId='phys0002')
         self.assertEqual(make_file_id(f, '2:!GRP'), 'id_2_GRP_0002')
+
+    def test_generate_range(self):
+        assert generate_range('PHYS_0001', 'PHYS_0005') == ['PHYS_0001', 'PHYS_0002', 'PHYS_0003', 'PHYS_0004']
+
 
 if __name__ == '__main__':
     main(__file__)


### PR DESCRIPTION
When processing works with a non-trivial amount of pages, or when a long process fails in the middle of a run, it would be useful to not only allow comma-separated page ID values but ranges of page IDs.

This PR implements this by introducing the syntax `--page-id <startid>..<endid>` which

* extracts the first contiguous match of numbers of both `<startid>` and `<endid>`
* counts from start to end number and replaces the number in <startid> with the zero-padded current number

E.g. you can do `ocrd-processor -g PHYS_0001..PHYS_0003` is equivalent to `ocrd-processor -g PHYS_0001,PHYS_0002,PHYS_0003` but shorter.