### PR TITLE
log to STDERR not STDOUT, fix #667

### DIFF
--- a/ocrd_utils/ocrd_logging.conf
+++ b/ocrd_utils/ocrd_logging.conf
@@ -82,12 +82,12 @@ qualname=PIL
 
 
 #
-# handle stdout output
+# handle stderr output
 #
 [handler_consoleHandler]
 class=StreamHandler
 formatter=defaultFormatter
-args=(sys.stdout,)
+args=(sys.stderr,)
 
 #
 # example logfile handler

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -19,6 +19,7 @@ from traceback import format_stack
 import logging
 import logging.config
 import os
+import sys
 
 from .constants import LOG_FORMAT, LOG_TIMEFMT
 
@@ -130,7 +131,7 @@ def initLogging():
         logging.getLogger('ocrd.logging').debug("Picked up logging config at %s" % config_file)
     else:
         # Default logging config
-        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, datefmt=LOG_TIMEFMT)
+        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, datefmt=LOG_TIMEFMT, stream=sys.stderr)
         logging.getLogger('').setLevel(logging.INFO)
         #  logging.getLogger('ocrd.resolver').setLevel(logging.INFO)
         #  logging.getLogger('ocrd.resolver.download_to_directory').setLevel(logging.INFO)

--- a/tests/test_logging_conf.py
+++ b/tests/test_logging_conf.py
@@ -10,13 +10,20 @@ import sys
 from ocrd_utils import pushd_popd
 from ocrd_utils.logging import (
     initLogging,
-    getLogger
+    getLogger,
+    disableLogging,
 )
 
 import pytest
 
+from tests.base import main
+
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../ocrd')
 TEST_ROOT = pathlib.Path(os.path.dirname(os.path.abspath(__file__))).parent
+
+def resetLogging():
+    disableLogging()
+    initLogging()
 
 
 @pytest.fixture(name="logging_conf")
@@ -34,13 +41,13 @@ def test_configured_dateformat(logging_conf, capsys):
 
     # arrange
     with pushd_popd(logging_conf):
-        initLogging()
+        resetLogging()
         test_logger = getLogger('')
 
         # act
         test_logger.info("test logger initialized")
 
-        log_info_output = capsys.readouterr().out
+        log_info_output = capsys.readouterr().err
         must_not_match = r"^\d{4}-\d{2}-\d{2}.*"
         assert not re.match(must_not_match, log_info_output)
         match_pattern = r"^\d{2}:\d{2}:\d{2}.*"
@@ -52,17 +59,17 @@ def test_configured_tensorflow_logger_present(logging_conf, capsys):
 
     # arrange
     os.chdir(logging_conf)
-    initLogging()
+    resetLogging()
     logger_under_test = getLogger('tensorflow')
 
     # act info
     logger_under_test.info("tensorflow logger initialized")
-    log_info_output = capsys.readouterr().out
+    log_info_output = capsys.readouterr().err
     assert not log_info_output
 
     # act error
     logger_under_test.error("tensorflow has error")
-    log_error_output = capsys.readouterr().out
+    log_error_output = capsys.readouterr().err
     assert log_error_output
 
 
@@ -71,15 +78,18 @@ def test_configured_shapely_logger_present(logging_conf, capsys):
 
     # arrange
     os.chdir(logging_conf)
-    initLogging()
+    resetLogging()
     logger_under_test = getLogger('shapely.geos')
 
     # act info
     logger_under_test.info("shapely.geos logger initialized")
-    log_info_output = capsys.readouterr().out
+    log_info_output = capsys.readouterr().err
     assert not log_info_output
 
     # act error
     logger_under_test.error("shapely alert")
-    log_error_output = capsys.readouterr().out
+    log_error_output = capsys.readouterr().err
     assert log_error_output
+
+if __name__ == '__main__':
+    main(__file__)


### PR DESCRIPTION
The default logger will log to STDERR. As discussed in #667, this will eliminate the need for workarounds like completely disabling logging to ensure logging output does not interfere with parseable output.

The default configuration file has also been adapted accordingly.