### PR TITLE
ocrd_page with_etree and improved docstrings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ generate-page: repo/assets
 		--root-element='PcGts' \
 		-o $(GDS_PAGE) \
 		--silence \
-		--export etree \
+		--export "write etree" \
 		--disable-generatedssuper-lookup \
 		--user-methods=$(GDS_PAGE_USER) \
 		ocrd_validators/ocrd_validators/page.xsd

--- a/docs/api/ocrd/ocrd.cli.bashlib.rst
+++ b/docs/api/ocrd/ocrd.cli.bashlib.rst
@@ -2,6 +2,6 @@ ocrd.cli.bashlib module
 =======================
 
 .. automodule:: ocrd.cli.bashlib
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.cli.log.rst
+++ b/docs/api/ocrd/ocrd.cli.log.rst
@@ -1,7 +1,7 @@
-ocrd.cli.zip module
+ocrd.cli.log module
 ===================
 
-.. automodule:: ocrd.cli.zip
+.. automodule:: ocrd.cli.log
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/ocrd/ocrd.cli.ocrd_tool.rst
+++ b/docs/api/ocrd/ocrd.cli.ocrd_tool.rst
@@ -2,6 +2,6 @@ ocrd.cli.ocrd\_tool module
 ==========================
 
 .. automodule:: ocrd.cli.ocrd_tool
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.cli.process.rst
+++ b/docs/api/ocrd/ocrd.cli.process.rst
@@ -2,6 +2,6 @@ ocrd.cli.process module
 =======================
 
 .. automodule:: ocrd.cli.process
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.cli.resmgr.rst
+++ b/docs/api/ocrd/ocrd.cli.resmgr.rst
@@ -1,0 +1,7 @@
+ocrd.cli.resmgr module
+======================
+
+.. automodule:: ocrd.cli.resmgr
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.cli.rst
+++ b/docs/api/ocrd/ocrd.cli.rst
@@ -2,18 +2,21 @@ ocrd.cli package
 ================
 
 .. automodule:: ocrd.cli
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
    ocrd.cli.bashlib
+   ocrd.cli.log
    ocrd.cli.ocrd_tool
    ocrd.cli.process
+   ocrd.cli.resmgr
+   ocrd.cli.validate
    ocrd.cli.workspace
    ocrd.cli.zip
-

--- a/docs/api/ocrd/ocrd.cli.validate.rst
+++ b/docs/api/ocrd/ocrd.cli.validate.rst
@@ -1,0 +1,7 @@
+ocrd.cli.validate module
+========================
+
+.. automodule:: ocrd.cli.validate
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.cli.workspace.rst
+++ b/docs/api/ocrd/ocrd.cli.workspace.rst
@@ -2,6 +2,6 @@ ocrd.cli.workspace module
 =========================
 
 .. automodule:: ocrd.cli.workspace
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.constants.rst
+++ b/docs/api/ocrd/ocrd.constants.rst
@@ -2,6 +2,6 @@ ocrd.constants module
 =====================
 
 .. automodule:: ocrd.constants
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.decorators.loglevel_option.rst
+++ b/docs/api/ocrd/ocrd.decorators.loglevel_option.rst
@@ -1,7 +1,7 @@
-ocrd\_validators.page\_validator module
+ocrd.decorators.loglevel\_option module
 =======================================
 
-.. automodule:: ocrd_validators.page_validator
+.. automodule:: ocrd.decorators.loglevel_option
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/ocrd/ocrd.decorators.mets_find_options.rst
+++ b/docs/api/ocrd/ocrd.decorators.mets_find_options.rst
@@ -1,0 +1,7 @@
+ocrd.decorators.mets\_find\_options module
+==========================================
+
+.. automodule:: ocrd.decorators.mets_find_options
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.decorators.ocrd_cli_options.rst
+++ b/docs/api/ocrd/ocrd.decorators.ocrd_cli_options.rst
@@ -1,0 +1,7 @@
+ocrd.decorators.ocrd\_cli\_options module
+=========================================
+
+.. automodule:: ocrd.decorators.ocrd_cli_options
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.decorators.parameter_option.rst
+++ b/docs/api/ocrd/ocrd.decorators.parameter_option.rst
@@ -1,0 +1,7 @@
+ocrd.decorators.parameter\_option module
+========================================
+
+.. automodule:: ocrd.decorators.parameter_option
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.decorators.rst
+++ b/docs/api/ocrd/ocrd.decorators.rst
@@ -1,7 +1,18 @@
-ocrd.decorators module
-======================
+ocrd.decorators package
+=======================
 
 .. automodule:: ocrd.decorators
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   ocrd.decorators.loglevel_option
+   ocrd.decorators.mets_find_options
+   ocrd.decorators.ocrd_cli_options
+   ocrd.decorators.parameter_option

--- a/docs/api/ocrd/ocrd.processor.base.rst
+++ b/docs/api/ocrd/ocrd.processor.base.rst
@@ -2,6 +2,6 @@ ocrd.processor.base module
 ==========================
 
 .. automodule:: ocrd.processor.base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.processor.builtin.dummy_processor.rst
+++ b/docs/api/ocrd/ocrd.processor.builtin.dummy_processor.rst
@@ -1,0 +1,7 @@
+ocrd.processor.builtin.dummy\_processor module
+==============================================
+
+.. automodule:: ocrd.processor.builtin.dummy_processor
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.processor.builtin.rst
+++ b/docs/api/ocrd/ocrd.processor.builtin.rst
@@ -1,0 +1,15 @@
+ocrd.processor.builtin package
+==============================
+
+.. automodule:: ocrd.processor.builtin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   ocrd.processor.builtin.dummy_processor

--- a/docs/api/ocrd/ocrd.processor.helpers.rst
+++ b/docs/api/ocrd/ocrd.processor.helpers.rst
@@ -1,7 +1,7 @@
-ocrd\_models.constants module
+ocrd.processor.helpers module
 =============================
 
-.. automodule:: ocrd_models.constants
+.. automodule:: ocrd.processor.helpers
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/ocrd/ocrd.processor.rst
+++ b/docs/api/ocrd/ocrd.processor.rst
@@ -2,14 +2,23 @@ ocrd.processor package
 ======================
 
 .. automodule:: ocrd.processor
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   ocrd.processor.builtin
 
 Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
    ocrd.processor.base
-
+   ocrd.processor.helpers

--- a/docs/api/ocrd/ocrd.resolver.rst
+++ b/docs/api/ocrd/ocrd.resolver.rst
@@ -2,6 +2,6 @@ ocrd.resolver module
 ====================
 
 .. automodule:: ocrd.resolver
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.resource_manager.rst
+++ b/docs/api/ocrd/ocrd.resource_manager.rst
@@ -1,7 +1,7 @@
-ocrd\_models.constants module
+ocrd.resource\_manager module
 =============================
 
-.. automodule:: ocrd_models.constants
+.. automodule:: ocrd.resource_manager
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/ocrd/ocrd.rst
+++ b/docs/api/ocrd/ocrd.rst
@@ -2,28 +2,30 @@ ocrd package
 ============
 
 .. automodule:: ocrd
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Subpackages
 -----------
 
 .. toctree::
+   :maxdepth: 4
 
-    ocrd.cli
-    ocrd.processor
+   ocrd.cli
+   ocrd.decorators
+   ocrd.processor
 
 Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
    ocrd.constants
-   ocrd.decorators
    ocrd.resolver
+   ocrd.resource_manager
    ocrd.task_sequence
    ocrd.workspace
    ocrd.workspace_backup
    ocrd.workspace_bagger
-

--- a/docs/api/ocrd/ocrd.task_sequence.rst
+++ b/docs/api/ocrd/ocrd.task_sequence.rst
@@ -2,6 +2,6 @@ ocrd.task\_sequence module
 ==========================
 
 .. automodule:: ocrd.task_sequence
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.workspace_backup.rst
+++ b/docs/api/ocrd/ocrd.workspace_backup.rst
@@ -2,6 +2,6 @@ ocrd.workspace\_backup module
 =============================
 
 .. automodule:: ocrd.workspace_backup
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd/ocrd.workspace_bagger.rst
+++ b/docs/api/ocrd/ocrd.workspace_bagger.rst
@@ -2,6 +2,6 @@ ocrd.workspace\_bagger module
 =============================
 
 .. automodule:: ocrd.workspace_bagger
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_modelfactory/ocrd_modelfactory.rst
+++ b/docs/api/ocrd_modelfactory/ocrd_modelfactory.rst
@@ -2,7 +2,6 @@ ocrd\_modelfactory package
 ==========================
 
 .. automodule:: ocrd_modelfactory
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_models/ocrd_models.ocrd_agent.rst
+++ b/docs/api/ocrd_models/ocrd_models.ocrd_agent.rst
@@ -2,6 +2,6 @@ ocrd\_models.ocrd\_agent module
 ===============================
 
 .. automodule:: ocrd_models.ocrd_agent
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_models/ocrd_models.ocrd_exif.rst
+++ b/docs/api/ocrd_models/ocrd_models.ocrd_exif.rst
@@ -2,6 +2,6 @@ ocrd\_models.ocrd\_exif module
 ==============================
 
 .. automodule:: ocrd_models.ocrd_exif
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_models/ocrd_models.ocrd_file.rst
+++ b/docs/api/ocrd_models/ocrd_models.ocrd_file.rst
@@ -2,6 +2,6 @@ ocrd\_models.ocrd\_file module
 ==============================
 
 .. automodule:: ocrd_models.ocrd_file
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_models/ocrd_models.ocrd_mets.rst
+++ b/docs/api/ocrd_models/ocrd_models.ocrd_mets.rst
@@ -2,6 +2,6 @@ ocrd\_models.ocrd\_mets module
 ==============================
 
 .. automodule:: ocrd_models.ocrd_mets
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_models/ocrd_models.ocrd_page.rst
+++ b/docs/api/ocrd_models/ocrd_models.ocrd_page.rst
@@ -2,6 +2,6 @@ ocrd\_models.ocrd\_page module
 ==============================
 
 .. automodule:: ocrd_models.ocrd_page
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_models/ocrd_models.ocrd_xml_base.rst
+++ b/docs/api/ocrd_models/ocrd_models.ocrd_xml_base.rst
@@ -2,6 +2,6 @@ ocrd\_models.ocrd\_xml\_base module
 ===================================
 
 .. automodule:: ocrd_models.ocrd_xml_base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_models/ocrd_models.report.rst
+++ b/docs/api/ocrd_models/ocrd_models.report.rst
@@ -1,7 +1,7 @@
-ocrd\_utils.logging module
+ocrd\_models.report module
 ==========================
 
-.. automodule:: ocrd_utils.logging
+.. automodule:: ocrd_models.report
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/ocrd_models/ocrd_models.rst
+++ b/docs/api/ocrd_models/ocrd_models.rst
@@ -2,14 +2,15 @@ ocrd\_models package
 ====================
 
 .. automodule:: ocrd_models
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
    ocrd_models.constants
    ocrd_models.ocrd_agent
@@ -18,5 +19,5 @@ Submodules
    ocrd_models.ocrd_mets
    ocrd_models.ocrd_page
    ocrd_models.ocrd_xml_base
+   ocrd_models.report
    ocrd_models.utils
-

--- a/docs/api/ocrd_models/ocrd_models.utils.rst
+++ b/docs/api/ocrd_models/ocrd_models.utils.rst
@@ -2,6 +2,6 @@ ocrd\_models.utils module
 =========================
 
 .. automodule:: ocrd_models.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_utils/ocrd_utils.deprecate.rst
+++ b/docs/api/ocrd_utils/ocrd_utils.deprecate.rst
@@ -1,7 +1,7 @@
-ocrd\_utils.constants module
+ocrd\_utils.deprecate module
 ============================
 
-.. automodule:: ocrd_utils.constants
+.. automodule:: ocrd_utils.deprecate
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/ocrd_utils/ocrd_utils.image.rst
+++ b/docs/api/ocrd_utils/ocrd_utils.image.rst
@@ -1,0 +1,7 @@
+ocrd\_utils.image module
+========================
+
+.. automodule:: ocrd_utils.image
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_utils/ocrd_utils.introspect.rst
+++ b/docs/api/ocrd_utils/ocrd_utils.introspect.rst
@@ -1,7 +1,7 @@
-ocrd\_models.constants module
+ocrd\_utils.introspect module
 =============================
 
-.. automodule:: ocrd_models.constants
+.. automodule:: ocrd_utils.introspect
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/ocrd_utils/ocrd_utils.os.rst
+++ b/docs/api/ocrd_utils/ocrd_utils.os.rst
@@ -1,7 +1,7 @@
-ocrd.workspace module
+ocrd\_utils.os module
 =====================
 
-.. automodule:: ocrd.workspace
+.. automodule:: ocrd_utils.os
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/ocrd_utils/ocrd_utils.rst
+++ b/docs/api/ocrd_utils/ocrd_utils.rst
@@ -2,15 +2,20 @@ ocrd\_utils package
 ===================
 
 .. automodule:: ocrd_utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
    ocrd_utils.constants
+   ocrd_utils.deprecate
+   ocrd_utils.image
+   ocrd_utils.introspect
    ocrd_utils.logging
-
+   ocrd_utils.os
+   ocrd_utils.str

--- a/docs/api/ocrd_utils/ocrd_utils.str.rst
+++ b/docs/api/ocrd_utils/ocrd_utils.str.rst
@@ -1,0 +1,7 @@
+ocrd\_utils.str module
+======================
+
+.. automodule:: ocrd_utils.str
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_validators/ocrd_validators.constants.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.constants.rst
@@ -2,6 +2,6 @@ ocrd\_validators.constants module
 =================================
 
 .. automodule:: ocrd_validators.constants
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_validators/ocrd_validators.json_validator.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.json_validator.rst
@@ -2,6 +2,6 @@ ocrd\_validators.json\_validator module
 =======================================
 
 .. automodule:: ocrd_validators.json_validator
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_validators/ocrd_validators.ocrd_tool_validator.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.ocrd_tool_validator.rst
@@ -2,6 +2,6 @@ ocrd\_validators.ocrd\_tool\_validator module
 =============================================
 
 .. automodule:: ocrd_validators.ocrd_tool_validator
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_validators/ocrd_validators.ocrd_zip_validator.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.ocrd_zip_validator.rst
@@ -2,6 +2,6 @@ ocrd\_validators.ocrd\_zip\_validator module
 ============================================
 
 .. automodule:: ocrd_validators.ocrd_zip_validator
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_validators/ocrd_validators.parameter_validator.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.parameter_validator.rst
@@ -2,6 +2,6 @@ ocrd\_validators.parameter\_validator module
 ============================================
 
 .. automodule:: ocrd_validators.parameter_validator
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_validators/ocrd_validators.report.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.report.rst
@@ -1,7 +1,0 @@
-ocrd\_validators.report module
-==============================
-
-.. automodule:: ocrd_validators.report
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/ocrd_validators/ocrd_validators.resource_list_validator.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.resource_list_validator.rst
@@ -1,0 +1,7 @@
+ocrd\_validators.resource\_list\_validator module
+=================================================
+
+.. automodule:: ocrd_validators.resource_list_validator
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/ocrd_validators/ocrd_validators.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.rst
@@ -2,14 +2,15 @@ ocrd\_validators package
 ========================
 
 .. automodule:: ocrd_validators
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
    ocrd_validators.constants
    ocrd_validators.json_validator
@@ -17,6 +18,8 @@ Submodules
    ocrd_validators.ocrd_zip_validator
    ocrd_validators.page_validator
    ocrd_validators.parameter_validator
-   ocrd_validators.report
+   ocrd_validators.resource_list_validator
    ocrd_validators.workspace_validator
-
+   ocrd_validators.xsd_mets_validator
+   ocrd_validators.xsd_page_validator
+   ocrd_validators.xsd_validator

--- a/docs/api/ocrd_validators/ocrd_validators.xsd_mets_validator.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.xsd_mets_validator.rst
@@ -1,7 +1,7 @@
-ocrd\_validators.workspace\_validator module
+ocrd\_validators.xsd\_mets\_validator module
 ============================================
 
-.. automodule:: ocrd_validators.workspace_validator
+.. automodule:: ocrd_validators.xsd_mets_validator
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/ocrd_validators/ocrd_validators.xsd_page_validator.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.xsd_page_validator.rst
@@ -1,7 +1,7 @@
-ocrd\_validators.workspace\_validator module
+ocrd\_validators.xsd\_page\_validator module
 ============================================
 
-.. automodule:: ocrd_validators.workspace_validator
+.. automodule:: ocrd_validators.xsd_page_validator
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/ocrd_validators/ocrd_validators.xsd_validator.rst
+++ b/docs/api/ocrd_validators/ocrd_validators.xsd_validator.rst
@@ -1,0 +1,7 @@
+ocrd\_validators.xsd\_validator module
+======================================
+
+.. automodule:: ocrd_validators.xsd_validator
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.coverage',
     'sphinx.ext.githubpages',
