### PR TITLE
Logging test fix

### DIFF
--- a/ocrd_utils/ocrd_logging.conf
+++ b/ocrd_utils/ocrd_logging.conf
@@ -1,13 +1,13 @@
-# This is a template configuration file to demonstrate
-# formats and destinations of log messages with OCR-D.
-# It's meant as an example, and should be customized.
+# This is a template configuration file which allows customizing
+# format and destination of log messages with OCR-D.
+# It is meant as an example, and should be customized.
 # To get into effect, you must put a copy (under the same name)
 # into your CWD, HOME or /etc. These directories are searched
 # in said order, and the first find wins. When no config file
-# is found, the default logging configuration applies (cf. ocrd_logging.py).
+# is found, the default logging configuration applies (cf. ocrd.logging.py).
 # 
 # mandatory loggers section
-# configure loggers with corresponding keys "root",""
+# configure loggers with correspnding keys "root", ""
 # each logger requires a corresponding configuration section below
 #
 [loggers]
@@ -15,23 +15,23 @@ keys=root,ocrd_tensorflow,ocrd_shapely_geos,ocrd_PIL
 
 #
 # mandatory handlers section
-# handle output for logging "channel"
+# handle output for each logging "channel"
 # i.e. console, file, smtp, syslog, http, ...
-# each handler requires a corresponding handler configuration section below
+# each handler requires a corresponding configuration section below
 #
 [handlers]
 keys=consoleHandler,fileHandler
 
 #
-# optional formatters section
-# format message records, to be used differently by logging handlers
+# optional custom formatters section
+# format message fields, to be used differently by logging handlers
 # each formatter requires a corresponding formatter section below
 #
 [formatters]
 keys=defaultFormatter,detailedFormatter
 
 #
-# default logger "root" configured to use only consoleHandler
+# default logger "root" using consoleHandler
 #
 [logger_root]
 level=INFO
@@ -47,10 +47,6 @@ handlers=consoleHandler
 # "qualname" must match the logger label used in the corresponding 
 # ocrd modul
 # see in the modul-of-interrest (moi)
-#
-# example configuration entry
-#
-# logger ocrd.workspace
 #
 #[logger_ocrd_workspace]
 #level=DEBUG

