### PR TITLE
Resmgr tess config

### DIFF
--- a/ocrd/ocrd/cli/resmgr.py
+++ b/ocrd/ocrd/cli/resmgr.py
@@ -131,6 +131,7 @@ def download(any_url, allow_uninstalled, overwrite, location, executable, url_or
                     resource_type=resdict['type'],
                     path_in_archive=resdict.get('path_in_archive', '.'),
                     overwrite=overwrite,
+                    size=resdict['size'],
                     no_subdir=location == 'cwd',
                     basedir=basedir,
                     progress_cb=lambda delta: bar.update(delta)

--- a/ocrd/ocrd/resource_list.yml
+++ b/ocrd/ocrd/resource_list.yml
@@ -45,6 +45,12 @@ ocrd-tesserocr-recognize:
     parameter_usage: 'without-extension'
     description: Tesseract Latin model
     size: 89384811
+  - url: https://github.com/tesseract-ocr/tesseract/archive/master.tar.gz
+    name: configs
+    description: Tesseract configs (parameter sets) for use with the standalone tesseract CLI
+    size: 1973268
+    type: tarball
+    path_in_archive: 'tesseract-master/tessdata/configs'
 ocrd-calamari-recognize:
   # XXX disabled since older ocrd_calamari versions don't support resource resolving
   #- url: https://qurator-data.de/calamari-models/GT4HistOCR/2019-07-22T15_49+0200/model.tar.xz

--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -153,12 +153,12 @@ class OcrdResourceManager():
         if usage == 'without-extension':
             return Path(name).stem
 
-    def _download_impl(self, url, filename, progress_cb=None):
+    def _download_impl(self, url, filename, progress_cb=None, size=None):
         log = getLogger('ocrd.resource_manager._download_impl')
         log.info("Downloading %s to %s" % (url, filename))
         with open(filename, 'wb') as f:
             with requests.get(url, stream=True) as r:
-                total = int(r.headers.get('content-length'))
+                total = size if size else int(r.headers.get('content-length'))
                 for data in r.iter_content(chunk_size=4096):
                     if progress_cb:
                         progress_cb(len(data))
@@ -189,6 +189,7 @@ class OcrdResourceManager():
         resource_type='file',
         path_in_archive='.',
         progress_cb=None,
+        size=None,
     ):
         """
         Download a resource by URL
@@ -212,7 +213,7 @@ class OcrdResourceManager():
         elif resource_type == 'tarball':
             with pushd_popd(tempdir=True):
                 if is_url:
-                    self._download_impl(url, 'download.tar.xx', progress_cb)
+                    self._download_impl(url, 'download.tar.xx', progress_cb, size)
                 else:
                     self._copy_impl(url, 'download.tar.xx', progress_cb)
                 Path('out').mkdir()


### PR DESCRIPTION
This allows downloading the configs, i.e. parameter sets, used by the upstream tesseract CLI.