### PR TITLE
ocrd_models requires six / tesseract resource URL change

### DIFF
--- a/ocrd/ocrd/resource_list.yml
+++ b/ocrd/ocrd/resource_list.yml
@@ -45,12 +45,12 @@ ocrd-tesserocr-recognize:
     parameter_usage: 'without-extension'
     description: Tesseract Latin model
     size: 89384811
-  - url: https://github.com/tesseract-ocr/tesseract/archive/master.tar.gz
+  - url: https://github.com/tesseract-ocr/tesseract/archive/main.tar.gz
     name: configs
     description: Tesseract configs (parameter sets) for use with the standalone tesseract CLI
-    size: 1973268
+    size: 1915529
     type: tarball
-    path_in_archive: 'tesseract-master/tessdata/configs'
+    path_in_archive: 'tesseract-main/tessdata/configs'
 ocrd-calamari-recognize:
   # XXX disabled since older ocrd_calamari versions don't support resource resolving
   #- url: https://qurator-data.de/calamari-models/GT4HistOCR/2019-07-22T15_49+0200/model.tar.xz

--- a/ocrd_models/requirements.txt
+++ b/ocrd_models/requirements.txt
@@ -1,1 +1,2 @@
 lxml
+six


### PR DESCRIPTION
Two small fixes (accidently in one PR, sorry)

1) ocrd_models/ocrd_page_generateds.py imports from `six`, but it is not listed in `requirements.txt`
....
in ocrd_models/ocrd_page_generateds.py line 27
    from six.moves import zip_longest
ModuleNotFoundError: No module named 'six'

2) The tesseract resource URLs changed (#719), this was fixed in 5f1c58974cb5e84aaf186be88c53771e0640131c except for the resource `configs` which still used the old branch name


