### PR TITLE
Add missing six requirement

### DIFF
--- a/ocrd_models/requirements.txt
+++ b/ocrd_models/requirements.txt
@@ -1,1 +1,2 @@
 lxml
+six


### PR DESCRIPTION
b8e7b68 introduced a dependency on six but ocrd_models does not require
it in requirements.txt. Fix this by adding six.

Fixes #730.