+    'sphinx_click',
     'recommonmark'
 ]
 
@@ -74,6 +75,10 @@ exclude_patterns = [u'build', 'Thumbs.db', '.DS_Store', 'src', 'venv']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# Generate autodoc from both class and init docstrings
+autoclass_content = 'both'
+# Generate autodoc from members ordered bysource instead of alphabetical
+autodoc_member_order = 'bysource'
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,6 @@ OCR-D/core
    ocrd_validators <api/ocrd_validators/modules>
    ocrd_modelfactory <api/ocrd_modelfactory/modules>
 
-   api/ocrd/ocrd
 
 Indices and tables
 ==================

--- a/ocrd/ocrd/__init__.py
+++ b/ocrd/ocrd/__init__.py
@@ -3,13 +3,13 @@ OCR-D reference implementation, base package: decorators and classes for process
 
 Related (and dependent) packages:
 
-* ``ocrd_utils``
+* :py:mod:`ocrd_utils`
   Contains utilities and constants, e.g. for logging, path normalization, coordinate calculation etc.
-* ``ocrd_models``
+* :py:mod:`ocrd_models`
   Contains file format wrappers for PAGE-XML, METS, EXIF metadata etc.
-* ``ocrd_modelfactory``
+* :py:mod:`ocrd_modelfactory`
   Code to instantiate models from existing data.
-* ``ocrd_validators``
+* :py:mod:`ocrd_validators`
   Schemas and routines for validating BagIt, ``ocrd-tool.json``, workspaces, METS, page, CLI parameters etc.
 
 """

--- a/ocrd/ocrd/cli/__init__.py
+++ b/ocrd/ocrd/cli/__init__.py
@@ -1,5 +1,14 @@
+"""
+OCR-D Command-line interface
+
+.. click:: ocrd.cli:cli
+    :prog: ocrd
+    :nested: short
+"""
 import re
 import click
+
+__all__ = ['cli']
 
 def command_with_replaced_help(*replacements):
 
@@ -28,7 +37,7 @@ from .log import log_cli
 @ocrd_loglevel
 def cli(**kwargs): # pylint: disable=unused-argument
     """
-    CLI to OCR-D
+    Entry-point of multi-purpose CLI for OCR-D
     """
 
 cli.add_command(ocrd_tool_cli)

--- a/ocrd/ocrd/cli/bashlib.py
+++ b/ocrd/ocrd/cli/bashlib.py
@@ -1,3 +1,11 @@
+"""
+OCR-D CLI: bash library
+
+.. click:: ocrd.cli.bashlib:bashlib_cli
+    :prog: ocrd bashlib
+    :nested: full
+
+"""
 from __future__ import print_function
 import sys
 import click
@@ -26,6 +34,8 @@ def bashlib_cli():
 def bashlib_filename():
     """
     Dump the bash library filename for sourcing by shell scripts
+
+    For functions exported by bashlib, see `<../../README.md>`_
     """
     print(BASHLIB_FILENAME)
 

--- a/ocrd/ocrd/cli/log.py
+++ b/ocrd/ocrd/cli/log.py
@@ -1,5 +1,9 @@
 """
-Logging CLI
+OCR-D CLI: Logging
+
+.. click:: ocrd.cli.log:log_cli
+    :prog: ocrd log
+    :nested: full
 """
 import click
 from ocrd_utils import initLogging, getLogger, getLevelName

--- a/ocrd/ocrd/cli/ocrd_tool.py
+++ b/ocrd/ocrd/cli/ocrd_tool.py
@@ -1,3 +1,11 @@
+"""
+OCR-D CLI: ocrd-tool.json management
+
+.. click:: ocrd.cli.ocrd_tool:ocrd_tool_cli
+    :prog: ocrd ocrd-tool
+    :nested: full
+
+"""
 from json import dumps
 import codecs
 import sys

--- a/ocrd/ocrd/cli/process.py
+++ b/ocrd/ocrd/cli/process.py
@@ -1,5 +1,10 @@
 """
-CLI for task_sequence
+OCR-D CLI: running task sequences (workflow processing)
+
+.. click:: ocrd.cli.process:process_cli
+    :prog: ocrd process
+    :nested: full
+
 """
 import click
 

--- a/ocrd/ocrd/cli/resmgr.py
+++ b/ocrd/ocrd/cli/resmgr.py
@@ -1,3 +1,10 @@
+"""
+OCR-D CLI: management of processor resources
+
+.. click:: ocrd.cli.resmgr:resmgr_cli
+    :prog: ocrd resmgr
+    :nested: full
+"""
 import sys
 from pathlib import Path
 from distutils.spawn import find_executable as which

--- a/ocrd/ocrd/cli/validate.py
+++ b/ocrd/ocrd/cli/validate.py
@@ -1,3 +1,10 @@
+"""
+OCR-D CLI: syntax validation
+
+.. click:: ocrd.cli.validate:validate_cli
+    :prog: ocrd validate
+    :nested: full
+"""
 import sys
 
 import click

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -1,3 +1,10 @@
+"""
+OCR-D CLI: workspace management
+
+.. click:: ocrd.cli.workspace:workspace_cli
+    :prog: ocrd workspace
+    :nested: full
+"""
 import os
 from os import getcwd
 from os.path import relpath, exists, join, isabs, dirname, basename, abspath

--- a/ocrd/ocrd/cli/zip.py
+++ b/ocrd/ocrd/cli/zip.py
@@ -1,3 +1,10 @@
+"""
+OCR-D CLI: OCRD-ZIP (BagIt) management
+
+.. click:: ocrd.cli.zip:zip_cli
+    :prog: ocrd zip
+    :nested: full
+"""
 import sys
 
 import click

--- a/ocrd/ocrd/resolver.py
+++ b/ocrd/ocrd/resolver.py
@@ -18,27 +18,30 @@ from ocrd_models.utils import handle_oai_response
 
 class Resolver():
     """
-    Handle Uploads, Downloads, Repository access and manage temporary directories
+    Handle uploads, downloads, repository access, and manage temporary directories
     """
 
     def download_to_directory(self, directory, url, basename=None, if_exists='skip', subdir=None):
         """
         Download a file to a directory.
 
-        Early Shortcut: If url is a local file and that file is already in the directory, keep it there.
+        Early Shortcut: If `url` is a local file and that file is already in the directory, keep it there.
 
-        If basename is not given but subdir is, assume user knows what she's doing and use last URL segment as the basename.
-        If basename is not given and no subdir is given, use the alnum characters in the URL as the basename.
+        If `basename` is not given but subdir is, assume user knows what she's doing and
+        use last URL segment as the basename.
+
+        If `basename` is not given and no subdir is given, use the alnum characters in the URL as the basename.
 
         Args:
             directory (string): Directory to download files to
             basename (string, None): basename part of the filename on disk.
             url (string): URL to download from
-            if_exists (string, "skip"): What to do if target file already exists. One of ``skip`` (default), ``overwrite`` or ``raise``
-            subdir (string, None): Subdirectory to create within the directory. Think fileGrp.
+            if_exists (string, "skip"): What to do if target file already exists. \
+                One of ``skip`` (default), ``overwrite`` or ``raise``
+            subdir (string, None): Subdirectory to create within the directory. Think ``mets:fileGrp``.
 
         Returns:
-            Local filename, __relative__ to directory
+            Local filename string, __relative__ to directory
         """
         log = getLogger('ocrd.resolver.download_to_directory') # pylint: disable=redefined-outer-name
         log.debug("directory=|%s| url=|%s| basename=|%s| if_exists=|%s| subdir=|%s|", directory, url, basename, if_exists, subdir)
@@ -107,17 +110,18 @@ class Resolver():
         """
         Create a workspace from a METS by URL (i.e. clone it).
 
-        Sets the mets.xml file
+        Sets the ``mets.xml`` file
 
         Arguments:
             mets_url (string): Source mets URL
             dst_dir (string, None): Target directory for the workspace
-            clobber_mets (boolean, False): Whether to overwrite existing mets.xml. By default existing mets.xml will raise an exception.
+            clobber_mets (boolean, False): Whether to overwrite existing mets.xml. \
+                By default existing mets.xml will raise an exception.
             download (boolean, False): Whether to download all the files
             src_baseurl (string, None): Base URL for resolving relative file locations
 
         Returns:
-            Workspace
+            a new :py:class:`~ocrd.workspace.Workspace`
         """
         log = getLogger('ocrd.resolver.workspace_from_url')
 

--- a/ocrd_modelfactory/ocrd_modelfactory/__init__.py
+++ b/ocrd_modelfactory/ocrd_modelfactory/__init__.py
@@ -25,11 +25,11 @@ __all__ = [
 
 def exif_from_filename(image_filename):
     """
-    Create `OcrdExif </../../ocrd_models/ocrd_models.ocrd_exif.html>`_
+    Create :py:class:`~ocrd_models.ocrd_exif.OcrdExif`
     by opening an image file with PIL and reading its metadata.
 
     Arguments:
-        * image_filename (string):
+        image_filename (str): Local image path name (relative to workspace).
     """
     if image_filename is None:
         raise Exception("Must pass 'image_filename' to 'exif_from_filename'")
@@ -39,14 +39,16 @@ def exif_from_filename(image_filename):
 
 def page_from_image(input_file, with_tree=False):
     """
-    Create `OcrdPage </../../ocrd_models/ocrd_models.ocrd_page.html>`_
-    from an `OcrdFile </../../ocrd_models/ocrd_models.ocrd_file.html>`_
-    representing an image (i.e. should have ``mimetype`` starting with ``image/``).
+    Create :py:class:`~ocrd_models.ocrd_page.OcrdPage`
+    from an :py:class:`~ocrd_models.ocrd_file.OcrdFile`
+    representing an image (i.e. should have ``@mimetype`` starting with ``image/``).
 
     Arguments:
-        * input_file (OcrdFile): file to open and produce a PAGE DOM for
+        input_file (:py:class:`~ocrd_models.ocrd_file.OcrdFile`): file to open \
+            and produce a PAGE DOM for
     Keyword arguments:
-        * with_tree (boolean): whether to return XML node tree, element-node mapping and reverse mapping, too
+        with_tree (boolean): whether to return XML node tree, element-node mapping \
+            and reverse mapping, too (cf. :py:func:`ocrd_models.ocrd_page.parseEtree`)
     """
     if not input_file.local_filename:
         raise ValueError("input_file must have 'local_filename' property")
@@ -80,9 +82,11 @@ def page_from_file(input_file, with_tree=False):
     Create a new PAGE-XML from a METS file representing a PAGE-XML or an image.
 
     Arguments:
-        * input_file (OcrdFile): file to open and produce a PAGE DOM for
+        input_file (:py:class:`~ocrd_models.ocrd_file.OcrdFile`): file to open \
+            and produce a PAGE DOM for
     Keyword arguments:
-        * with_tree (boolean): whether to return XML node tree, element-node mapping and reverse mapping, too
+        with_tree (boolean): whether to return XML node tree, element-node mapping \
+            and reverse mapping, too (cf. :py:func:`ocrd_models.ocrd_page.parseEtree`)
     """
     if not input_file.local_filename:
         raise ValueError("input_file must have 'local_filename' property")

--- a/ocrd_models/ocrd_models/ocrd_exif.py
+++ b/ocrd_models/ocrd_models/ocrd_exif.py
@@ -7,25 +7,27 @@ from math import sqrt
 class OcrdExif():
     """Represents technical image metadata.
 
-    Members:
+    Attributes:
+        width (int): pixel dimensions
+        height (int): pixel dimensions
+        photometricInterpretation (str): pixel type/depth, e.g. \
 
-    - `width` / `height`: pixel dimensions
-    - `photometricInterpretation`: pixel type/depth, e.g.
-      '1' for b/w,
-      'L' for 8-bit grayscale,
-      'RGB' for 24-bit truecolor,
-      'I' for 32-bit signed integer grayscale,
-      'F' for floating-point grayscale
-      (see PIL concept `mode`)
-    - `resolution` / `xResolution` / `yResolution`: pixel density
-    - `resolutionUnit`: unit of measurement (either `inches` or `cm`)
-
+            * ``1`` for b/w,
+            * ``L`` for 8-bit grayscale,
+            * ``RGB`` for 24-bit truecolor,
+            * ``I`` for 32-bit signed integer grayscale,
+            * ``F`` for floating-point grayscale
+          (see PIL concept **mode**)
+        resolution (int): pixel density
+        xResolution (int): pixel density
+        yResolution (int): pixel density
+        resolutionUnit (str): unit of measurement (either ``inches`` or ``cm``)
     """
 
     def __init__(self, img):
         """
         Arguments:
-            img (PIL.Image): PIL image technical metadata is about.
+            img (`PIL.Image`): PIL image technical metadata is about.
         """
         #  print(img.__dict__)
         self.width = img.width
@@ -63,7 +65,7 @@ class OcrdExif():
 
     def to_xml(self):
         """
-        Serialize all properties as XML
+        Serialize all properties as XML string.
         """
         ret = '<exif>'
         for k in self.__dict__:

