### PR TITLE
run_processor: add mets:agent/mets:note with fileGrps and params

### DIFF
--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -88,20 +88,25 @@ def run_processor(
     processor.process()
     t1_wall = perf_counter() - t0_wall
     t1_cpu = process_time() - t0_cpu
-    logProfile.info("Executing processor '%s' took %fs (wall) %fs (CPU)( [--input-file-grp='%s' --output-file-grp='%s' --parameter='%s']" % (
+    logProfile.info("Executing processor '%s' took %fs (wall) %fs (CPU)( [--input-file-grp='%s' --output-file-grp='%s' --parameter='%s' --page-id='%s']" % (
         ocrd_tool['executable'],
         t1_wall,
         t1_cpu,
-        input_file_grp if input_file_grp else '',
-        output_file_grp if output_file_grp else '',
-        json.dumps(parameter) if parameter else {}
+        input_file_grp or '',
+        output_file_grp or '',
+        json.dumps(parameter) or '',
+        page_id or ''
     ))
     workspace.mets.add_agent(
         name=name,
         _type='OTHER',
         othertype='SOFTWARE',
         role='OTHER',
-        otherrole=otherrole
+        otherrole=otherrole,
+        notes=[({'option': 'input-file-grp'}, input_file_grp or ''),
+               ({'option': 'output-file-grp'}, output_file_grp or ''),
+               ({'option': 'parameter'}, json.dumps(parameter or '')),
+               ({'option': 'page-id'}, page_id or '')]
     )
     workspace.save_mets()
     return processor

--- a/ocrd_models/ocrd_models/constants.py
+++ b/ocrd_models/ocrd_models/constants.py
@@ -17,6 +17,7 @@ __all__ = [
     'TAG_METS_FLOCAT',
     'TAG_METS_METSHDR',
     'TAG_METS_NAME',
+    'TAG_METS_NOTE',
     'TAG_METS_STRUCTMAP',
     'TAG_MODS_IDENTIFIER',
     'TAG_PAGE_ALTERNATIVEIMAGE',
@@ -39,6 +40,7 @@ NAMESPACES = {
     'xlink': "http://www.w3.org/1999/xlink",
     'page': "http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15",
     'xsl': 'http://www.w3.org/1999/XSL/Transform#',
+    'ocrd': 'https://ocr-d.de',
 }
 
 # pylint: disable=bad-whitespace
@@ -51,6 +53,7 @@ TAG_METS_FPTR             = '{%s}fptr' % NAMESPACES['mets']
 TAG_METS_FLOCAT           = '{%s}FLocat' % NAMESPACES['mets']
 TAG_METS_METSHDR          = '{%s}metsHdr' % NAMESPACES['mets']
 TAG_METS_NAME             = '{%s}name' % NAMESPACES['mets']
+TAG_METS_NOTE             = '{%s}note' % NAMESPACES['mets']
 TAG_METS_STRUCTMAP        = '{%s}structMap' % NAMESPACES['mets']
 
 TAG_MODS_IDENTIFIER       = '{%s}identifier' % NAMESPACES['mods']

--- a/ocrd_models/ocrd_models/ocrd_agent.py
+++ b/ocrd_models/ocrd_models/ocrd_agent.py
@@ -2,7 +2,7 @@
 API to ``mets:agent``
 """
 #  import os
-from .constants import NAMESPACES as NS, TAG_METS_AGENT, TAG_METS_NAME
+from .constants import NAMESPACES as NS, TAG_METS_AGENT, TAG_METS_NAME, TAG_METS_NOTE
 from .ocrd_xml_base import ET
 
 class OcrdAgent():
@@ -20,7 +20,8 @@ class OcrdAgent():
     #      #  version = name_parts[1][1:]     # v0.0.1 => 0.0.1
     #      return OcrdAgent(el, name, role, _type, otherrole)
 
-    def __init__(self, el=None, name=None, _type=None, othertype=None, role=None, otherrole=None):
+    def __init__(self, el=None, name=None, _type=None, othertype=None, role=None, otherrole=None,
+                 notes=None):
         """
         Args:
             el (LxmlElement):
@@ -29,6 +30,7 @@ class OcrdAgent():
             othertype (string):
             role (string):
             otherrole (string):
+            notes (dict):
         """
         if el is None:
             el = ET.Element(TAG_METS_AGENT)
@@ -38,6 +40,7 @@ class OcrdAgent():
         self.othertype = othertype
         self.role = role
         self.otherrole = otherrole
+        self.notes = notes
 
     def __str__(self):
         """
@@ -105,7 +108,7 @@ class OcrdAgent():
     @otherrole.setter
     def otherrole(self, otherrole):
         """
-        Get the ``OTHERROLE`` attribute value.
+        Set the ``OTHERROLE`` attribute value.
         """
         if otherrole is not None:
             self._el.set('ROLE', 'OTHER')
@@ -116,17 +119,44 @@ class OcrdAgent():
         """
         Get the ``mets:name`` element value.
         """
-        el_name = self._el.find('mets:name', NS)
+        el_name = self._el.find(TAG_METS_NAME)
         if el_name is not None:
             return el_name.text
 
     @name.setter
     def name(self, name):
         """
-        Get the ``mets:name`` element value.
+        Set the ``mets:name`` element value.
         """
         if name is not None:
-            el_name = self._el.find('mets:name', NS)
+            el_name = self._el.find(TAG_METS_NAME)
             if el_name is None:
                 el_name = ET.SubElement(self._el, TAG_METS_NAME)
             el_name.text = name
+
+    @property
+    def notes(self):
+        """
+        Get the ``mets:note`` element values (as tuples of attributes and text).
+        """
+        el_notes = self._el.findall(TAG_METS_NOTE)
+        if el_notes is not None:
+            return [(note.attrib, note.text)
+                    for note in el_notes]
+
+    @notes.setter
+    def notes(self, notes):
+        """
+        Set the ``mets:note`` element values.
+        """
+        el_notes = self._el.findall(TAG_METS_NOTE)
+        if el_notes:
+            for el_note in el_notes:
+                self._el.remove(el_note)
+        if notes:
+            for note in notes:
+                el_note = ET.SubElement(self._el, TAG_METS_NOTE, nsmap=NS)
+                attrib, text = note
+                el_note.text = text
+                for name, value in attrib.items():
+                    el_note.set('{%s}' % NS["ocrd"] + name, value)


### PR DESCRIPTION
So far we only save the parameters into the PAGE-XML, but it's hard to reconstruct the exact workflow path from that alone. This adds the information which tool processed which fileGrps (and the parameters again – as I feel this redundancy is useful).

Note that the METS schema does allow attributes under `metsHdr/agent/note`, but only if they are from a foreign namespace – so I decided to just invent a (pseudo) OCR-D namespace.

Example output:
```XML
    <mets:agent TYPE="OTHER" OTHERTYPE="SOFTWARE" ROLE="OTHER" OTHERROLE="layout/segmentation/region">
      <mets:name>ocrd-cis-ocropy-segment v0.1.5</mets:name>
      <mets:note xmlns:ocrd="https://ocr-d.de" ocrd:option="input-file-grp">OCR-D-GT-SEG-PAGE-BINPAGE-sauvola-DENOISE-ocropy-DESKEW-tesseract-DESKEW-ocropy</mets:note>
      <mets:note xmlns:ocrd="https://ocr-d.de" ocrd:option="output-file-grp">OCR-D-SEG-BLOCK-ocropy</mets:note>
      <mets:note xmlns:ocrd="https://ocr-d.de" ocrd:option="parameter">{"level-of-operation": "page", "dpi": 0, "maxcolseps": 20, "maxseps": 20, "maximages": 10, "csminheight": 4, "hlminwidth": 10, "gap_height": 0.01, "gap_width": 1.5, "overwrite_order": true, "overwrite_separators": true, "overwrite_regions": true, "overwrite_lines": true, "spread": 2.4}</mets:note>
      <mets:note xmlns:ocrd="https://ocr-d.de" ocrd:option="page-id"/>
    </mets:agent>
```