--- a/tests/base.py
+++ b/tests/base.py
@@ -22,11 +22,8 @@ def main(fn=None):
 
 class TestCase(VanillaTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        chdir(dirname(realpath(__file__)) + '/..')
-
     def setUp(self):
+        chdir(dirname(realpath(__file__)) + '/..')
         disableLogging()
         initLogging()
 

--- a/tests/cli/test_bashlib.py
+++ b/tests/cli/test_bashlib.py
@@ -13,6 +13,7 @@ class TestBashlibCli(TestCase):
 
     def setUp(self):
         self.maxDiff = None
+        super().setUp()
 
     def test_filename(self):
         exit_code, out, err = self.invoke_cli(bashlib_cli, ['filename'])

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -27,8 +27,8 @@ class TestLogCli(TestCase):
             del(ENV['OCRD_TOOL_NAME'])
 
     def test_loglevel(self):
-        assert ' DEBUG root - foo' not in self._get_log_output('log', 'debug', 'foo')
-        assert ' DEBUG root - foo' in self._get_log_output('-l', 'DEBUG', 'log', 'debug', 'foo')
+        assert 'DEBUG root - foo' not in self._get_log_output('log', 'debug', 'foo')
+        assert 'DEBUG root - foo' in self._get_log_output('-l', 'DEBUG', 'log', 'debug', 'foo')
 
     def test_log_basic(self):
         assert 'INFO root - foo bar' in self._get_log_output('log', 'info', 'foo bar')

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 # pylint: disable=import-error, no-name-in-module
 from tests.base import CapturingTestCase as TestCase, assets, copy_of_directory, main
 
-from ocrd_utils import initLogging, pushd_popd, setOverrideLogLevel
+from ocrd_utils import initLogging, pushd_popd, setOverrideLogLevel, disableLogging
 from ocrd.cli.workspace import workspace_cli
 from ocrd import Resolver
 
@@ -17,6 +17,7 @@ class TestCli(TestCase):
 
     def setUp(self):
         super().setUp()
+        disableLogging()
         self.maxDiff = None
         self.resolver = Resolver()
         self.runner = CliRunner(mix_stderr=False)
@@ -176,7 +177,7 @@ class TestCli(TestCase):
         page_id = 'foo123page'
         file_grp = 'TEST_GROUP'
         mimetype = 'image/tiff'
-        with TemporaryDirectory() as tempdir:
+        with pushd_popd(tempdir=True) as tempdir:
             ws = self.resolver.workspace_from_nothing(directory=tempdir)
             ws.save_mets()
             exit_code, out, err = self.invoke_cli(workspace_cli, [
@@ -386,8 +387,10 @@ class TestCli(TestCase):
     def test_mets_get_id_set_id(self):
         with pushd_popd(tempdir=True):
             self.invoke_cli(workspace_cli, ['init'])
+            disableLogging()
             mets_id = 'foo123'
             self.invoke_cli(workspace_cli, ['set-id', mets_id])
+            disableLogging()
             _, out, _ = self.invoke_cli(workspace_cli, ['get-id'])
             self.assertEqual(out, mets_id + '\n')
 

--- a/tests/model/test_ocrd_page.py
+++ b/tests/model/test_ocrd_page.py
@@ -55,6 +55,7 @@ simple_page = """\
 class TestOcrdPage(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.maxDiff = 5000
         with open(assets.path_to('glyph-consistency/data/OCR-D-GT-PAGE/FAULTY_GLYPHS.xml'), 'rb') as f:
             self.xml_as_str = f.read()

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -12,8 +12,7 @@ from ocrd.processor.base import Processor, run_processor, run_cli
 class TestProcessor(TestCase):
 
     def setUp(self):
-        disableLogging()
-        initLogging()
+        super().setUp()
         self.resolver = Resolver()
         self.workspace = self.resolver.workspace_from_url(assets.url_of('SBB0000F29300010000/data/mets.xml'))
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -14,7 +14,7 @@ from ocrd.decorators import (
     ocrd_loglevel,
     ocrd_cli_wrap_processor,
 )    # pylint: disable=protected-access
-from ocrd_utils import pushd_popd, VERSION as OCRD_VERSION
+from ocrd_utils import pushd_popd, VERSION as OCRD_VERSION, disableLogging
 
 @click.command()
 @ocrd_cli_options
@@ -39,6 +39,10 @@ def cli_dummy_processor(*args, **kwargs):
 DEFAULT_IN_OUT = ('-I', 'OCR-D-IMG', '-O', 'OUTPUT')
 
 class TestDecorators(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        disableLogging()
 
     def test_minimal(self):
         exit_code, out, err = self.invoke_cli(cli_with_ocrd_cli_options, ['-l', 'DEBUG'])

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -23,6 +23,7 @@ TIMEFMT_RE = r'\d\d:\d\d:\d\d\.(\d+)? '
 class TestLogging(TestCase):
 
     def setUp(self):
+        super().setUp()
         disableLogging()
 
     def test_setOverrideLogLevel(self):

--- a/tests/test_logging_conf.py
+++ b/tests/test_logging_conf.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import sys
 
+from ocrd_utils import pushd_popd
 from ocrd_utils.logging import (
     initLogging,
     getLogger
@@ -32,18 +33,18 @@ def test_configured_dateformat(logging_conf, capsys):
     """Ensure example ocrd_logging.conf is valid and produces desired record format"""
 
     # arrange
-    os.chdir(logging_conf)
-    initLogging()
-    test_logger = getLogger('')
+    with pushd_popd(logging_conf):
+        initLogging()
+        test_logger = getLogger('')
 
-    # act
-    test_logger.info("test logger initialized")
+        # act
+        test_logger.info("test logger initialized")
 
-    log_info_output = capsys.readouterr().out
-    must_not_match = r"^\d{4}-\d{2}-\d{2}.*"
-    assert not re.match(must_not_match, log_info_output)
-    match_pattern = r"^\d{2}:\d{2}:\d{2}.*"
-    assert re.match(match_pattern, log_info_output)
+        log_info_output = capsys.readouterr().out
+        must_not_match = r"^\d{4}-\d{2}-\d{2}.*"
+        assert not re.match(must_not_match, log_info_output)
+        match_pattern = r"^\d{2}:\d{2}:\d{2}.*"
+        assert re.match(match_pattern, log_info_output)
 
 
 def test_configured_tensorflow_logger_present(logging_conf, capsys):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -19,6 +19,7 @@ class TestResolver(TestCase):
     def setUp(self):
         initLogging()
         self.resolver = Resolver()
+        super().setUp()
 
     def test_workspace_from_url_bad(self):
         with self.assertRaisesRegex(Exception, "Must pass 'mets_url'"):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -32,6 +32,7 @@ def count_files():
 class TestWorkspace(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.resolver = Resolver()
 
     def test_workspace_add_file(self):

--- a/tests/utils/test_os.py
+++ b/tests/utils/test_os.py
@@ -14,6 +14,7 @@ class TestOsUtils(TestCase):
         self.maxDiff = None
         self.tempdir_path = mkdtemp()
         ENV['OCRD_DUMMY_PATH'] = self.tempdir_path
+        super().setUp()
 
     def tearDown(self):
         rmtree(self.tempdir_path)

--- a/tests/validator/test_json_validator.py
+++ b/tests/validator/test_json_validator.py
@@ -16,6 +16,7 @@ class TestParameterValidator(TestCase):
             }
         }
         self.defaults_validator = JsonValidator(self.schema, DefaultValidatingDraft4Validator)
+        super().setUp()
 
     def test_validate_string(self):
         report = JsonValidator.validate('{}', {})

--- a/tests/validator/test_ocrd_tool_validator.py
+++ b/tests/validator/test_ocrd_tool_validator.py
@@ -24,6 +24,7 @@ skeleton = '''
 class TestOcrdToolValidator(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.ocrd_tool = json.loads(skeleton)
 
     def test_smoke(self):

--- a/tests/validator/test_ocrd_zip_validator.py
+++ b/tests/validator/test_ocrd_zip_validator.py
@@ -14,6 +14,7 @@ from ocrd.resolver import Resolver
 class TestOcrdZipValidator(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.resolver = Resolver()
         self.bagger = WorkspaceBagger(self.resolver)
         self.tempdir = mkdtemp()

--- a/tests/validator/test_page_validator.py
+++ b/tests/validator/test_page_validator.py
@@ -9,9 +9,6 @@ FAULTY_GLYPH_PAGE_FILENAME = assets.path_to('glyph-consistency/data/OCR-D-GT-PAG
 
 class TestPageValidator(TestCase):
 
-    def setUp(self):
-        pass
-
     def test_validate_err(self):
         with self.assertRaisesRegex(Exception, 'At least one of ocrd_page, ocrd_file or filename must be set'):
             PageValidator.validate()

--- a/tests/validator/test_workspace_backup.py
+++ b/tests/validator/test_workspace_backup.py
@@ -11,6 +11,7 @@ from ocrd.resolver import Resolver
 class TestWorkspaceBackup(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.resolver = Resolver()
         self.tempdir = mkdtemp()
         self.workspace_dir = join(self.tempdir, 'kant_aufklaerung_1784')

--- a/tests/validator/test_workspace_bagger.py
+++ b/tests/validator/test_workspace_bagger.py
@@ -14,6 +14,8 @@ README_FILE = abspath('README.md')
 class TestWorkspaceBagger(TestCase):
 
     def setUp(self):
+        super().setUp()
+        pass
         if exists(BACKUPDIR):
             rmtree(BACKUPDIR)
         self.resolver = Resolver()

--- a/tests/validator/test_xsd_validator.py
+++ b/tests/validator/test_xsd_validator.py
@@ -13,6 +13,7 @@ from tests.model.test_ocrd_page import simple_page
 class TestXsdValidator(TestCase):
 
     def setUp(self):
+        super().setUp()
         self.resolver = Resolver()
         self.ws = self.resolver.workspace_from_url(assets.url_of('SBB0000F29300010000/data/mets.xml'))
 


### PR DESCRIPTION
The unit tests behaved strangely when a `$HOME/ocrd_logging.conf` was present. Most of the errors result from different configuration, hence the `string in processor-output` tests fail, which is to be expected. However, there were issues related to the `os.chdir` call in `setUpClass` in `tests/base.py`. Moving this to `setUp` and ensuring that all tests call `super().setUp` in their own `setUp` (where applicable) fixes this.

Also contains a few improvements to the comments in the bundled `ocrd_logging.conf` by @bertsky.

We should probably create an ocrd_logging.conf that is equivalent to the builtin config and run the unit tests once without `ocrd_logging.conf` and once with.