--- a/ocrd_models/ocrd_models/ocrd_page.py
+++ b/ocrd_models/ocrd_models/ocrd_page.py
@@ -7,6 +7,7 @@ __all__ = [
     'parse',
     'parseEtree',
     'parseString',
+    'OcrdPage',
 
     "AdvertRegionType",
     "AlternativeImageType",
@@ -129,9 +130,56 @@ from .ocrd_page_generateds import (
 
 from .constants import NAMESPACES
 
+# add docstrings
+parse.__doc__ = (
+    """Parse a file, create the object tree, and export it.
+
+    Arguments:
+        inFileName (str) -- Path to the PAGE-XML file.
+        print_warnings (boolean) -- If true, write parser \
+                                    warnings to stderr.
+
+    Returns:
+        The root object in the tree.
+    """
+)
+
+parseEtree.__doc__ = (
+    """Parse a file, create the object tree, and export it. Return tree and mappings, too.
+
+    Arguments:
+        inFileName (str) -- Path to the PAGE-XML file.
+        print_warnings (boolean) -- If true, write parser \
+                                    warnings to stderr.
+
+    Returns:
+        A tuple of
+         * The root object in the tree.
+         * The full node tree.
+         * A mapping from object IDs to tree nodes.
+         * A reverse mapping from tree nodes to object IDs.
+    """
+)
+
+# fix generated (malformed) docstrings
+parseString.__doc__ = (
+    """Parse a string, create the object tree, and export it.
+
+    Arguments:
+        inString (str) -- This XML fragment should not start \
+                          with an XML declaration containing an encoding.
+
+    Returns:
+        The root object in the tree.
+    """
+)
+
+# add alias for DOM root
+OcrdPage = PcGtsType
+
 def to_xml(el, skip_declaration=False):
     """
-    Serialize ``pc:PcGts`` document
+    Serialize ``pc:PcGts`` document as string.
     """
     # XXX remove potential empty ReadingOrder
     if hasattr(el, 'prune_ReadingOrder'):

--- a/ocrd_models/ocrd_models/ocrd_page.py
+++ b/ocrd_models/ocrd_models/ocrd_page.py
@@ -5,6 +5,7 @@ from io import StringIO
 
 __all__ = [
     'parse',
+    'parseEtree',
     'parseString',
 
     "AdvertRegionType",
@@ -67,6 +68,7 @@ __all__ = [
 
 from .ocrd_page_generateds import (
     parse,
+    parseEtree,
     parseString,
 
     AdvertRegionType,

--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,15 +2,15 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Wed Jun 23 12:05:40 2021 by generateDS.py version 2.35.20.
-# Python 3.6.9 (default, Jan 26 2021, 15:33:00)  [GCC 8.4.0]
+# Generated Wed Jun 23 17:59:57 2021 by generateDS.py version 2.35.20.
+# Python 3.6.9 (default, Apr 18 2020, 01:56:04)  [GCC 8.4.0]
 #
 # Command line options:
 #   ('-f', '')
 #   ('--root-element', 'PcGts')
 #   ('-o', 'ocrd_models/ocrd_models/ocrd_page_generateds.py')
 #   ('--silence', '')
-#   ('--export', 'etree')
+#   ('--export', 'write etree')
 #   ('--disable-generatedssuper-lookup', '')
 #   ('--user-methods', 'ocrd_models/ocrd_page_user_methods.py')
 #
@@ -18,7 +18,7 @@
 #   ocrd_validators/ocrd_validators/page.xsd
 #
 # Command line:
-#   /home/kba/monorepo/ocrd_all/venv/bin/generateDS -f --root-element="PcGts" -o "ocrd_models/ocrd_models/ocrd_page_generateds.py" --silence --export="etree" --disable-generatedssuper-lookup --user-methods="ocrd_models/ocrd_page_user_methods.py" ocrd_validators/ocrd_validators/page.xsd
+#   /home/xbert/install/tesseract/build-debug/venv/bin/generateDS -f --root-element="PcGts" -o "ocrd_models/ocrd_models/ocrd_page_generateds.py" --silence --export="write etree" --disable-generatedssuper-lookup --user-methods="ocrd_models/ocrd_page_user_methods.py" ocrd_validators/ocrd_validators/page.xsd
 #
 # Current working directory (os.getcwd()):
 #   core
@@ -1143,6 +1143,44 @@ class PcGtsType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='PcGtsType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PcGtsType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'PcGtsType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PcGtsType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PcGtsType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PcGtsType'):
+        if self.pcGtsId is not None and 'pcGtsId' not in already_processed:
+            already_processed.add('pcGtsId')
+            outfile.write(' pcGtsId=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.pcGtsId), input_name='pcGtsId')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='PcGtsType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Metadata is not None:
+            namespaceprefix_ = self.Metadata_nsprefix_ + ':' if (UseCapturedNS_ and self.Metadata_nsprefix_) else ''
+            self.Metadata.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Metadata', pretty_print=pretty_print)
+        if self.Page is not None:
+            namespaceprefix_ = self.Page_nsprefix_ + ':' if (UseCapturedNS_ and self.Page_nsprefix_) else ''
+            self.Page.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Page', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='PcGtsType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -1369,6 +1407,60 @@ class MetadataType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" xmlns:None="http://www.w3.org/2001/XMLSchema" ', name_='MetadataType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('MetadataType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'MetadataType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='MetadataType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='MetadataType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='MetadataType'):
+        if self.externalRef is not None and 'externalRef' not in already_processed:
+            already_processed.add('externalRef')
+            outfile.write(' externalRef=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.externalRef), input_name='externalRef')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" xmlns:None="http://www.w3.org/2001/XMLSchema" ', name_='MetadataType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Creator is not None:
+            namespaceprefix_ = self.Creator_nsprefix_ + ':' if (UseCapturedNS_ and self.Creator_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sCreator>%s</%sCreator>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Creator), input_name='Creator')), namespaceprefix_ , eol_))
+        if self.Created is not None:
+            namespaceprefix_ = self.Created_nsprefix_ + ':' if (UseCapturedNS_ and self.Created_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sCreated>%s</%sCreated>%s' % (namespaceprefix_ , self.gds_format_datetime(self.Created, input_name='Created'), namespaceprefix_ , eol_))
+        if self.LastChange is not None:
+            namespaceprefix_ = self.LastChange_nsprefix_ + ':' if (UseCapturedNS_ and self.LastChange_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sLastChange>%s</%sLastChange>%s' % (namespaceprefix_ , self.gds_format_datetime(self.LastChange, input_name='LastChange'), namespaceprefix_ , eol_))
+        if self.Comments is not None:
+            namespaceprefix_ = self.Comments_nsprefix_ + ':' if (UseCapturedNS_ and self.Comments_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sComments>%s</%sComments>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Comments), input_name='Comments')), namespaceprefix_ , eol_))
+        if self.UserDefined is not None:
+            namespaceprefix_ = self.UserDefined_nsprefix_ + ':' if (UseCapturedNS_ and self.UserDefined_nsprefix_) else ''
+            self.UserDefined.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserDefined', pretty_print=pretty_print)
+        for MetadataItem_ in self.MetadataItem:
+            namespaceprefix_ = self.MetadataItem_nsprefix_ + ':' if (UseCapturedNS_ and self.MetadataItem_nsprefix_) else ''
+            MetadataItem_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='MetadataItem', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='MetadataType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -1542,6 +1634,50 @@ class MetadataItemType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='MetadataItemType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('MetadataItemType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'MetadataItemType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='MetadataItemType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='MetadataItemType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='MetadataItemType'):
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            outfile.write(' value=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.value), input_name='value')), ))
+        if self.date is not None and 'date' not in already_processed:
+            already_processed.add('date')
+            outfile.write(' date="%s"' % self.gds_format_datetime(self.date, input_name='date'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='MetadataItemType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='MetadataItemType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -1692,6 +1828,50 @@ class LabelsType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='LabelsType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('LabelsType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'LabelsType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='LabelsType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='LabelsType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='LabelsType'):
+        if self.externalModel is not None and 'externalModel' not in already_processed:
+            already_processed.add('externalModel')
+            outfile.write(' externalModel=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.externalModel), input_name='externalModel')), ))
+        if self.externalId is not None and 'externalId' not in already_processed:
+            already_processed.add('externalId')
+            outfile.write(' externalId=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.externalId), input_name='externalId')), ))
+        if self.prefix is not None and 'prefix' not in already_processed:
+            already_processed.add('prefix')
+            outfile.write(' prefix=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.prefix), input_name='prefix')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='LabelsType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for Label_ in self.Label:
+            namespaceprefix_ = self.Label_nsprefix_ + ':' if (UseCapturedNS_ and self.Label_nsprefix_) else ''
+            Label_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Label', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='LabelsType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -1819,6 +1999,40 @@ class LabelType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='LabelType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('LabelType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'LabelType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='LabelType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='LabelType', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='LabelType'):
+        if self.value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            outfile.write(' value=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.value), input_name='value')), ))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='LabelType', fromsubclass_=False, pretty_print=True):
+        pass
     def to_etree(self, parent_element=None, name_='LabelType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -2475,6 +2689,155 @@ class PageType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='PageType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PageType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'PageType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PageType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PageType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PageType'):
+        if self.imageFilename is not None and 'imageFilename' not in already_processed:
+            already_processed.add('imageFilename')
+            outfile.write(' imageFilename=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.imageFilename), input_name='imageFilename')), ))
+        if self.imageWidth is not None and 'imageWidth' not in already_processed:
+            already_processed.add('imageWidth')
+            outfile.write(' imageWidth="%s"' % self.gds_format_integer(self.imageWidth, input_name='imageWidth'))
+        if self.imageHeight is not None and 'imageHeight' not in already_processed:
+            already_processed.add('imageHeight')
+            outfile.write(' imageHeight="%s"' % self.gds_format_integer(self.imageHeight, input_name='imageHeight'))
+        if self.imageXResolution is not None and 'imageXResolution' not in already_processed:
+            already_processed.add('imageXResolution')
+            outfile.write(' imageXResolution="%s"' % self.gds_format_float(self.imageXResolution, input_name='imageXResolution'))
+        if self.imageYResolution is not None and 'imageYResolution' not in already_processed:
+            already_processed.add('imageYResolution')
+            outfile.write(' imageYResolution="%s"' % self.gds_format_float(self.imageYResolution, input_name='imageYResolution'))
+        if self.imageResolutionUnit is not None and 'imageResolutionUnit' not in already_processed:
+            already_processed.add('imageResolutionUnit')
+            outfile.write(' imageResolutionUnit=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.imageResolutionUnit), input_name='imageResolutionUnit')), ))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.primaryLanguage is not None and 'primaryLanguage' not in already_processed:
+            already_processed.add('primaryLanguage')
+            outfile.write(' primaryLanguage=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.primaryLanguage), input_name='primaryLanguage')), ))
+        if self.secondaryLanguage is not None and 'secondaryLanguage' not in already_processed:
+            already_processed.add('secondaryLanguage')
+            outfile.write(' secondaryLanguage=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.secondaryLanguage), input_name='secondaryLanguage')), ))
+        if self.primaryScript is not None and 'primaryScript' not in already_processed:
+            already_processed.add('primaryScript')
+            outfile.write(' primaryScript=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.primaryScript), input_name='primaryScript')), ))
+        if self.secondaryScript is not None and 'secondaryScript' not in already_processed:
+            already_processed.add('secondaryScript')
+            outfile.write(' secondaryScript=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.secondaryScript), input_name='secondaryScript')), ))
+        if self.readingDirection is not None and 'readingDirection' not in already_processed:
+            already_processed.add('readingDirection')
+            outfile.write(' readingDirection=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.readingDirection), input_name='readingDirection')), ))
+        if self.textLineOrder is not None and 'textLineOrder' not in already_processed:
+            already_processed.add('textLineOrder')
+            outfile.write(' textLineOrder=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.textLineOrder), input_name='textLineOrder')), ))
+        if self.conf is not None and 'conf' not in already_processed:
+            already_processed.add('conf')
+            outfile.write(' conf="%s"' % self.gds_format_float(self.conf, input_name='conf'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='PageType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for AlternativeImage_ in self.AlternativeImage:
+            namespaceprefix_ = self.AlternativeImage_nsprefix_ + ':' if (UseCapturedNS_ and self.AlternativeImage_nsprefix_) else ''
+            AlternativeImage_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='AlternativeImage', pretty_print=pretty_print)
+        if self.Border is not None:
+            namespaceprefix_ = self.Border_nsprefix_ + ':' if (UseCapturedNS_ and self.Border_nsprefix_) else ''
+            self.Border.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Border', pretty_print=pretty_print)
+        if self.PrintSpace is not None:
+            namespaceprefix_ = self.PrintSpace_nsprefix_ + ':' if (UseCapturedNS_ and self.PrintSpace_nsprefix_) else ''
+            self.PrintSpace.export(outfile, level, namespaceprefix_, namespacedef_='', name_='PrintSpace', pretty_print=pretty_print)
+        if self.ReadingOrder is not None:
+            namespaceprefix_ = self.ReadingOrder_nsprefix_ + ':' if (UseCapturedNS_ and self.ReadingOrder_nsprefix_) else ''
+            self.ReadingOrder.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ReadingOrder', pretty_print=pretty_print)
+        if self.Layers is not None:
+            namespaceprefix_ = self.Layers_nsprefix_ + ':' if (UseCapturedNS_ and self.Layers_nsprefix_) else ''
+            self.Layers.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Layers', pretty_print=pretty_print)
+        if self.Relations is not None:
+            namespaceprefix_ = self.Relations_nsprefix_ + ':' if (UseCapturedNS_ and self.Relations_nsprefix_) else ''
+            self.Relations.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Relations', pretty_print=pretty_print)
+        if self.TextStyle is not None:
+            namespaceprefix_ = self.TextStyle_nsprefix_ + ':' if (UseCapturedNS_ and self.TextStyle_nsprefix_) else ''
+            self.TextStyle.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextStyle', pretty_print=pretty_print)
+        if self.UserDefined is not None:
+            namespaceprefix_ = self.UserDefined_nsprefix_ + ':' if (UseCapturedNS_ and self.UserDefined_nsprefix_) else ''
+            self.UserDefined.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserDefined', pretty_print=pretty_print)
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
+        for TextRegion_ in self.TextRegion:
+            namespaceprefix_ = self.TextRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.TextRegion_nsprefix_) else ''
+            TextRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextRegion', pretty_print=pretty_print)
+        for ImageRegion_ in self.ImageRegion:
+            namespaceprefix_ = self.ImageRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.ImageRegion_nsprefix_) else ''
+            ImageRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ImageRegion', pretty_print=pretty_print)
+        for LineDrawingRegion_ in self.LineDrawingRegion:
+            namespaceprefix_ = self.LineDrawingRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.LineDrawingRegion_nsprefix_) else ''
+            LineDrawingRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='LineDrawingRegion', pretty_print=pretty_print)
+        for GraphicRegion_ in self.GraphicRegion:
+            namespaceprefix_ = self.GraphicRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.GraphicRegion_nsprefix_) else ''
+            GraphicRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='GraphicRegion', pretty_print=pretty_print)
+        for TableRegion_ in self.TableRegion:
+            namespaceprefix_ = self.TableRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.TableRegion_nsprefix_) else ''
+            TableRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TableRegion', pretty_print=pretty_print)
+        for ChartRegion_ in self.ChartRegion:
+            namespaceprefix_ = self.ChartRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.ChartRegion_nsprefix_) else ''
+            ChartRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ChartRegion', pretty_print=pretty_print)
+        for MapRegion_ in self.MapRegion:
+            namespaceprefix_ = self.MapRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.MapRegion_nsprefix_) else ''
+            MapRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='MapRegion', pretty_print=pretty_print)
+        for SeparatorRegion_ in self.SeparatorRegion:
+            namespaceprefix_ = self.SeparatorRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.SeparatorRegion_nsprefix_) else ''
+            SeparatorRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='SeparatorRegion', pretty_print=pretty_print)
+        for MathsRegion_ in self.MathsRegion:
+            namespaceprefix_ = self.MathsRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.MathsRegion_nsprefix_) else ''
+            MathsRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='MathsRegion', pretty_print=pretty_print)
+        for ChemRegion_ in self.ChemRegion:
+            namespaceprefix_ = self.ChemRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.ChemRegion_nsprefix_) else ''
+            ChemRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ChemRegion', pretty_print=pretty_print)
+        for MusicRegion_ in self.MusicRegion:
+            namespaceprefix_ = self.MusicRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.MusicRegion_nsprefix_) else ''
+            MusicRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='MusicRegion', pretty_print=pretty_print)
+        for AdvertRegion_ in self.AdvertRegion:
+            namespaceprefix_ = self.AdvertRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.AdvertRegion_nsprefix_) else ''
+            AdvertRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='AdvertRegion', pretty_print=pretty_print)
+        for NoiseRegion_ in self.NoiseRegion:
+            namespaceprefix_ = self.NoiseRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.NoiseRegion_nsprefix_) else ''
+            NoiseRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='NoiseRegion', pretty_print=pretty_print)
+        for UnknownRegion_ in self.UnknownRegion:
+            namespaceprefix_ = self.UnknownRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.UnknownRegion_nsprefix_) else ''
+            UnknownRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UnknownRegion', pretty_print=pretty_print)
+        for CustomRegion_ in self.CustomRegion:
+            namespaceprefix_ = self.CustomRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.CustomRegion_nsprefix_) else ''
+            CustomRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CustomRegion', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='PageType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -3061,6 +3424,37 @@ class CoordsType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='CoordsType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('CoordsType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'CoordsType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='CoordsType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='CoordsType', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CoordsType'):
+        if self.points is not None and 'points' not in already_processed:
+            already_processed.add('points')
+            outfile.write(' points=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.points), input_name='points')), ))
+        if self.conf is not None and 'conf' not in already_processed:
+            already_processed.add('conf')
+            outfile.write(' conf="%s"' % self.gds_format_float(self.conf, input_name='conf'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='CoordsType', fromsubclass_=False, pretty_print=True):
+        pass
     def to_etree(self, parent_element=None, name_='CoordsType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -3386,6 +3780,86 @@ class TextLineType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='TextLineType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('TextLineType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'TextLineType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='TextLineType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='TextLineType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='TextLineType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.primaryLanguage is not None and 'primaryLanguage' not in already_processed:
+            already_processed.add('primaryLanguage')
+            outfile.write(' primaryLanguage=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.primaryLanguage), input_name='primaryLanguage')), ))
+        if self.primaryScript is not None and 'primaryScript' not in already_processed:
+            already_processed.add('primaryScript')
+            outfile.write(' primaryScript=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.primaryScript), input_name='primaryScript')), ))
+        if self.secondaryScript is not None and 'secondaryScript' not in already_processed:
+            already_processed.add('secondaryScript')
+            outfile.write(' secondaryScript=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.secondaryScript), input_name='secondaryScript')), ))
+        if self.readingDirection is not None and 'readingDirection' not in already_processed:
+            already_processed.add('readingDirection')
+            outfile.write(' readingDirection=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.readingDirection), input_name='readingDirection')), ))
+        if self.production is not None and 'production' not in already_processed:
+            already_processed.add('production')
+            outfile.write(' production=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.production), input_name='production')), ))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+        if self.index is not None and 'index' not in already_processed:
+            already_processed.add('index')
+            outfile.write(' index="%s"' % self.gds_format_integer(self.index, input_name='index'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='TextLineType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for AlternativeImage_ in self.AlternativeImage:
+            namespaceprefix_ = self.AlternativeImage_nsprefix_ + ':' if (UseCapturedNS_ and self.AlternativeImage_nsprefix_) else ''
+            AlternativeImage_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='AlternativeImage', pretty_print=pretty_print)
+        if self.Coords is not None:
+            namespaceprefix_ = self.Coords_nsprefix_ + ':' if (UseCapturedNS_ and self.Coords_nsprefix_) else ''
+            self.Coords.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Coords', pretty_print=pretty_print)
+        if self.Baseline is not None:
+            namespaceprefix_ = self.Baseline_nsprefix_ + ':' if (UseCapturedNS_ and self.Baseline_nsprefix_) else ''
+            self.Baseline.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Baseline', pretty_print=pretty_print)
+        for Word_ in self.Word:
+            namespaceprefix_ = self.Word_nsprefix_ + ':' if (UseCapturedNS_ and self.Word_nsprefix_) else ''
+            Word_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Word', pretty_print=pretty_print)
+        for TextEquiv_ in self.TextEquiv:
+            namespaceprefix_ = self.TextEquiv_nsprefix_ + ':' if (UseCapturedNS_ and self.TextEquiv_nsprefix_) else ''
+            TextEquiv_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextEquiv', pretty_print=pretty_print)
+        if self.TextStyle is not None:
+            namespaceprefix_ = self.TextStyle_nsprefix_ + ':' if (UseCapturedNS_ and self.TextStyle_nsprefix_) else ''
+            self.TextStyle.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextStyle', pretty_print=pretty_print)
+        if self.UserDefined is not None:
+            namespaceprefix_ = self.UserDefined_nsprefix_ + ':' if (UseCapturedNS_ and self.UserDefined_nsprefix_) else ''
+            self.UserDefined.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserDefined', pretty_print=pretty_print)
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='TextLineType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -3826,6 +4300,80 @@ class WordType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='WordType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('WordType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'WordType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='WordType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='WordType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='WordType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.language is not None and 'language' not in already_processed:
+            already_processed.add('language')
+            outfile.write(' language=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.language), input_name='language')), ))
+        if self.primaryScript is not None and 'primaryScript' not in already_processed:
+            already_processed.add('primaryScript')
+            outfile.write(' primaryScript=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.primaryScript), input_name='primaryScript')), ))
+        if self.secondaryScript is not None and 'secondaryScript' not in already_processed:
+            already_processed.add('secondaryScript')
+            outfile.write(' secondaryScript=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.secondaryScript), input_name='secondaryScript')), ))
+        if self.readingDirection is not None and 'readingDirection' not in already_processed:
+            already_processed.add('readingDirection')
+            outfile.write(' readingDirection=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.readingDirection), input_name='readingDirection')), ))
+        if self.production is not None and 'production' not in already_processed:
+            already_processed.add('production')
+            outfile.write(' production=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.production), input_name='production')), ))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='WordType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for AlternativeImage_ in self.AlternativeImage:
+            namespaceprefix_ = self.AlternativeImage_nsprefix_ + ':' if (UseCapturedNS_ and self.AlternativeImage_nsprefix_) else ''
+            AlternativeImage_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='AlternativeImage', pretty_print=pretty_print)
+        if self.Coords is not None:
+            namespaceprefix_ = self.Coords_nsprefix_ + ':' if (UseCapturedNS_ and self.Coords_nsprefix_) else ''
+            self.Coords.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Coords', pretty_print=pretty_print)
+        for Glyph_ in self.Glyph:
+            namespaceprefix_ = self.Glyph_nsprefix_ + ':' if (UseCapturedNS_ and self.Glyph_nsprefix_) else ''
+            Glyph_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Glyph', pretty_print=pretty_print)
+        for TextEquiv_ in self.TextEquiv:
+            namespaceprefix_ = self.TextEquiv_nsprefix_ + ':' if (UseCapturedNS_ and self.TextEquiv_nsprefix_) else ''
+            TextEquiv_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextEquiv', pretty_print=pretty_print)
+        if self.TextStyle is not None:
+            namespaceprefix_ = self.TextStyle_nsprefix_ + ':' if (UseCapturedNS_ and self.TextStyle_nsprefix_) else ''
+            self.TextStyle.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextStyle', pretty_print=pretty_print)
+        if self.UserDefined is not None:
+            namespaceprefix_ = self.UserDefined_nsprefix_ + ':' if (UseCapturedNS_ and self.UserDefined_nsprefix_) else ''
+            self.UserDefined.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserDefined', pretty_print=pretty_print)
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='WordType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -4205,6 +4753,77 @@ class GlyphType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GlyphType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('GlyphType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'GlyphType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GlyphType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='GlyphType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='GlyphType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.ligature is not None and 'ligature' not in already_processed:
+            already_processed.add('ligature')
+            outfile.write(' ligature="%s"' % self.gds_format_boolean(self.ligature, input_name='ligature'))
+        if self.symbol is not None and 'symbol' not in already_processed:
+            already_processed.add('symbol')
+            outfile.write(' symbol="%s"' % self.gds_format_boolean(self.symbol, input_name='symbol'))
+        if self.script is not None and 'script' not in already_processed:
+            already_processed.add('script')
+            outfile.write(' script=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.script), input_name='script')), ))
+        if self.production is not None and 'production' not in already_processed:
+            already_processed.add('production')
+            outfile.write(' production=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.production), input_name='production')), ))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GlyphType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for AlternativeImage_ in self.AlternativeImage:
+            namespaceprefix_ = self.AlternativeImage_nsprefix_ + ':' if (UseCapturedNS_ and self.AlternativeImage_nsprefix_) else ''
+            AlternativeImage_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='AlternativeImage', pretty_print=pretty_print)
+        if self.Coords is not None:
+            namespaceprefix_ = self.Coords_nsprefix_ + ':' if (UseCapturedNS_ and self.Coords_nsprefix_) else ''
+            self.Coords.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Coords', pretty_print=pretty_print)
+        if self.Graphemes is not None:
+            namespaceprefix_ = self.Graphemes_nsprefix_ + ':' if (UseCapturedNS_ and self.Graphemes_nsprefix_) else ''
+            self.Graphemes.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Graphemes', pretty_print=pretty_print)
+        for TextEquiv_ in self.TextEquiv:
+            namespaceprefix_ = self.TextEquiv_nsprefix_ + ':' if (UseCapturedNS_ and self.TextEquiv_nsprefix_) else ''
+            TextEquiv_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextEquiv', pretty_print=pretty_print)
+        if self.TextStyle is not None:
+            namespaceprefix_ = self.TextStyle_nsprefix_ + ':' if (UseCapturedNS_ and self.TextStyle_nsprefix_) else ''
+            self.TextStyle.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextStyle', pretty_print=pretty_print)
+        if self.UserDefined is not None:
+            namespaceprefix_ = self.UserDefined_nsprefix_ + ':' if (UseCapturedNS_ and self.UserDefined_nsprefix_) else ''
+            self.UserDefined.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserDefined', pretty_print=pretty_print)
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='GlyphType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -4512,6 +5131,58 @@ class TextEquivType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" xmlns:None="http://www.w3.org/2001/XMLSchema" ', name_='TextEquivType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('TextEquivType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'TextEquivType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='TextEquivType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='TextEquivType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='TextEquivType'):
+        if self.index is not None and 'index' not in already_processed:
+            already_processed.add('index')
+            outfile.write(' index="%s"' % self.gds_format_integer(self.index, input_name='index'))
+        if self.conf is not None and 'conf' not in already_processed:
+            already_processed.add('conf')
+            outfile.write(' conf="%s"' % self.gds_format_float(self.conf, input_name='conf'))
+        if self.dataType is not None and 'dataType' not in already_processed:
+            already_processed.add('dataType')
+            outfile.write(' dataType=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.dataType), input_name='dataType')), ))
+        if self.dataTypeDetails is not None and 'dataTypeDetails' not in already_processed:
+            already_processed.add('dataTypeDetails')
+            outfile.write(' dataTypeDetails=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.dataTypeDetails), input_name='dataTypeDetails')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" xmlns:None="http://www.w3.org/2001/XMLSchema" ', name_='TextEquivType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.PlainText is not None:
+            namespaceprefix_ = self.PlainText_nsprefix_ + ':' if (UseCapturedNS_ and self.PlainText_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sPlainText>%s</%sPlainText>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.PlainText), input_name='PlainText')), namespaceprefix_ , eol_))
+        if self.Unicode is not None:
+            namespaceprefix_ = self.Unicode_nsprefix_ + ':' if (UseCapturedNS_ and self.Unicode_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sUnicode>%s</%sUnicode>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Unicode), input_name='Unicode')), namespaceprefix_ , eol_))
     def to_etree(self, parent_element=None, name_='TextEquivType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -4648,6 +5319,39 @@ class GridType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GridType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('GridType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'GridType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GridType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='GridType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='GridType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GridType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for GridPoints_ in self.GridPoints:
+            namespaceprefix_ = self.GridPoints_nsprefix_ + ':' if (UseCapturedNS_ and self.GridPoints_nsprefix_) else ''
+            GridPoints_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='GridPoints', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='GridType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -4751,6 +5455,37 @@ class GridPointsType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GridPointsType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('GridPointsType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'GridPointsType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GridPointsType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='GridPointsType', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='GridPointsType'):
+        if self.index is not None and 'index' not in already_processed:
+            already_processed.add('index')
+            outfile.write(' index="%s"' % self.gds_format_integer(self.index, input_name='index'))
+        if self.points is not None and 'points' not in already_processed:
+            already_processed.add('points')
+            outfile.write(' points=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.points), input_name='points')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GridPointsType', fromsubclass_=False, pretty_print=True):
+        pass
     def to_etree(self, parent_element=None, name_='GridPointsType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -4847,6 +5582,39 @@ class PrintSpaceType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='PrintSpaceType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PrintSpaceType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'PrintSpaceType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PrintSpaceType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PrintSpaceType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PrintSpaceType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='PrintSpaceType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Coords is not None:
+            namespaceprefix_ = self.Coords_nsprefix_ + ':' if (UseCapturedNS_ and self.Coords_nsprefix_) else ''
+            self.Coords.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Coords', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='PrintSpaceType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -4966,6 +5734,44 @@ class ReadingOrderType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='ReadingOrderType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('ReadingOrderType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'ReadingOrderType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='ReadingOrderType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='ReadingOrderType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='ReadingOrderType'):
+        if self.conf is not None and 'conf' not in already_processed:
+            already_processed.add('conf')
+            outfile.write(' conf="%s"' % self.gds_format_float(self.conf, input_name='conf'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='ReadingOrderType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.OrderedGroup is not None:
+            namespaceprefix_ = self.OrderedGroup_nsprefix_ + ':' if (UseCapturedNS_ and self.OrderedGroup_nsprefix_) else ''
+            self.OrderedGroup.export(outfile, level, namespaceprefix_, namespacedef_='', name_='OrderedGroup', pretty_print=pretty_print)
+        if self.UnorderedGroup is not None:
+            namespaceprefix_ = self.UnorderedGroup_nsprefix_ + ':' if (UseCapturedNS_ and self.UnorderedGroup_nsprefix_) else ''
+            self.UnorderedGroup.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UnorderedGroup', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='ReadingOrderType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -5074,6 +5880,37 @@ class RegionRefIndexedType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RegionRefIndexedType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RegionRefIndexedType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'RegionRefIndexedType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RegionRefIndexedType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RegionRefIndexedType', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RegionRefIndexedType'):
+        if self.index is not None and 'index' not in already_processed:
+            already_processed.add('index')
+            outfile.write(' index="%s"' % self.gds_format_integer(self.index, input_name='index'))
+        if self.regionRef is not None and 'regionRef' not in already_processed:
+            already_processed.add('regionRef')
+            outfile.write(' regionRef=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.regionRef), input_name='regionRef')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RegionRefIndexedType', fromsubclass_=False, pretty_print=True):
+        pass
     def to_etree(self, parent_element=None, name_='RegionRefIndexedType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -5308,6 +6145,74 @@ class OrderedGroupIndexedType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='OrderedGroupIndexedType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('OrderedGroupIndexedType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'OrderedGroupIndexedType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='OrderedGroupIndexedType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='OrderedGroupIndexedType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='OrderedGroupIndexedType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.regionRef is not None and 'regionRef' not in already_processed:
+            already_processed.add('regionRef')
+            outfile.write(' regionRef=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.regionRef), input_name='regionRef')), ))
+        if self.index is not None and 'index' not in already_processed:
+            already_processed.add('index')
+            outfile.write(' index="%s"' % self.gds_format_integer(self.index, input_name='index'))
+        if self.caption is not None and 'caption' not in already_processed:
+            already_processed.add('caption')
+            outfile.write(' caption=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.caption), input_name='caption')), ))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.continuation is not None and 'continuation' not in already_processed:
+            already_processed.add('continuation')
+            outfile.write(' continuation="%s"' % self.gds_format_boolean(self.continuation, input_name='continuation'))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='OrderedGroupIndexedType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.UserDefined is not None:
+            namespaceprefix_ = self.UserDefined_nsprefix_ + ':' if (UseCapturedNS_ and self.UserDefined_nsprefix_) else ''
+            self.UserDefined.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserDefined', pretty_print=pretty_print)
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
+        for RegionRefIndexed_ in self.RegionRefIndexed:
+            namespaceprefix_ = self.RegionRefIndexed_nsprefix_ + ':' if (UseCapturedNS_ and self.RegionRefIndexed_nsprefix_) else ''
+            RegionRefIndexed_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='RegionRefIndexed', pretty_print=pretty_print)
+        for OrderedGroupIndexed_ in self.OrderedGroupIndexed:
+            namespaceprefix_ = self.OrderedGroupIndexed_nsprefix_ + ':' if (UseCapturedNS_ and self.OrderedGroupIndexed_nsprefix_) else ''
+            OrderedGroupIndexed_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='OrderedGroupIndexed', pretty_print=pretty_print)
+        for UnorderedGroupIndexed_ in self.UnorderedGroupIndexed:
+            namespaceprefix_ = self.UnorderedGroupIndexed_nsprefix_ + ':' if (UseCapturedNS_ and self.UnorderedGroupIndexed_nsprefix_) else ''
+            UnorderedGroupIndexed_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UnorderedGroupIndexed', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='OrderedGroupIndexedType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -5712,6 +6617,74 @@ class UnorderedGroupIndexedType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='UnorderedGroupIndexedType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('UnorderedGroupIndexedType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'UnorderedGroupIndexedType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='UnorderedGroupIndexedType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='UnorderedGroupIndexedType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='UnorderedGroupIndexedType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.regionRef is not None and 'regionRef' not in already_processed:
+            already_processed.add('regionRef')
+            outfile.write(' regionRef=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.regionRef), input_name='regionRef')), ))
+        if self.index is not None and 'index' not in already_processed:
+            already_processed.add('index')
+            outfile.write(' index="%s"' % self.gds_format_integer(self.index, input_name='index'))
+        if self.caption is not None and 'caption' not in already_processed:
+            already_processed.add('caption')
+            outfile.write(' caption=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.caption), input_name='caption')), ))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.continuation is not None and 'continuation' not in already_processed:
+            already_processed.add('continuation')
+            outfile.write(' continuation="%s"' % self.gds_format_boolean(self.continuation, input_name='continuation'))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='UnorderedGroupIndexedType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.UserDefined is not None:
+            namespaceprefix_ = self.UserDefined_nsprefix_ + ':' if (UseCapturedNS_ and self.UserDefined_nsprefix_) else ''
+            self.UserDefined.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserDefined', pretty_print=pretty_print)
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
+        for RegionRef_ in self.RegionRef:
+            namespaceprefix_ = self.RegionRef_nsprefix_ + ':' if (UseCapturedNS_ and self.RegionRef_nsprefix_) else ''
+            RegionRef_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='RegionRef', pretty_print=pretty_print)
+        for OrderedGroup_ in self.OrderedGroup:
+            namespaceprefix_ = self.OrderedGroup_nsprefix_ + ':' if (UseCapturedNS_ and self.OrderedGroup_nsprefix_) else ''
+            OrderedGroup_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='OrderedGroup', pretty_print=pretty_print)
+        for UnorderedGroup_ in self.UnorderedGroup:
+            namespaceprefix_ = self.UnorderedGroup_nsprefix_ + ':' if (UseCapturedNS_ and self.UnorderedGroup_nsprefix_) else ''
+            UnorderedGroup_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UnorderedGroup', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='UnorderedGroupIndexedType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -5884,6 +6857,34 @@ class RegionRefType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RegionRefType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RegionRefType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'RegionRefType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RegionRefType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RegionRefType', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RegionRefType'):
+        if self.regionRef is not None and 'regionRef' not in already_processed:
+            already_processed.add('regionRef')
+            outfile.write(' regionRef=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.regionRef), input_name='regionRef')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RegionRefType', fromsubclass_=False, pretty_print=True):
+        pass
     def to_etree(self, parent_element=None, name_='RegionRefType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -6103,6 +7104,71 @@ class OrderedGroupType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='OrderedGroupType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('OrderedGroupType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'OrderedGroupType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='OrderedGroupType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='OrderedGroupType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='OrderedGroupType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.regionRef is not None and 'regionRef' not in already_processed:
+            already_processed.add('regionRef')
+            outfile.write(' regionRef=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.regionRef), input_name='regionRef')), ))
+        if self.caption is not None and 'caption' not in already_processed:
+            already_processed.add('caption')
+            outfile.write(' caption=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.caption), input_name='caption')), ))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.continuation is not None and 'continuation' not in already_processed:
+            already_processed.add('continuation')
+            outfile.write(' continuation="%s"' % self.gds_format_boolean(self.continuation, input_name='continuation'))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='OrderedGroupType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.UserDefined is not None:
+            namespaceprefix_ = self.UserDefined_nsprefix_ + ':' if (UseCapturedNS_ and self.UserDefined_nsprefix_) else ''
+            self.UserDefined.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserDefined', pretty_print=pretty_print)
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
+        for RegionRefIndexed_ in self.RegionRefIndexed:
+            namespaceprefix_ = self.RegionRefIndexed_nsprefix_ + ':' if (UseCapturedNS_ and self.RegionRefIndexed_nsprefix_) else ''
+            RegionRefIndexed_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='RegionRefIndexed', pretty_print=pretty_print)
+        for OrderedGroupIndexed_ in self.OrderedGroupIndexed:
+            namespaceprefix_ = self.OrderedGroupIndexed_nsprefix_ + ':' if (UseCapturedNS_ and self.OrderedGroupIndexed_nsprefix_) else ''
+            OrderedGroupIndexed_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='OrderedGroupIndexed', pretty_print=pretty_print)
+        for UnorderedGroupIndexed_ in self.UnorderedGroupIndexed:
+            namespaceprefix_ = self.UnorderedGroupIndexed_nsprefix_ + ':' if (UseCapturedNS_ and self.UnorderedGroupIndexed_nsprefix_) else ''
+            UnorderedGroupIndexed_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UnorderedGroupIndexed', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='OrderedGroupType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -6492,6 +7558,71 @@ class UnorderedGroupType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='UnorderedGroupType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('UnorderedGroupType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'UnorderedGroupType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='UnorderedGroupType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='UnorderedGroupType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='UnorderedGroupType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.regionRef is not None and 'regionRef' not in already_processed:
+            already_processed.add('regionRef')
+            outfile.write(' regionRef=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.regionRef), input_name='regionRef')), ))
+        if self.caption is not None and 'caption' not in already_processed:
+            already_processed.add('caption')
+            outfile.write(' caption=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.caption), input_name='caption')), ))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.continuation is not None and 'continuation' not in already_processed:
+            already_processed.add('continuation')
+            outfile.write(' continuation="%s"' % self.gds_format_boolean(self.continuation, input_name='continuation'))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='UnorderedGroupType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.UserDefined is not None:
+            namespaceprefix_ = self.UserDefined_nsprefix_ + ':' if (UseCapturedNS_ and self.UserDefined_nsprefix_) else ''
+            self.UserDefined.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserDefined', pretty_print=pretty_print)
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
+        for RegionRef_ in self.RegionRef:
+            namespaceprefix_ = self.RegionRef_nsprefix_ + ':' if (UseCapturedNS_ and self.RegionRef_nsprefix_) else ''
+            RegionRef_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='RegionRef', pretty_print=pretty_print)
+        for OrderedGroup_ in self.OrderedGroup:
+            namespaceprefix_ = self.OrderedGroup_nsprefix_ + ':' if (UseCapturedNS_ and self.OrderedGroup_nsprefix_) else ''
+            OrderedGroup_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='OrderedGroup', pretty_print=pretty_print)
+        for UnorderedGroup_ in self.UnorderedGroup:
+            namespaceprefix_ = self.UnorderedGroup_nsprefix_ + ':' if (UseCapturedNS_ and self.UnorderedGroup_nsprefix_) else ''
+            UnorderedGroup_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UnorderedGroup', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='UnorderedGroupType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -6660,6 +7791,39 @@ class BorderType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='BorderType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('BorderType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'BorderType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='BorderType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='BorderType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='BorderType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='BorderType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Coords is not None:
+            namespaceprefix_ = self.Coords_nsprefix_ + ':' if (UseCapturedNS_ and self.Coords_nsprefix_) else ''
+            self.Coords.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Coords', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='BorderType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -6770,6 +7934,39 @@ class LayersType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='LayersType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('LayersType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'LayersType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='LayersType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='LayersType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='LayersType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='LayersType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for Layer_ in self.Layer:
+            namespaceprefix_ = self.Layer_nsprefix_ + ':' if (UseCapturedNS_ and self.Layer_nsprefix_) else ''
+            Layer_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Layer', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='LayersType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -6883,6 +8080,47 @@ class LayerType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='LayerType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('LayerType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'LayerType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='LayerType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='LayerType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='LayerType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.zIndex is not None and 'zIndex' not in already_processed:
+            already_processed.add('zIndex')
+            outfile.write(' zIndex="%s"' % self.gds_format_integer(self.zIndex, input_name='zIndex'))
+        if self.caption is not None and 'caption' not in already_processed:
+            already_processed.add('caption')
+            outfile.write(' caption=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.caption), input_name='caption')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='LayerType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for RegionRef_ in self.RegionRef:
+            namespaceprefix_ = self.RegionRef_nsprefix_ + ':' if (UseCapturedNS_ and self.RegionRef_nsprefix_) else ''
+            RegionRef_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='RegionRef', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='LayerType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -7017,6 +8255,37 @@ class BaselineType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='BaselineType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('BaselineType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'BaselineType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='BaselineType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='BaselineType', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='BaselineType'):
+        if self.points is not None and 'points' not in already_processed:
+            already_processed.add('points')
+            outfile.write(' points=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.points), input_name='points')), ))
+        if self.conf is not None and 'conf' not in already_processed:
+            already_processed.add('conf')
+            outfile.write(' conf="%s"' % self.gds_format_float(self.conf, input_name='conf'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='BaselineType', fromsubclass_=False, pretty_print=True):
+        pass
     def to_etree(self, parent_element=None, name_='BaselineType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -7120,6 +8389,39 @@ class RelationsType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RelationsType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RelationsType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'RelationsType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RelationsType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RelationsType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RelationsType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RelationsType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for Relation_ in self.Relation:
+            namespaceprefix_ = self.Relation_nsprefix_ + ':' if (UseCapturedNS_ and self.Relation_nsprefix_) else ''
+            Relation_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Relation', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='RelationsType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -7271,6 +8573,56 @@ class RelationType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RelationType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RelationType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'RelationType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RelationType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RelationType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RelationType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RelationType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
+        if self.SourceRegionRef is not None:
+            namespaceprefix_ = self.SourceRegionRef_nsprefix_ + ':' if (UseCapturedNS_ and self.SourceRegionRef_nsprefix_) else ''
+            self.SourceRegionRef.export(outfile, level, namespaceprefix_, namespacedef_='', name_='SourceRegionRef', pretty_print=pretty_print)
+        if self.TargetRegionRef is not None:
+            namespaceprefix_ = self.TargetRegionRef_nsprefix_ + ':' if (UseCapturedNS_ and self.TargetRegionRef_nsprefix_) else ''
+            self.TargetRegionRef.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TargetRegionRef', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='RelationType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -7573,6 +8925,91 @@ class TextStyleType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='TextStyleType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('TextStyleType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'TextStyleType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='TextStyleType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='TextStyleType', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='TextStyleType'):
+        if self.fontFamily is not None and 'fontFamily' not in already_processed:
+            already_processed.add('fontFamily')
+            outfile.write(' fontFamily=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.fontFamily), input_name='fontFamily')), ))
+        if self.serif is not None and 'serif' not in already_processed:
+            already_processed.add('serif')
+            outfile.write(' serif="%s"' % self.gds_format_boolean(self.serif, input_name='serif'))
+        if self.monospace is not None and 'monospace' not in already_processed:
+            already_processed.add('monospace')
+            outfile.write(' monospace="%s"' % self.gds_format_boolean(self.monospace, input_name='monospace'))
+        if self.fontSize is not None and 'fontSize' not in already_processed:
+            already_processed.add('fontSize')
+            outfile.write(' fontSize="%s"' % self.gds_format_float(self.fontSize, input_name='fontSize'))
+        if self.xHeight is not None and 'xHeight' not in already_processed:
+            already_processed.add('xHeight')
+            outfile.write(' xHeight="%s"' % self.gds_format_integer(self.xHeight, input_name='xHeight'))
+        if self.kerning is not None and 'kerning' not in already_processed:
+            already_processed.add('kerning')
+            outfile.write(' kerning="%s"' % self.gds_format_integer(self.kerning, input_name='kerning'))
+        if self.textColour is not None and 'textColour' not in already_processed:
+            already_processed.add('textColour')
+            outfile.write(' textColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.textColour), input_name='textColour')), ))
+        if self.textColourRgb is not None and 'textColourRgb' not in already_processed:
+            already_processed.add('textColourRgb')
+            outfile.write(' textColourRgb="%s"' % self.gds_format_integer(self.textColourRgb, input_name='textColourRgb'))
+        if self.bgColour is not None and 'bgColour' not in already_processed:
+            already_processed.add('bgColour')
+            outfile.write(' bgColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bgColour), input_name='bgColour')), ))
+        if self.bgColourRgb is not None and 'bgColourRgb' not in already_processed:
+            already_processed.add('bgColourRgb')
+            outfile.write(' bgColourRgb="%s"' % self.gds_format_integer(self.bgColourRgb, input_name='bgColourRgb'))
+        if self.reverseVideo is not None and 'reverseVideo' not in already_processed:
+            already_processed.add('reverseVideo')
+            outfile.write(' reverseVideo="%s"' % self.gds_format_boolean(self.reverseVideo, input_name='reverseVideo'))
+        if self.bold is not None and 'bold' not in already_processed:
+            already_processed.add('bold')
+            outfile.write(' bold="%s"' % self.gds_format_boolean(self.bold, input_name='bold'))
+        if self.italic is not None and 'italic' not in already_processed:
+            already_processed.add('italic')
+            outfile.write(' italic="%s"' % self.gds_format_boolean(self.italic, input_name='italic'))
+        if self.underlined is not None and 'underlined' not in already_processed:
+            already_processed.add('underlined')
+            outfile.write(' underlined="%s"' % self.gds_format_boolean(self.underlined, input_name='underlined'))
+        if self.underlineStyle is not None and 'underlineStyle' not in already_processed:
+            already_processed.add('underlineStyle')
+            outfile.write(' underlineStyle=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.underlineStyle), input_name='underlineStyle')), ))
+        if self.subscript is not None and 'subscript' not in already_processed:
+            already_processed.add('subscript')
+            outfile.write(' subscript="%s"' % self.gds_format_boolean(self.subscript, input_name='subscript'))
+        if self.superscript is not None and 'superscript' not in already_processed:
+            already_processed.add('superscript')
+            outfile.write(' superscript="%s"' % self.gds_format_boolean(self.superscript, input_name='superscript'))
+        if self.strikethrough is not None and 'strikethrough' not in already_processed:
+            already_processed.add('strikethrough')
+            outfile.write(' strikethrough="%s"' % self.gds_format_boolean(self.strikethrough, input_name='strikethrough'))
+        if self.smallCaps is not None and 'smallCaps' not in already_processed:
+            already_processed.add('smallCaps')
+            outfile.write(' smallCaps="%s"' % self.gds_format_boolean(self.smallCaps, input_name='smallCaps'))
+        if self.letterSpaced is not None and 'letterSpaced' not in already_processed:
+            already_processed.add('letterSpaced')
+            outfile.write(' letterSpaced="%s"' % self.gds_format_boolean(self.letterSpaced, input_name='letterSpaced'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='TextStyleType', fromsubclass_=False, pretty_print=True):
+        pass
     def to_etree(self, parent_element=None, name_='TextStyleType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -8150,6 +9587,112 @@ class RegionType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'RegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RegionType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+        if self.continuation is not None and 'continuation' not in already_processed:
+            already_processed.add('continuation')
+            outfile.write(' continuation="%s"' % self.gds_format_boolean(self.continuation, input_name='continuation'))
+        if self.extensiontype_ is not None and 'xsi:type' not in already_processed:
+            already_processed.add('xsi:type')
+            outfile.write(' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"')
+            if ":" not in self.extensiontype_:
+                imported_ns_type_prefix_ = GenerateDSNamespaceTypePrefixes_.get(self.extensiontype_, '')
+                outfile.write(' xsi:type="%s%s"' % (imported_ns_type_prefix_, self.extensiontype_))
+            else:
+                outfile.write(' xsi:type="%s"' % self.extensiontype_)
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RegionType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for AlternativeImage_ in self.AlternativeImage:
+            namespaceprefix_ = self.AlternativeImage_nsprefix_ + ':' if (UseCapturedNS_ and self.AlternativeImage_nsprefix_) else ''
+            AlternativeImage_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='AlternativeImage', pretty_print=pretty_print)
+        if self.Coords is not None:
+            namespaceprefix_ = self.Coords_nsprefix_ + ':' if (UseCapturedNS_ and self.Coords_nsprefix_) else ''
+            self.Coords.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Coords', pretty_print=pretty_print)
+        if self.UserDefined is not None:
+            namespaceprefix_ = self.UserDefined_nsprefix_ + ':' if (UseCapturedNS_ and self.UserDefined_nsprefix_) else ''
+            self.UserDefined.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserDefined', pretty_print=pretty_print)
+        for Labels_ in self.Labels:
+            namespaceprefix_ = self.Labels_nsprefix_ + ':' if (UseCapturedNS_ and self.Labels_nsprefix_) else ''
+            Labels_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Labels', pretty_print=pretty_print)
+        if self.Roles is not None:
+            namespaceprefix_ = self.Roles_nsprefix_ + ':' if (UseCapturedNS_ and self.Roles_nsprefix_) else ''
+            self.Roles.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Roles', pretty_print=pretty_print)
+        for TextRegion_ in self.TextRegion:
+            namespaceprefix_ = self.TextRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.TextRegion_nsprefix_) else ''
+            TextRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextRegion', pretty_print=pretty_print)
+        for ImageRegion_ in self.ImageRegion:
+            namespaceprefix_ = self.ImageRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.ImageRegion_nsprefix_) else ''
+            ImageRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ImageRegion', pretty_print=pretty_print)
+        for LineDrawingRegion_ in self.LineDrawingRegion:
+            namespaceprefix_ = self.LineDrawingRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.LineDrawingRegion_nsprefix_) else ''
+            LineDrawingRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='LineDrawingRegion', pretty_print=pretty_print)
+        for GraphicRegion_ in self.GraphicRegion:
+            namespaceprefix_ = self.GraphicRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.GraphicRegion_nsprefix_) else ''
+            GraphicRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='GraphicRegion', pretty_print=pretty_print)
+        for TableRegion_ in self.TableRegion:
+            namespaceprefix_ = self.TableRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.TableRegion_nsprefix_) else ''
+            TableRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TableRegion', pretty_print=pretty_print)
+        for ChartRegion_ in self.ChartRegion:
+            namespaceprefix_ = self.ChartRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.ChartRegion_nsprefix_) else ''
+            ChartRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ChartRegion', pretty_print=pretty_print)
+        for SeparatorRegion_ in self.SeparatorRegion:
+            namespaceprefix_ = self.SeparatorRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.SeparatorRegion_nsprefix_) else ''
+            SeparatorRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='SeparatorRegion', pretty_print=pretty_print)
+        for MathsRegion_ in self.MathsRegion:
+            namespaceprefix_ = self.MathsRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.MathsRegion_nsprefix_) else ''
+            MathsRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='MathsRegion', pretty_print=pretty_print)
+        for ChemRegion_ in self.ChemRegion:
+            namespaceprefix_ = self.ChemRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.ChemRegion_nsprefix_) else ''
+            ChemRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ChemRegion', pretty_print=pretty_print)
+        for MusicRegion_ in self.MusicRegion:
+            namespaceprefix_ = self.MusicRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.MusicRegion_nsprefix_) else ''
+            MusicRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='MusicRegion', pretty_print=pretty_print)
+        for AdvertRegion_ in self.AdvertRegion:
+            namespaceprefix_ = self.AdvertRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.AdvertRegion_nsprefix_) else ''
+            AdvertRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='AdvertRegion', pretty_print=pretty_print)
+        for NoiseRegion_ in self.NoiseRegion:
+            namespaceprefix_ = self.NoiseRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.NoiseRegion_nsprefix_) else ''
+            NoiseRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='NoiseRegion', pretty_print=pretty_print)
+        for UnknownRegion_ in self.UnknownRegion:
+            namespaceprefix_ = self.UnknownRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.UnknownRegion_nsprefix_) else ''
+            UnknownRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UnknownRegion', pretty_print=pretty_print)
+        for CustomRegion_ in self.CustomRegion:
+            namespaceprefix_ = self.CustomRegion_nsprefix_ + ':' if (UseCapturedNS_ and self.CustomRegion_nsprefix_) else ''
+            CustomRegion_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CustomRegion', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='RegionType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -8471,6 +10014,40 @@ class AlternativeImageType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='AlternativeImageType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('AlternativeImageType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'AlternativeImageType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='AlternativeImageType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='AlternativeImageType', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='AlternativeImageType'):
+        if self.filename is not None and 'filename' not in already_processed:
+            already_processed.add('filename')
+            outfile.write(' filename=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.filename), input_name='filename')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+        if self.conf is not None and 'conf' not in already_processed:
+            already_processed.add('conf')
+            outfile.write(' conf="%s"' % self.gds_format_float(self.conf, input_name='conf'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='AlternativeImageType', fromsubclass_=False, pretty_print=True):
+        pass
     def to_etree(self, parent_element=None, name_='AlternativeImageType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -8612,6 +10189,45 @@ class GraphemesType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GraphemesType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('GraphemesType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'GraphemesType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GraphemesType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='GraphemesType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='GraphemesType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GraphemesType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for Grapheme_ in self.Grapheme:
+            namespaceprefix_ = self.Grapheme_nsprefix_ + ':' if (UseCapturedNS_ and self.Grapheme_nsprefix_) else ''
+            Grapheme_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Grapheme', pretty_print=pretty_print)
+        for NonPrintingChar_ in self.NonPrintingChar:
+            namespaceprefix_ = self.NonPrintingChar_nsprefix_ + ':' if (UseCapturedNS_ and self.NonPrintingChar_nsprefix_) else ''
+            NonPrintingChar_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='NonPrintingChar', pretty_print=pretty_print)
+        for GraphemeGroup_ in self.GraphemeGroup:
+            namespaceprefix_ = self.GraphemeGroup_nsprefix_ + ':' if (UseCapturedNS_ and self.GraphemeGroup_nsprefix_) else ''
+            GraphemeGroup_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='GraphemeGroup', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='GraphemesType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -8769,6 +10385,64 @@ class GraphemeBaseType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GraphemeBaseType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('GraphemeBaseType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'GraphemeBaseType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GraphemeBaseType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='GraphemeBaseType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='GraphemeBaseType'):
+        if self.id is not None and 'id' not in already_processed:
+            already_processed.add('id')
+            outfile.write(' id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.id), input_name='id')), ))
+        if self.index is not None and 'index' not in already_processed:
+            already_processed.add('index')
+            outfile.write(' index="%s"' % self.gds_format_integer(self.index, input_name='index'))
+        if self.ligature is not None and 'ligature' not in already_processed:
+            already_processed.add('ligature')
+            outfile.write(' ligature="%s"' % self.gds_format_boolean(self.ligature, input_name='ligature'))
+        if self.charType is not None and 'charType' not in already_processed:
+            already_processed.add('charType')
+            outfile.write(' charType=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.charType), input_name='charType')), ))
+        if self.custom is not None and 'custom' not in already_processed:
+            already_processed.add('custom')
+            outfile.write(' custom=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.custom), input_name='custom')), ))
+        if self.comments is not None and 'comments' not in already_processed:
+            already_processed.add('comments')
+            outfile.write(' comments=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.comments), input_name='comments')), ))
+        if self.extensiontype_ is not None and 'xsi:type' not in already_processed:
+            already_processed.add('xsi:type')
+            outfile.write(' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"')
+            if ":" not in self.extensiontype_:
+                imported_ns_type_prefix_ = GenerateDSNamespaceTypePrefixes_.get(self.extensiontype_, '')
+                outfile.write(' xsi:type="%s%s"' % (imported_ns_type_prefix_, self.extensiontype_))
+            else:
+                outfile.write(' xsi:type="%s"' % self.extensiontype_)
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GraphemeBaseType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for TextEquiv_ in self.TextEquiv:
+            namespaceprefix_ = self.TextEquiv_nsprefix_ + ':' if (UseCapturedNS_ and self.TextEquiv_nsprefix_) else ''
+            TextEquiv_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextEquiv', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='GraphemeBaseType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -8903,6 +10577,40 @@ class GraphemeType(GraphemeBaseType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GraphemeType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('GraphemeType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'GraphemeType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GraphemeType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='GraphemeType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='GraphemeType'):
+        super(GraphemeType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GraphemeType')
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GraphemeType', fromsubclass_=False, pretty_print=True):
+        super(GraphemeType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Coords is not None:
+            namespaceprefix_ = self.Coords_nsprefix_ + ':' if (UseCapturedNS_ and self.Coords_nsprefix_) else ''
+            self.Coords.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Coords', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='GraphemeType', mapping_=None, nsmap_=None):
         element = super(GraphemeType, self).to_etree(parent_element, name_, mapping_)
         if self.Coords is not None:
@@ -8983,6 +10691,33 @@ class NonPrintingCharType(GraphemeBaseType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='NonPrintingCharType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('NonPrintingCharType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'NonPrintingCharType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='NonPrintingCharType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='NonPrintingCharType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='NonPrintingCharType'):
+        super(NonPrintingCharType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='NonPrintingCharType')
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='NonPrintingCharType', fromsubclass_=False, pretty_print=True):
+        super(NonPrintingCharType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='NonPrintingCharType', mapping_=None, nsmap_=None):
         element = super(NonPrintingCharType, self).to_etree(parent_element, name_, mapping_)
         if mapping_ is not None:
@@ -9086,6 +10821,43 @@ class GraphemeGroupType(GraphemeBaseType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GraphemeGroupType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('GraphemeGroupType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'GraphemeGroupType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GraphemeGroupType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='GraphemeGroupType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='GraphemeGroupType'):
+        super(GraphemeGroupType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GraphemeGroupType')
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='GraphemeGroupType', fromsubclass_=False, pretty_print=True):
+        super(GraphemeGroupType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for Grapheme_ in self.Grapheme:
+            namespaceprefix_ = self.Grapheme_nsprefix_ + ':' if (UseCapturedNS_ and self.Grapheme_nsprefix_) else ''
+            Grapheme_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Grapheme', pretty_print=pretty_print)
+        for NonPrintingChar_ in self.NonPrintingChar:
+            namespaceprefix_ = self.NonPrintingChar_nsprefix_ + ':' if (UseCapturedNS_ and self.NonPrintingChar_nsprefix_) else ''
+            NonPrintingChar_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='NonPrintingChar', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='GraphemeGroupType', mapping_=None, nsmap_=None):
         element = super(GraphemeGroupType, self).to_etree(parent_element, name_, mapping_)
         for Grapheme_ in self.Grapheme:
@@ -9184,6 +10956,39 @@ class UserDefinedType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='UserDefinedType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('UserDefinedType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'UserDefinedType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='UserDefinedType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='UserDefinedType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='UserDefinedType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='UserDefinedType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for UserAttribute_ in self.UserAttribute:
+            namespaceprefix_ = self.UserAttribute_nsprefix_ + ':' if (UseCapturedNS_ and self.UserAttribute_nsprefix_) else ''
+            UserAttribute_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='UserAttribute', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='UserDefinedType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -9289,6 +11094,43 @@ class UserAttributeType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='UserAttributeType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('UserAttributeType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'UserAttributeType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='UserAttributeType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='UserAttributeType', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='UserAttributeType'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.description is not None and 'description' not in already_processed:
+            already_processed.add('description')
+            outfile.write(' description=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.description), input_name='description')), ))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            outfile.write(' value=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.value), input_name='value')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='UserAttributeType', fromsubclass_=False, pretty_print=True):
+        pass
     def to_etree(self, parent_element=None, name_='UserAttributeType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -9421,6 +11263,46 @@ class TableCellRoleType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='TableCellRoleType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('TableCellRoleType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'TableCellRoleType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='TableCellRoleType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='TableCellRoleType', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='TableCellRoleType'):
+        if self.rowIndex is not None and 'rowIndex' not in already_processed:
+            already_processed.add('rowIndex')
+            outfile.write(' rowIndex="%s"' % self.gds_format_integer(self.rowIndex, input_name='rowIndex'))
+        if self.columnIndex is not None and 'columnIndex' not in already_processed:
+            already_processed.add('columnIndex')
+            outfile.write(' columnIndex="%s"' % self.gds_format_integer(self.columnIndex, input_name='columnIndex'))
+        if self.rowSpan is not None and 'rowSpan' not in already_processed:
+            already_processed.add('rowSpan')
+            outfile.write(' rowSpan="%s"' % self.gds_format_integer(self.rowSpan, input_name='rowSpan'))
+        if self.colSpan is not None and 'colSpan' not in already_processed:
+            already_processed.add('colSpan')
+            outfile.write(' colSpan="%s"' % self.gds_format_integer(self.colSpan, input_name='colSpan'))
+        if self.header is not None and 'header' not in already_processed:
+            already_processed.add('header')
+            outfile.write(' header="%s"' % self.gds_format_boolean(self.header, input_name='header'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='TableCellRoleType', fromsubclass_=False, pretty_print=True):
+        pass
     def to_etree(self, parent_element=None, name_='TableCellRoleType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -9532,6 +11414,39 @@ class RolesType(GeneratedsSuper):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RolesType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RolesType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'RolesType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RolesType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RolesType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RolesType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"', name_='RolesType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.TableCellRole is not None:
+            namespaceprefix_ = self.TableCellRole_nsprefix_ + ':' if (UseCapturedNS_ and self.TableCellRole_nsprefix_) else ''
+            self.TableCellRole.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TableCellRole', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='RolesType', mapping_=None, nsmap_=None):
         if parent_element is None:
             element = etree_.Element('{http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15}' + name_, nsmap=nsmap_)
@@ -9622,6 +11537,36 @@ class CustomRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CustomRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('CustomRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'CustomRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='CustomRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='CustomRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CustomRegionType'):
+        super(CustomRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='CustomRegionType')
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CustomRegionType', fromsubclass_=False, pretty_print=True):
+        super(CustomRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='CustomRegionType', mapping_=None, nsmap_=None):
         element = super(CustomRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.type_ is not None:
@@ -9698,6 +11643,33 @@ class UnknownRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='UnknownRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('UnknownRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'UnknownRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='UnknownRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='UnknownRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='UnknownRegionType'):
+        super(UnknownRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='UnknownRegionType')
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='UnknownRegionType', fromsubclass_=False, pretty_print=True):
+        super(UnknownRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='UnknownRegionType', mapping_=None, nsmap_=None):
         element = super(UnknownRegionType, self).to_etree(parent_element, name_, mapping_)
         if mapping_ is not None:
@@ -9770,6 +11742,33 @@ class NoiseRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='NoiseRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('NoiseRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'NoiseRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='NoiseRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='NoiseRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='NoiseRegionType'):
+        super(NoiseRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='NoiseRegionType')
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='NoiseRegionType', fromsubclass_=False, pretty_print=True):
+        super(NoiseRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='NoiseRegionType', mapping_=None, nsmap_=None):
         element = super(NoiseRegionType, self).to_etree(parent_element, name_, mapping_)
         if mapping_ is not None:
@@ -9873,6 +11872,39 @@ class AdvertRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='AdvertRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('AdvertRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'AdvertRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='AdvertRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='AdvertRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='AdvertRegionType'):
+        super(AdvertRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='AdvertRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.bgColour is not None and 'bgColour' not in already_processed:
+            already_processed.add('bgColour')
+            outfile.write(' bgColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bgColour), input_name='bgColour')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='AdvertRegionType', fromsubclass_=False, pretty_print=True):
+        super(AdvertRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='AdvertRegionType', mapping_=None, nsmap_=None):
         element = super(AdvertRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -10001,6 +12033,39 @@ class MusicRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='MusicRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('MusicRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'MusicRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='MusicRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='MusicRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='MusicRegionType'):
+        super(MusicRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='MusicRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.bgColour is not None and 'bgColour' not in already_processed:
+            already_processed.add('bgColour')
+            outfile.write(' bgColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bgColour), input_name='bgColour')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='MusicRegionType', fromsubclass_=False, pretty_print=True):
+        super(MusicRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='MusicRegionType', mapping_=None, nsmap_=None):
         element = super(MusicRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -10109,6 +12174,36 @@ class MapRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='MapRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('MapRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'MapRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='MapRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='MapRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='MapRegionType'):
+        super(MapRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='MapRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='MapRegionType', fromsubclass_=False, pretty_print=True):
+        super(MapRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='MapRegionType', mapping_=None, nsmap_=None):
         element = super(MapRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -10231,6 +12326,39 @@ class ChemRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='ChemRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('ChemRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'ChemRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='ChemRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='ChemRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='ChemRegionType'):
+        super(ChemRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='ChemRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.bgColour is not None and 'bgColour' not in already_processed:
+            already_processed.add('bgColour')
+            outfile.write(' bgColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bgColour), input_name='bgColour')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='ChemRegionType', fromsubclass_=False, pretty_print=True):
+        super(ChemRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='ChemRegionType', mapping_=None, nsmap_=None):
         element = super(ChemRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -10360,6 +12488,39 @@ class MathsRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='MathsRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('MathsRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'MathsRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='MathsRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='MathsRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='MathsRegionType'):
+        super(MathsRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='MathsRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.bgColour is not None and 'bgColour' not in already_processed:
+            already_processed.add('bgColour')
+            outfile.write(' bgColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bgColour), input_name='bgColour')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='MathsRegionType', fromsubclass_=False, pretty_print=True):
+        super(MathsRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='MathsRegionType', mapping_=None, nsmap_=None):
         element = super(MathsRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -10490,6 +12651,39 @@ class SeparatorRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SeparatorRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('SeparatorRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'SeparatorRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='SeparatorRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='SeparatorRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='SeparatorRegionType'):
+        super(SeparatorRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='SeparatorRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.colour is not None and 'colour' not in already_processed:
+            already_processed.add('colour')
+            outfile.write(' colour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.colour), input_name='colour')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SeparatorRegionType', fromsubclass_=False, pretty_print=True):
+        super(SeparatorRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='SeparatorRegionType', mapping_=None, nsmap_=None):
         element = super(SeparatorRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -10658,6 +12852,48 @@ class ChartRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='ChartRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('ChartRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'ChartRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='ChartRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='ChartRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='ChartRegionType'):
+        super(ChartRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='ChartRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.numColours is not None and 'numColours' not in already_processed:
+            already_processed.add('numColours')
+            outfile.write(' numColours="%s"' % self.gds_format_integer(self.numColours, input_name='numColours'))
+        if self.bgColour is not None and 'bgColour' not in already_processed:
+            already_processed.add('bgColour')
+            outfile.write(' bgColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bgColour), input_name='bgColour')), ))
+        if self.embText is not None and 'embText' not in already_processed:
+            already_processed.add('embText')
+            outfile.write(' embText="%s"' % self.gds_format_boolean(self.embText, input_name='embText'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='ChartRegionType', fromsubclass_=False, pretty_print=True):
+        super(ChartRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='ChartRegionType', mapping_=None, nsmap_=None):
         element = super(ChartRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -10861,6 +13097,61 @@ class TableRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='TableRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('TableRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'TableRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='TableRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='TableRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='TableRegionType'):
+        super(TableRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='TableRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.rows is not None and 'rows' not in already_processed:
+            already_processed.add('rows')
+            outfile.write(' rows="%s"' % self.gds_format_integer(self.rows, input_name='rows'))
+        if self.columns is not None and 'columns' not in already_processed:
+            already_processed.add('columns')
+            outfile.write(' columns="%s"' % self.gds_format_integer(self.columns, input_name='columns'))
+        if self.lineColour is not None and 'lineColour' not in already_processed:
+            already_processed.add('lineColour')
+            outfile.write(' lineColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.lineColour), input_name='lineColour')), ))
+        if self.bgColour is not None and 'bgColour' not in already_processed:
+            already_processed.add('bgColour')
+            outfile.write(' bgColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bgColour), input_name='bgColour')), ))
+        if self.lineSeparators is not None and 'lineSeparators' not in already_processed:
+            already_processed.add('lineSeparators')
+            outfile.write(' lineSeparators="%s"' % self.gds_format_boolean(self.lineSeparators, input_name='lineSeparators'))
+        if self.embText is not None and 'embText' not in already_processed:
+            already_processed.add('embText')
+            outfile.write(' embText="%s"' % self.gds_format_boolean(self.embText, input_name='embText'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='TableRegionType', fromsubclass_=False, pretty_print=True):
+        super(TableRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Grid is not None:
+            namespaceprefix_ = self.Grid_nsprefix_ + ':' if (UseCapturedNS_ and self.Grid_nsprefix_) else ''
+            self.Grid.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Grid', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='TableRegionType', mapping_=None, nsmap_=None):
         element = super(TableRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -11056,6 +13347,45 @@ class GraphicRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='GraphicRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('GraphicRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'GraphicRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GraphicRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='GraphicRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='GraphicRegionType'):
+        super(GraphicRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='GraphicRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.numColours is not None and 'numColours' not in already_processed:
+            already_processed.add('numColours')
+            outfile.write(' numColours="%s"' % self.gds_format_integer(self.numColours, input_name='numColours'))
+        if self.embText is not None and 'embText' not in already_processed:
+            already_processed.add('embText')
+            outfile.write(' embText="%s"' % self.gds_format_boolean(self.embText, input_name='embText'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='GraphicRegionType', fromsubclass_=False, pretty_print=True):
+        super(GraphicRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='GraphicRegionType', mapping_=None, nsmap_=None):
         element = super(GraphicRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -11219,6 +13549,45 @@ class LineDrawingRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='LineDrawingRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('LineDrawingRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'LineDrawingRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='LineDrawingRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='LineDrawingRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='LineDrawingRegionType'):
+        super(LineDrawingRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='LineDrawingRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.penColour is not None and 'penColour' not in already_processed:
+            already_processed.add('penColour')
+            outfile.write(' penColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.penColour), input_name='penColour')), ))
+        if self.bgColour is not None and 'bgColour' not in already_processed:
+            already_processed.add('bgColour')
+            outfile.write(' bgColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bgColour), input_name='bgColour')), ))
+        if self.embText is not None and 'embText' not in already_processed:
+            already_processed.add('embText')
+            outfile.write(' embText="%s"' % self.gds_format_boolean(self.embText, input_name='embText'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='LineDrawingRegionType', fromsubclass_=False, pretty_print=True):
+        super(LineDrawingRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='LineDrawingRegionType', mapping_=None, nsmap_=None):
         element = super(LineDrawingRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -11396,6 +13765,45 @@ class ImageRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='ImageRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('ImageRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'ImageRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='ImageRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='ImageRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='ImageRegionType'):
+        super(ImageRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='ImageRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.colourDepth is not None and 'colourDepth' not in already_processed:
+            already_processed.add('colourDepth')
+            outfile.write(' colourDepth=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.colourDepth), input_name='colourDepth')), ))
+        if self.bgColour is not None and 'bgColour' not in already_processed:
+            already_processed.add('bgColour')
+            outfile.write(' bgColour=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bgColour), input_name='bgColour')), ))
+        if self.embText is not None and 'embText' not in already_processed:
+            already_processed.add('embText')
+            outfile.write(' embText="%s"' % self.gds_format_boolean(self.embText, input_name='embText'))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='ImageRegionType', fromsubclass_=False, pretty_print=True):
+        super(ImageRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='ImageRegionType', mapping_=None, nsmap_=None):
         element = super(ImageRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:
@@ -11763,6 +14171,85 @@ class TextRegionType(RegionType):
             return True
         else:
             return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='TextRegionType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('TextRegionType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'TextRegionType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='TextRegionType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='TextRegionType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='TextRegionType'):
+        super(TextRegionType, self).exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='TextRegionType')
+        if self.orientation is not None and 'orientation' not in already_processed:
+            already_processed.add('orientation')
+            outfile.write(' orientation="%s"' % self.gds_format_float(self.orientation, input_name='orientation'))
+        if self.type_ is not None and 'type_' not in already_processed:
+            already_processed.add('type_')
+            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
+        if self.leading is not None and 'leading' not in already_processed:
+            already_processed.add('leading')
+            outfile.write(' leading="%s"' % self.gds_format_integer(self.leading, input_name='leading'))
+        if self.readingDirection is not None and 'readingDirection' not in already_processed:
+            already_processed.add('readingDirection')
+            outfile.write(' readingDirection=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.readingDirection), input_name='readingDirection')), ))
+        if self.textLineOrder is not None and 'textLineOrder' not in already_processed:
+            already_processed.add('textLineOrder')
+            outfile.write(' textLineOrder=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.textLineOrder), input_name='textLineOrder')), ))
+        if self.readingOrientation is not None and 'readingOrientation' not in already_processed:
+            already_processed.add('readingOrientation')
+            outfile.write(' readingOrientation="%s"' % self.gds_format_float(self.readingOrientation, input_name='readingOrientation'))
+        if self.indented is not None and 'indented' not in already_processed:
+            already_processed.add('indented')
+            outfile.write(' indented="%s"' % self.gds_format_boolean(self.indented, input_name='indented'))
+        if self.align is not None and 'align' not in already_processed:
+            already_processed.add('align')
+            outfile.write(' align=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.align), input_name='align')), ))
+        if self.primaryLanguage is not None and 'primaryLanguage' not in already_processed:
+            already_processed.add('primaryLanguage')
+            outfile.write(' primaryLanguage=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.primaryLanguage), input_name='primaryLanguage')), ))
+        if self.secondaryLanguage is not None and 'secondaryLanguage' not in already_processed:
+            already_processed.add('secondaryLanguage')
+            outfile.write(' secondaryLanguage=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.secondaryLanguage), input_name='secondaryLanguage')), ))
+        if self.primaryScript is not None and 'primaryScript' not in already_processed:
+            already_processed.add('primaryScript')
+            outfile.write(' primaryScript=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.primaryScript), input_name='primaryScript')), ))
+        if self.secondaryScript is not None and 'secondaryScript' not in already_processed:
+            already_processed.add('secondaryScript')
+            outfile.write(' secondaryScript=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.secondaryScript), input_name='secondaryScript')), ))
+        if self.production is not None and 'production' not in already_processed:
+            already_processed.add('production')
+            outfile.write(' production=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.production), input_name='production')), ))
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='TextRegionType', fromsubclass_=False, pretty_print=True):
+        super(TextRegionType, self).exportChildren(outfile, level, namespaceprefix_, namespacedef_, name_, True, pretty_print=pretty_print)
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for TextLine_ in self.TextLine:
+            namespaceprefix_ = self.TextLine_nsprefix_ + ':' if (UseCapturedNS_ and self.TextLine_nsprefix_) else ''
+            TextLine_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextLine', pretty_print=pretty_print)
+        for TextEquiv_ in self.TextEquiv:
+            namespaceprefix_ = self.TextEquiv_nsprefix_ + ':' if (UseCapturedNS_ and self.TextEquiv_nsprefix_) else ''
+            TextEquiv_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextEquiv', pretty_print=pretty_print)
+        if self.TextStyle is not None:
+            namespaceprefix_ = self.TextStyle_nsprefix_ + ':' if (UseCapturedNS_ and self.TextStyle_nsprefix_) else ''
+            self.TextStyle.export(outfile, level, namespaceprefix_, namespacedef_='', name_='TextStyle', pretty_print=pretty_print)
     def to_etree(self, parent_element=None, name_='TextRegionType', mapping_=None, nsmap_=None):
         element = super(TextRegionType, self).to_etree(parent_element, name_, mapping_)
         if self.orientation is not None:

--- a/ocrd_models/ocrd_models/ocrd_page_generateds.py
+++ b/ocrd_models/ocrd_models/ocrd_page_generateds.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Wed Jun 23 17:59:57 2021 by generateDS.py version 2.35.20.
+# Generated Wed Jun 30 02:03:43 2021 by generateDS.py version 2.35.20.
 # Python 3.6.9 (default, Apr 18 2020, 01:56:04)  [GCC 8.4.0]
 #
 # Command line options:
@@ -1236,14 +1236,17 @@ class PcGtsType(GeneratedsSuper):
         return hash(val)
     def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True):
         """
-        Get all the pc:AlternativeImage/@filename paths referenced in the PAGE-XML document.
+        Get all the ``pc:AlternativeImage/@filename`` paths referenced in the PAGE-XML document.
     
+        Arguments:
+            page (boolean): Get images on ``pc:Page`` level
+            region (boolean): Get images on ``pc:*Region`` level
+            line (boolean): Get images on ``pc:TextLine`` level
+            word (boolean): Get images on ``pc:Word`` level
+            glyph (boolean): Get images on ``pc:Glyph`` level
     
-        page (boolean): Get pc:Page level images
-        region (boolean): Get images on pc:*Region level
-        line (boolean) Get images on pc:TextLine level
-        word (boolean) Get images on pc:Word level
-        glyph (boolean) Get images on pc:Glyph level
+        Returns:
+            a list of image filename strings
         """
         from .constants import NAMESPACES, PAGE_REGION_TYPES # pylint: disable=relative-beyond-top-level,import-outside-toplevel
         from io import StringIO  # pylint: disable=import-outside-toplevel
@@ -3196,16 +3199,29 @@ class PageType(GeneratedsSuper):
     
     def get_AllRegions(self, classes=None, order='document', depth=0):
         """
-        Get all the *Region element or only those provided by ``classes``.
-        Returned in document order unless ``order`` is ``reading-order``
+        Get all the ``*Region`` elements, or only those provided by `classes`.
+        Return in document order, unless `order` is ``reading-order``.
+    
         Arguments:
-            classes (list) Classes of regions that shall be returned, e.g. ``['Text', 'Image']``
-            order ("document"|"reading-order"|"reading-order-only") Whether to
+            classes (list): Classes of regions that shall be returned, \
+                e.g. ``['Text', 'Image']``
+            order ("document"|"reading-order"|"reading-order-only"): Whether to \
                 return regions sorted by document order (``document``, default) or by
                 reading order with regions not in the reading order at the end of the
                 returned list (``reading-order``) or regions not in the reading order
                 omitted (``reading-order-only``)
-            depth (int) Recursive depth to look for regions at, set to `0` for all regions at any depth. Default: 0
+            depth (int): Recursive depth to look for regions at, set to `0` for \
+                all regions at any depth. Default: 0
+    
+        Returns:
+            a list of :py:class:`TextRegionType`, :py:class:`ImageRegionType`, \
+                :py:class:`LineDrawingRegionType`, :py:class:`GraphicRegionType`, \
+                :py:class:`TableRegionType`, :py:class:`ChartRegionType`, \
+                :py:class:`MapRegionType`, :py:class:`SeparatorRegionType`, \
+                :py:class:`MathsRegionType`, :py:class:`ChemRegionType`, \
+                :py:class:`MusicRegionType`, :py:class:`AdvertRegionType`, \
+                :py:class:`NoiseRegionType`, :py:class:`UnknownRegionType`, \
+                and/or :py:class:`CustomRegionType`
     
         For example, to get all text anywhere on the page in reading order, use:
         ::
@@ -3239,14 +3255,17 @@ class PageType(GeneratedsSuper):
         return ret
     def get_AllAlternativeImages(self, page=True, region=True, line=True, word=True, glyph=True):
         """
-        Get all the pc:AlternativeImage in a document
+        Get all the ``pc:AlternativeImage`` in a document
     
+        Arguments:
+            page (boolean): Get images on ``pc:Page`` level
+            region (boolean): Get images on ``pc:*Region`` level
+            line (boolean): Get images on ``pc:TextLine`` level
+            word (boolean): Get images on ``pc:Word`` level
+            glyph (boolean): Get images on ``pc:Glyph`` level
     
-        page (boolean): Get pc:Page level images
-        region (boolean): Get images on pc:*Region level
-        line (boolean) Get images on pc:TextLine level
-        word (boolean) Get images on pc:Word level
-        glyph (boolean) Get images on pc:Glyph level
+        Returns:
+            a list of :py:class:`AlternativeImageType`
         """
         ret = []
         if page:
@@ -3269,7 +3288,7 @@ class PageType(GeneratedsSuper):
         """
         Remove derived images from this segment (due to changed coordinates).
     
-        If ``feature_selector`` is not none, remove only images with
+        If `feature_selector` is not none, remove only images with
         matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
         """
         existing_images = self.AlternativeImage or []
@@ -3298,10 +3317,10 @@ class PageType(GeneratedsSuper):
                 image.get_comments() or '', name))
     def set_Border(self, Border):
         """
-        Set coordinate polygon by given object.
-        Moreover, invalidate self's AlternativeImages
+        Set coordinate polygon by given :py:class:`BorderType` object.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been cropped with a bbox
-         of the previous polygon).
+        of the previous polygon).
         """
         self.invalidate_AlternativeImage(feature_selector='cropped')
         self.Border = Border
@@ -3310,12 +3329,15 @@ class PageType(GeneratedsSuper):
         Return all the TextLine in the document
     
         Arguments:
-            region_order ("document"|"reading-order"|"reading-order-only") Whether to
-                return regions sorted by document order (``document``, default) or by
-                reading order with regions not in the reading order at the end of the
-                returned list (``reading-order``) or regions not in the reading order
+            region_order ("document"|"reading-order"|"reading-order-only"): Whether to \
+                return regions sorted by document order (``document``, default) or by \
+                reading order with regions not in the reading order at the end of the \
+                returned list (``reading-order``) or regions not in the reading order \
                 omitted (``reading-order-only``)
-            respect_textline_order (boolean) Whether to respect textlineOrder attribute
+            respect_textline_order (boolean): Whether to respect `@textLineOrder` attribute
+    
+        Returns:
+            a list of :py:class:`TextLineType`
         """
         # TODO handle textLineOrder according to https://github.com/PRImA-Research-Lab/PAGE-XML/issues/26
         ret = []
@@ -3330,10 +3352,10 @@ class PageType(GeneratedsSuper):
     
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -3505,9 +3527,9 @@ class CoordsType(GeneratedsSuper):
     def set_points(self, points):
         """
         Set coordinate polygon by given string.
-        Moreover, invalidate the parent's AlternativeImages
+        Moreover, invalidate the parent's ``pc:AlternativeImage``s
         (because they will have been cropped with a bbox
-         of the previous polygon).
+        of the previous polygon).
         """
         if hasattr(self, 'parent_object_'):
             parent = self.parent_object_
@@ -4014,7 +4036,7 @@ class TextLineType(GeneratedsSuper):
         """
         Remove derived images from this segment (due to changed coordinates).
     
-        If ``feature_selector`` is not none, remove only images with
+        If `feature_selector` is not none, remove only images with
         matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
         """
         existing_images = self.AlternativeImage or []
@@ -4043,10 +4065,10 @@ class TextLineType(GeneratedsSuper):
                 image.get_comments() or '', name))
     def set_Coords(self, Coords):
         """
-        Set coordinate polygon by given object.
-        Moreover, invalidate self's AlternativeImages
+        Set coordinate polygon by given :py:class:`CoordsType` object.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been cropped with a bbox
-         of the previous polygon).
+        of the previous polygon).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # RegionType, TextLineType, WordType, GlyphType:
@@ -4514,7 +4536,7 @@ class WordType(GeneratedsSuper):
         """
         Remove derived images from this segment (due to changed coordinates).
     
-        If ``feature_selector`` is not none, remove only images with
+        If `feature_selector` is not none, remove only images with
         matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
         """
         existing_images = self.AlternativeImage or []
@@ -4543,10 +4565,10 @@ class WordType(GeneratedsSuper):
                 image.get_comments() or '', name))
     def set_Coords(self, Coords):
         """
-        Set coordinate polygon by given object.
-        Moreover, invalidate self's AlternativeImages
+        Set coordinate polygon by given :py:class:`CoordsType` object.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been cropped with a bbox
-         of the previous polygon).
+        of the previous polygon).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # RegionType, TextLineType, WordType, GlyphType:
@@ -4966,7 +4988,7 @@ class GlyphType(GeneratedsSuper):
         """
         Remove derived images from this segment (due to changed coordinates).
     
-        If ``feature_selector`` is not none, remove only images with
+        If `feature_selector` is not none, remove only images with
         matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
         """
         existing_images = self.AlternativeImage or []
@@ -4995,10 +5017,10 @@ class GlyphType(GeneratedsSuper):
                 image.get_comments() or '', name))
     def set_Coords(self, Coords):
         """
-        Set coordinate polygon by given object.
-        Moreover, invalidate self's AlternativeImages
+        Set coordinate polygon by given :py:class:`CoordsType` object.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been cropped with a bbox
-         of the previous polygon).
+        of the previous polygon).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # RegionType, TextLineType, WordType, GlyphType:
@@ -6340,8 +6362,14 @@ class OrderedGroupIndexedType(GeneratedsSuper):
         Get all indexed children sorted by their ``@index``.
     
         Arguments:
-            classes (list): Type of children to return. Default: ['RegionRef', 'OrderedGroup', 'UnorderedGroup']
+            classes (list): Type of children (sans ``Indexed``) to return. \
+                Default: ``['RegionRef', 'OrderedGroup', 'UnorderedGroup']``
             index_sort (boolean): Whether to sort by ``@index``
+    
+        Returns:
+            a list of :py:class:`RegionRefIndexedType`, \
+                :py:class:`OrderedGroupIndexedType`, and \
+                :py:class:`UnorderedGroupIndexedType`
         """
         if not classes:
             classes = ['RegionRef', 'OrderedGroup', 'UnorderedGroup']
@@ -6361,8 +6389,8 @@ class OrderedGroupIndexedType(GeneratedsSuper):
     # pylint: disable=line-too-long,invalid-name,missing-module-docstring
     def extend_AllIndexed(self, elements, validate_continuity=False):
         """
-        Add all elements in list ``elements``, respecting ``@index`` order.
-        With ``validate_continuity``, check that all new elements come after all old elements
+        Add all elements in list `elements`, respecting ``@index`` order.
+        With `validate_continuity`, check that all new elements come after all old elements
         (or raise an exception). 
         Otherwise, ensure this condition silently (by increasing ``@index`` accordingly).
         """
@@ -6808,7 +6836,7 @@ class UnorderedGroupIndexedType(GeneratedsSuper):
         return hash(val)
     def get_UnorderedGroupChildren(self):
         """
-        List all non-metadata children of an UnorderedGroup
+        List all non-metadata children of an :py:class:`UnorderedGroupType`
         """
         # TODO: should not change order
         return self.get_RegionRef() + self.get_OrderedGroup() + self.get_UnorderedGroup()
@@ -7290,8 +7318,14 @@ class OrderedGroupType(GeneratedsSuper):
         Get all indexed children sorted by their ``@index``.
     
         Arguments:
-            classes (list): Type of children to return. Default: ['RegionRef', 'OrderedGroup', 'UnorderedGroup']
+            classes (list): Type of children (sans ``Indexed``) to return. \
+                Default: ``['RegionRef', 'OrderedGroup', 'UnorderedGroup']``
             index_sort (boolean): Whether to sort by ``@index``
+    
+        Returns:
+            a list of :py:class:`RegionRefIndexedType`, \
+                :py:class:`OrderedGroupIndexedType`, and \
+                :py:class:`UnorderedGroupIndexedType`
         """
         if not classes:
             classes = ['RegionRef', 'OrderedGroup', 'UnorderedGroup']
@@ -7311,8 +7345,8 @@ class OrderedGroupType(GeneratedsSuper):
     # pylint: disable=line-too-long,invalid-name,missing-module-docstring
     def extend_AllIndexed(self, elements, validate_continuity=False):
         """
-        Add all elements in list ``elements``, respecting ``@index`` order.
-        With ``validate_continuity``, check that all new elements come after all old elements
+        Add all elements in list `elements`, respecting ``@index`` order.
+        With `validate_continuity`, check that all new elements come after all old elements
         (or raise an exception). 
         Otherwise, ensure this condition silently (by increasing ``@index`` accordingly).
         """
@@ -7740,7 +7774,7 @@ class UnorderedGroupType(GeneratedsSuper):
         return hash(val)
     def get_UnorderedGroupChildren(self):
         """
-        List all non-metadata children of an UnorderedGroup
+        List all non-metadata children of an :py:class:`UnorderedGroupType`
         """
         # TODO: should not change order
         return self.get_RegionRef() + self.get_OrderedGroup() + self.get_UnorderedGroup()
@@ -7866,10 +7900,10 @@ class BorderType(GeneratedsSuper):
         return hash(val)
     def set_Coords(self, Coords):
         """
-        Set coordinate polygon by given object.
-        Moreover, invalidate self's AlternativeImages
+        Set coordinate polygon by given :py:class:`CoordsType` object.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been cropped with a bbox
-         of the previous polygon).
+        of the previous polygon).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # RegionType, TextLineType, WordType, GlyphType:
@@ -9899,7 +9933,7 @@ class RegionType(GeneratedsSuper):
         """
         Remove derived images from this segment (due to changed coordinates).
     
-        If ``feature_selector`` is not none, remove only images with
+        If `feature_selector` is not none, remove only images with
         matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
         """
         existing_images = self.AlternativeImage or []
@@ -9928,10 +9962,10 @@ class RegionType(GeneratedsSuper):
                 image.get_comments() or '', name))
     def set_Coords(self, Coords):
         """
-        Set coordinate polygon by given object.
-        Moreover, invalidate self's AlternativeImages
+        Set coordinate polygon by given :py:class:`CoordsType` object.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been cropped with a bbox
-         of the previous polygon).
+        of the previous polygon).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # RegionType, TextLineType, WordType, GlyphType:
@@ -11952,10 +11986,10 @@ class AdvertRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -12113,10 +12147,10 @@ class MusicRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -12244,10 +12278,10 @@ class MapRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -12406,10 +12440,10 @@ class ChemRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -12568,10 +12602,10 @@ class MathsRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -12731,10 +12765,10 @@ class SeparatorRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -12965,10 +12999,10 @@ class ChartRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -13247,10 +13281,10 @@ class TableRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -13450,10 +13484,10 @@ class GraphicRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -13653,10 +13687,10 @@ class LineDrawingRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -13869,10 +13903,10 @@ class ImageRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:
@@ -14398,10 +14432,10 @@ class TextRegionType(RegionType):
         return hash(val)
     def set_orientation(self, orientation):
         """
-        Set deskewing angle to given number.
-        Moreover, invalidate self's AlternativeImages
+        Set deskewing angle to given `orientation` number.
+        Moreover, invalidate self's ``pc:AlternativeImage``s
         (because they will have been rotated and enlarged
-         with the angle of the previous value).
+        with the angle of the previous value).
         """
         if hasattr(self, 'invalidate_AlternativeImage'):
             # PageType, RegionType:

--- a/ocrd_models/ocrd_page_user_methods/extend_AllIndexed.py
+++ b/ocrd_models/ocrd_page_user_methods/extend_AllIndexed.py
@@ -1,8 +1,8 @@
 # pylint: disable=line-too-long,invalid-name,missing-module-docstring
 def extend_AllIndexed(self, elements, validate_continuity=False):
     """
-    Add all elements in list ``elements``, respecting ``@index`` order.
-    With ``validate_continuity``, check that all new elements come after all old elements
+    Add all elements in list `elements`, respecting ``@index`` order.
+    With `validate_continuity`, check that all new elements come after all old elements
     (or raise an exception). 
     Otherwise, ensure this condition silently (by increasing ``@index`` accordingly).
     """

--- a/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImagePaths.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImagePaths.py
@@ -1,13 +1,16 @@
 def get_AllAlternativeImagePaths(self, page=True, region=True, line=True, word=True, glyph=True):
     """
-    Get all the pc:AlternativeImage/@filename paths referenced in the PAGE-XML document.
+    Get all the ``pc:AlternativeImage/@filename`` paths referenced in the PAGE-XML document.
 
+    Arguments:
+        page (boolean): Get images on ``pc:Page`` level
+        region (boolean): Get images on ``pc:*Region`` level
+        line (boolean): Get images on ``pc:TextLine`` level
+        word (boolean): Get images on ``pc:Word`` level
+        glyph (boolean): Get images on ``pc:Glyph`` level
 
-    page (boolean): Get pc:Page level images
-    region (boolean): Get images on pc:*Region level
-    line (boolean) Get images on pc:TextLine level
-    word (boolean) Get images on pc:Word level
-    glyph (boolean) Get images on pc:Glyph level
+    Returns:
+        a list of image filename strings
     """
     from .constants import NAMESPACES, PAGE_REGION_TYPES # pylint: disable=relative-beyond-top-level,import-outside-toplevel
     from io import StringIO  # pylint: disable=import-outside-toplevel

--- a/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImages.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllAlternativeImages.py
@@ -1,13 +1,16 @@
 def get_AllAlternativeImages(self, page=True, region=True, line=True, word=True, glyph=True):
     """
-    Get all the pc:AlternativeImage in a document
+    Get all the ``pc:AlternativeImage`` in a document
 
+    Arguments:
+        page (boolean): Get images on ``pc:Page`` level
+        region (boolean): Get images on ``pc:*Region`` level
+        line (boolean): Get images on ``pc:TextLine`` level
+        word (boolean): Get images on ``pc:Word`` level
+        glyph (boolean): Get images on ``pc:Glyph`` level
 
-    page (boolean): Get pc:Page level images
-    region (boolean): Get images on pc:*Region level
-    line (boolean) Get images on pc:TextLine level
-    word (boolean) Get images on pc:Word level
-    glyph (boolean) Get images on pc:Glyph level
+    Returns:
+        a list of :py:class:`AlternativeImageType`
     """
     ret = []
     if page:

--- a/ocrd_models/ocrd_page_user_methods/get_AllIndexed.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllIndexed.py
@@ -4,8 +4,14 @@ def get_AllIndexed(self, classes=None, index_sort=True):
     Get all indexed children sorted by their ``@index``.
 
     Arguments:
-        classes (list): Type of children to return. Default: ['RegionRef', 'OrderedGroup', 'UnorderedGroup']
+        classes (list): Type of children (sans ``Indexed``) to return. \
+            Default: ``['RegionRef', 'OrderedGroup', 'UnorderedGroup']``
         index_sort (boolean): Whether to sort by ``@index``
+
+    Returns:
+        a list of :py:class:`RegionRefIndexedType`, \
+            :py:class:`OrderedGroupIndexedType`, and \
+            :py:class:`UnorderedGroupIndexedType`
     """
     if not classes:
         classes = ['RegionRef', 'OrderedGroup', 'UnorderedGroup']

--- a/ocrd_models/ocrd_page_user_methods/get_AllRegions.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllRegions.py
@@ -42,16 +42,29 @@ def _get_recursive_reading_order(self, rogroup):
 
 def get_AllRegions(self, classes=None, order='document', depth=0):
     """
-    Get all the *Region element or only those provided by ``classes``.
-    Returned in document order unless ``order`` is ``reading-order``
+    Get all the ``*Region`` elements, or only those provided by `classes`.
+    Return in document order, unless `order` is ``reading-order``.
+
     Arguments:
-        classes (list) Classes of regions that shall be returned, e.g. ``['Text', 'Image']``
-        order ("document"|"reading-order"|"reading-order-only") Whether to
+        classes (list): Classes of regions that shall be returned, \
+            e.g. ``['Text', 'Image']``
+        order ("document"|"reading-order"|"reading-order-only"): Whether to \
             return regions sorted by document order (``document``, default) or by
             reading order with regions not in the reading order at the end of the
             returned list (``reading-order``) or regions not in the reading order
             omitted (``reading-order-only``)
-        depth (int) Recursive depth to look for regions at, set to `0` for all regions at any depth. Default: 0
+        depth (int): Recursive depth to look for regions at, set to `0` for \
+            all regions at any depth. Default: 0
+
+    Returns:
+        a list of :py:class:`TextRegionType`, :py:class:`ImageRegionType`, \
+            :py:class:`LineDrawingRegionType`, :py:class:`GraphicRegionType`, \
+            :py:class:`TableRegionType`, :py:class:`ChartRegionType`, \
+            :py:class:`MapRegionType`, :py:class:`SeparatorRegionType`, \
+            :py:class:`MathsRegionType`, :py:class:`ChemRegionType`, \
+            :py:class:`MusicRegionType`, :py:class:`AdvertRegionType`, \
+            :py:class:`NoiseRegionType`, :py:class:`UnknownRegionType`, \
+            and/or :py:class:`CustomRegionType`
 
     For example, to get all text anywhere on the page in reading order, use:
     ::

--- a/ocrd_models/ocrd_page_user_methods/get_AllTextLines.py
+++ b/ocrd_models/ocrd_page_user_methods/get_AllTextLines.py
@@ -3,12 +3,15 @@ def get_AllTextLines(self, region_order='document', respect_textline_order=True)
     Return all the TextLine in the document
 
     Arguments:
-        region_order ("document"|"reading-order"|"reading-order-only") Whether to
-            return regions sorted by document order (``document``, default) or by
-            reading order with regions not in the reading order at the end of the
-            returned list (``reading-order``) or regions not in the reading order
+        region_order ("document"|"reading-order"|"reading-order-only"): Whether to \
+            return regions sorted by document order (``document``, default) or by \
+            reading order with regions not in the reading order at the end of the \
+            returned list (``reading-order``) or regions not in the reading order \
             omitted (``reading-order-only``)
-        respect_textline_order (boolean) Whether to respect textlineOrder attribute
+        respect_textline_order (boolean): Whether to respect `@textLineOrder` attribute
+
+    Returns:
+        a list of :py:class:`TextLineType`
     """
     # TODO handle textLineOrder according to https://github.com/PRImA-Research-Lab/PAGE-XML/issues/26
     ret = []

--- a/ocrd_models/ocrd_page_user_methods/get_UnorderedGroupChildren.py
+++ b/ocrd_models/ocrd_page_user_methods/get_UnorderedGroupChildren.py
@@ -1,6 +1,6 @@
 def get_UnorderedGroupChildren(self):
     """
-    List all non-metadata children of an UnorderedGroup
+    List all non-metadata children of an :py:class:`UnorderedGroupType`
     """
     # TODO: should not change order
     return self.get_RegionRef() + self.get_OrderedGroup() + self.get_UnorderedGroup()

--- a/ocrd_models/ocrd_page_user_methods/invalidate_AlternativeImage.py
+++ b/ocrd_models/ocrd_page_user_methods/invalidate_AlternativeImage.py
@@ -2,7 +2,7 @@ def invalidate_AlternativeImage(self, feature_selector=None):
     """
     Remove derived images from this segment (due to changed coordinates).
 
-    If ``feature_selector`` is not none, remove only images with
+    If `feature_selector` is not none, remove only images with
     matching ``@comments``, e.g. ``feature_selector=cropped,deskewed``.
     """
     existing_images = self.AlternativeImage or []

--- a/ocrd_models/ocrd_page_user_methods/set_Border.py
+++ b/ocrd_models/ocrd_page_user_methods/set_Border.py
@@ -1,9 +1,9 @@
 def set_Border(self, Border):
     """
-    Set coordinate polygon by given object.
-    Moreover, invalidate self's AlternativeImages
+    Set coordinate polygon by given :py:class:`BorderType` object.
+    Moreover, invalidate self's ``pc:AlternativeImage``s
     (because they will have been cropped with a bbox
-     of the previous polygon).
+    of the previous polygon).
     """
     self.invalidate_AlternativeImage(feature_selector='cropped')
     self.Border = Border

--- a/ocrd_models/ocrd_page_user_methods/set_Coords.py
+++ b/ocrd_models/ocrd_page_user_methods/set_Coords.py
@@ -1,9 +1,9 @@
 def set_Coords(self, Coords):
     """
-    Set coordinate polygon by given object.
-    Moreover, invalidate self's AlternativeImages
+    Set coordinate polygon by given :py:class:`CoordsType` object.
+    Moreover, invalidate self's ``pc:AlternativeImage``s
     (because they will have been cropped with a bbox
-     of the previous polygon).
+    of the previous polygon).
     """
     if hasattr(self, 'invalidate_AlternativeImage'):
         # RegionType, TextLineType, WordType, GlyphType:

--- a/ocrd_models/ocrd_page_user_methods/set_orientation.py
+++ b/ocrd_models/ocrd_page_user_methods/set_orientation.py
@@ -1,9 +1,9 @@
 def set_orientation(self, orientation):
     """
-    Set deskewing angle to given number.
-    Moreover, invalidate self's AlternativeImages
+    Set deskewing angle to given `orientation` number.
+    Moreover, invalidate self's ``pc:AlternativeImage``s
     (because they will have been rotated and enlarged
-     with the angle of the previous value).
+    with the angle of the previous value).
     """
     if hasattr(self, 'invalidate_AlternativeImage'):
         # PageType, RegionType:

--- a/ocrd_models/ocrd_page_user_methods/set_points.py
+++ b/ocrd_models/ocrd_page_user_methods/set_points.py
@@ -1,9 +1,9 @@
 def set_points(self, points):
     """
     Set coordinate polygon by given string.
-    Moreover, invalidate the parent's AlternativeImages
+    Moreover, invalidate the parent's ``pc:AlternativeImage``s
     (because they will have been cropped with a bbox
-     of the previous polygon).
+    of the previous polygon).
     """
     if hasattr(self, 'parent_object_'):
         parent = self.parent_object_

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,6 +2,7 @@ pytest >= 4.0.0
 generateDS == 2.35.20
 coverage >= 4.5.2
 sphinx
+sphinx_click
 codecov >= 2.0.15
 recommonmark >= 0.5.0
 docstr-coverage

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -52,7 +52,11 @@ class TestDecorators(TestCase):
     def test_loglevel_invalid(self):
         code, _, err = self.invoke_cli(cli_with_ocrd_loglevel, ['--log-level', 'foo'])
         assert code
-        self.assertIn('invalid choice: foo', err)
+        import click
+        if int(click.__version__[0]) < 8:
+            assert 'invalid choice: foo' in err
+        else:
+            assert "'foo' is not one of" in err
 
     def test_loglevel_override(self):
         import logging


### PR DESCRIPTION
This picks up on an old idea: #313 originally provided lxml etree nodes alongside the parsed OcrdPage DOM. This is helpful in processors and core for doing XPath queries on PAGE-XML (without the need to regenerate and reparse). It also allows some basic _mapping_ between DOM objects and lxml nodes:

```python
from ocrd_models.ocrd_page import parseEtree
pcgts, pcgts_root, pcgts_mapping, pcgts_revmap = parseEtree('page.xml')
line = pcgts.get_Page().get_TextRegion()[2].get_TextLine()[1]
assert pcgts_mapping[id(line)].attrib['id'] == line.id
```

The same can be achieved via:
```python
from ocrd_modelfactory import page_from_file, page_from_image
pcgts, pcgts_root, pcgts_mapping, pcgts_revmap = page_from_image(input_file, with_etree=True)
pcgts, pcgts_root, pcgts_mapping, pcgts_revmap = page_from_file(input_file, with_etree=True)
```

I have _not_ included shortcuts like `obj2node` or `node2id`, since (in the current implementation) one would need to pass the mappings along anyway. 

This is deliberate: This time, let's **not**:
1. monkey-patch the generated classes to store the mappings automatically, and 
2. take hold of implementation details to get a reverse mapping of memory objects from their `id`:
    ```python
    def di(ID):
        return _ctypes.PyObj_FromPtr(ID)
    ```

IIRC these hacks (which @cneud called _a path to the dark side_) were the culprits against adopting the old PR entirely, with the [main argument](https://github.com/OCR-D/core/pull/313#discussion_r370090562) being that we might loose performance _and_ stability, esp. when the DOM is changed and thus becomes inconsistent with the etree.

The reverse mapping in the present form might still be helpful to merely check against DOM object candidates already of interest.

