### PR TITLE
Feat/rfct/pytest

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,7 +8,7 @@ recommonmark >= 0.5.0
 docstr-coverage
 pylint
 atomicwrites
-opencv-python
+opencv-python-headless
 deprecated
 click
 twine

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
+autopep8
 pytest >= 4.0.0
 generateDS == 2.35.20
 coverage >= 4.5.2

--- a/tests/model/test_agent.py
+++ b/tests/model/test_agent.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 
-from ocrd_models import OcrdAgent
+from ocrd_models import (
+    OcrdAgent
+)
+from tests.base import (
+    main
+)
 
 
 def test_init_role_no_name():
     ag = OcrdAgent(role='FOO')
-    assert 'FOO' == ag.role
-    assert None == ag.name
+    assert ag.role == 'FOO'
+    assert ag.name is None
 
 
 def test_init_role_as_string():
@@ -17,18 +22,22 @@ def test_init_role_as_string():
 
 def test_init_otherrole_and_othertype():
     ag = OcrdAgent(otherrole='BAR', othertype='x')
-    assert 'OTHER' == ag.role
-    assert 'BAR' == ag.otherrole
-    assert 'x' == ag.othertype
+    assert ag.role == 'OTHER'
+    assert ag.otherrole == 'BAR'
+    assert ag.othertype == 'x'
 
 
 def test_init_othertype():
     ag = OcrdAgent(othertype='foobar')
-    assert 'OTHER' == ag.type
+    assert ag.type == 'OTHER'
 
 
 def test_set_name():
     ag = OcrdAgent(name='foobar')
-    assert 'foobar' == ag.name
-    ag.name = 'barfoo'
-    assert 'barfoo' == ag.name
+    assert ag.name == 'foobar'
+    ag.name = 'barfoo' 
+    assert ag.name == 'barfoo'
+
+
+if __name__ == '__main__':
+    main(__file__)

--- a/tests/model/test_agent.py
+++ b/tests/model/test_agent.py
@@ -1,32 +1,34 @@
-from tests.base import TestCase, assets, main # pylint: disable=unused-import
+# -*- coding: utf-8 -*-
 
 from ocrd_models import OcrdAgent
 
-# pylint: disable=no-member
-class TestOcrdAgent(TestCase):
 
-    def test_basic1(self):
-        ag = OcrdAgent(role='FOO')
-        self.assertEqual(ag.role, 'FOO')
-        self.assertEqual(ag.name, None)
-        self.assertEqual(str(ag), '<OcrdAgent [type=---, othertype=---, role=FOO, otherrole=---, name=---]/>')
+def test_init_role_no_name():
+    ag = OcrdAgent(role='FOO')
+    assert 'FOO' == ag.role
+    assert None == ag.name
 
-    def test_basic2(self):
-        ag = OcrdAgent(otherrole='BAR', othertype='x')
-        self.assertEqual(ag.role, 'OTHER')
-        self.assertEqual(ag.otherrole, 'BAR')
-        self.assertEqual(ag.othertype, 'x')
 
-    def test_basic3(self):
-        ag = OcrdAgent(name='foobar')
-        self.assertEqual(ag.name, 'foobar')
-        ag.name = 'barfoo'
-        self.assertEqual(ag.name, 'barfoo')
+def test_init_role_as_string():
+    ag = OcrdAgent(role='FOO')
+    expected = '<OcrdAgent [type=---, othertype=---, role=FOO, otherrole=---, name=---]/>'
+    assert expected == str(ag)
 
-    def test_basic4(self):
-        ag = OcrdAgent(othertype='foobar')
-        self.assertEqual(ag.type, 'OTHER')
-        #  print(ag)
 
-if __name__ == '__main__':
-    main()
+def test_init_otherrole_and_othertype():
+    ag = OcrdAgent(otherrole='BAR', othertype='x')
+    assert 'OTHER' == ag.role
+    assert 'BAR' == ag.otherrole
+    assert 'x' == ag.othertype
+
+
+def test_init_othertype():
+    ag = OcrdAgent(othertype='foobar')
+    assert 'OTHER' == ag.type
+
+
+def test_set_name():
+    ag = OcrdAgent(name='foobar')
+    assert 'foobar' == ag.name
+    ag.name = 'barfoo'
+    assert 'barfoo' == ag.name

--- a/tests/model/test_exif.py
+++ b/tests/model/test_exif.py
@@ -55,7 +55,6 @@ def test_ocrd_exif(path, width, height, xResolution, yResolution, resolution, re
     assert ocrd_exif.compression == compression
 
 
-@pytest.mark.skipif(not sys.platform.startswith('linux'), reason="not platform-independent/stable")
 def test_ocrd_exif_serialize_xml():
     with Image.open(assets.path_to('SBB0000F29300010000/data/OCR-D-IMG/FILE_0001_IMAGE.tif')) as img:
         exif = OcrdExif(img)

--- a/tests/model/test_exif.py
+++ b/tests/model/test_exif.py
@@ -1,82 +1,69 @@
+# -*- coding: utf-8 -*-
+
+import sys
+
 from PIL import Image, __version__ as pil_version
-from tests.base import TestCase, main, assets
+
+import pytest
+
+from tests.base import assets
 
 from ocrd_models import OcrdExif
 
-pil_version_major, pil_version_minor  = [int(x) for x in pil_version.split('.')][:2]
-pil_below_83 = pil_version_major < 8 or (pil_version_major == 8 and pil_version_minor < 3)
-
-# pylint: disable=no-member
-class TestOcrdExif(TestCase):
-
-    def test_str(self):
-        with Image.open(assets.path_to('SBB0000F29300010000/data/OCR-D-IMG/FILE_0001_IMAGE.tif')) as img:
-            exif = OcrdExif(img)
-        print(str(exif.to_xml()))
-        # XXX not platform-independent/stable
-        #  self.assertEqual(
-        #      exif.to_xml(),
-        #      '<exif><width>2875</width><height>3749</height><photometricInterpretation>RGB</photometricInterpretation><compression>jpeg</compression><photometric_interpretation>None</photometric_interpretation><xResolution>300.0</xResolution><yResolution>300.0</yResolution><resolutionUnit>inches</resolutionUnit></exif>'
-        #  )
+pil_version_major, pil_version_minor = [
+    int(x) for x in pil_version.split('.')][:2]
+pil_below_83 = pil_version_major < 8 or (
+    pil_version_major == 8 and pil_version_minor < 3)
 
 
-    def test_tiff(self):
-        with Image.open(assets.path_to('SBB0000F29300010000/data/OCR-D-IMG/FILE_0001_IMAGE.tif')) as img:
-            exif = OcrdExif(img)
-        self.assertEqual(exif.width, 2875)
-        self.assertEqual(exif.height, 3749)
-        self.assertEqual(exif.xResolution, 300)
-        self.assertEqual(exif.yResolution, 300)
-        self.assertEqual(exif.resolution, 300)
-        self.assertEqual(exif.compression, 'jpeg')
-        self.assertEqual(exif.photometricInterpretation, 'RGB')
-        self.assertEqual(exif.resolutionUnit, 'inches')
+@pytest.mark.parametrize("path,width,height,xResolution,yResolution,resolution,resolutionUnit,photometricInterpretation,compression", [
+    ('SBB0000F29300010000/data/OCR-D-IMG/FILE_0001_IMAGE.tif',
+     2875, 3749, 300, 300, 300, 'inches', 'RGB', 'jpeg'),
+    ('kant_aufklaerung_1784-binarized/data/OCR-D-IMG-BIN/BIN_0020.png',
+     1457, 2084, 295 if pil_below_83 else 294, 295 if pil_below_83 else 294, 295 if pil_below_83 else 294, 'inches', '1', None),
+    ('scribo-test/data/OCR-D-PRE-BIN-SAUVOLA/OCR-D-PRE-BIN-SAUVOLA_0001-BIN_sauvola.png',
+     2097, 3062, 1, 1, 1, 'inches', '1', None),
+    ('leptonica_samples/data/OCR-D-IMG/OCR-D-IMG_1555_007.jpg',
+     944, 1472, 1, 1, 1, 'inches', 'RGB', None),
+    ('kant_aufklaerung_1784-jp2/data/OCR-D-IMG/INPUT_0020.jp2',
+     1457, 2084, 1, 1, 1, 'inches', 'RGB', None)
+])
+def test_ocrd_exif(path, width, height, xResolution, yResolution, resolution, resolutionUnit, photometricInterpretation, compression):
+    """Check EXIF attributes for different input formats
+    * tiff
+    * binarized png
+    * png
+    * jpg
+    * jp2
+    """
 
-    def test_png1(self):
-        with Image.open(assets.path_to('kant_aufklaerung_1784-binarized/data/OCR-D-IMG-BIN/BIN_0020.png')) as img:
-            exif = OcrdExif(img)
-        self.assertEqual(exif.width, 1457)
-        self.assertEqual(exif.height, 2084)
-        self.assertEqual(exif.xResolution, 295 if pil_below_83 else 294)
-        self.assertEqual(exif.yResolution, 295 if pil_below_83 else 294)
-        self.assertEqual(exif.resolution, 295 if pil_below_83 else 294)
-        self.assertEqual(exif.resolutionUnit, 'inches')
-        self.assertEqual(exif.compression, None)
-        self.assertEqual(exif.photometricInterpretation, '1')
+    with Image.open(assets.path_to(path)) as img:
+        ocrd_exif = OcrdExif(img)
+    assert ocrd_exif.width == width
+    assert ocrd_exif.height == height
+    assert ocrd_exif.xResolution == xResolution
+    assert ocrd_exif.yResolution == yResolution
+    assert ocrd_exif.resolution == resolution
+    assert ocrd_exif.resolutionUnit == resolutionUnit
+    assert ocrd_exif.photometricInterpretation == photometricInterpretation
+    # pylint: disable=no-member
+    assert ocrd_exif.compression == compression
 
-    def test_png2(self):
-        with Image.open(assets.path_to('scribo-test/data/OCR-D-PRE-BIN-SAUVOLA/OCR-D-PRE-BIN-SAUVOLA_0001-BIN_sauvola.png')) as img:
-            exif = OcrdExif(img)
-        self.assertEqual(exif.width, 2097)
-        self.assertEqual(exif.height, 3062)
-        self.assertEqual(exif.xResolution, 1)
-        self.assertEqual(exif.yResolution, 1)
-        self.assertEqual(exif.resolution, 1)
-        self.assertEqual(exif.photometricInterpretation, '1')
-        self.assertEqual(exif.resolutionUnit, 'inches')
 
-    def test_jpg(self):
-        with Image.open(assets.path_to('leptonica_samples/data/OCR-D-IMG/OCR-D-IMG_1555_007.jpg')) as img:
-            exif = OcrdExif(img)
-        self.assertEqual(exif.width, 944)
-        self.assertEqual(exif.height, 1472)
-        self.assertEqual(exif.xResolution, 1)
-        self.assertEqual(exif.yResolution, 1)
-        self.assertEqual(exif.resolution, 1)
-        self.assertEqual(exif.resolutionUnit, 'inches')
-        self.assertEqual(exif.photometricInterpretation, 'RGB')
-        self.assertEqual(exif.resolutionUnit, 'inches')
-
-    def test_jp2(self):
-        with Image.open(assets.path_to('kant_aufklaerung_1784-jp2/data/OCR-D-IMG/INPUT_0020.jp2')) as img:
-            exif = OcrdExif(img)
-        self.assertEqual(exif.width, 1457)
-        self.assertEqual(exif.height, 2084)
-        self.assertEqual(exif.xResolution, 1)
-        self.assertEqual(exif.yResolution, 1)
-        self.assertEqual(exif.resolution, 1)
-        self.assertEqual(exif.photometricInterpretation, 'RGB')
-        self.assertEqual(exif.resolutionUnit, 'inches')
-
-if __name__ == '__main__':
-    main(__file__)
+@pytest.mark.skipif(not sys.platform.startswith('linux'), reason="not platform-independent/stable")
+def test_ocrd_exif_serialize_xml():
+    with Image.open(assets.path_to('SBB0000F29300010000/data/OCR-D-IMG/FILE_0001_IMAGE.tif')) as img:
+        exif = OcrdExif(img)
+    expected = ('<exif>'
+                '<width>2875</width>'
+                '<height>3749</height>'
+                '<photometricInterpretation>RGB</photometricInterpretation>'
+                '<n_frames>1</n_frames>'
+                '<compression>jpeg</compression>'
+                '<photometric_interpretation>None</photometric_interpretation>'
+                '<xResolution>300</xResolution>'
+                '<yResolution>300</yResolution>'
+                '<resolutionUnit>inches</resolutionUnit>'
+                '<resolution>300</resolution>'
+                '</exif>')
+    assert expected == exif.to_xml()

--- a/tests/model/test_exif.py
+++ b/tests/model/test_exif.py
@@ -6,9 +6,14 @@ from PIL import Image, __version__ as pil_version
 
 import pytest
 
-from tests.base import assets
+from tests.base import (
+    assets,
+    main
+)
 
 from ocrd_models import OcrdExif
+
+# pylint: disable=no-member
 
 pil_version_major, pil_version_minor = [
     int(x) for x in pil_version.split('.')][:2]
@@ -46,7 +51,7 @@ def test_ocrd_exif(path, width, height, xResolution, yResolution, resolution, re
     assert ocrd_exif.resolution == resolution
     assert ocrd_exif.resolutionUnit == resolutionUnit
     assert ocrd_exif.photometricInterpretation == photometricInterpretation
-    # pylint: disable=no-member
+
     assert ocrd_exif.compression == compression
 
 
@@ -67,3 +72,7 @@ def test_ocrd_exif_serialize_xml():
                 '<resolution>300</resolution>'
                 '</exif>')
     assert expected == exif.to_xml()
+
+
+if __name__ == '__main__':
+    main(__file__)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,157 +1,281 @@
 # -*- coding: utf-8 -*-
 
-from os.path import join as pjoin
-from pathlib import Path
-from tempfile import TemporaryDirectory
+import os
+import shutil
 
-from tests.base import TestCase, assets, main, copy_of_directory
+from pathlib import (
+    Path
+)
+from unittest import (
+    mock
+)
+
+import pytest
+
+from tests.base import (
+    assets, 
+    main
+)
 
 from ocrd.resolver import Resolver
-from ocrd_utils import pushd_popd, initLogging
+from ocrd_utils import pushd_popd
+
+# set pylint once on module level
+# pylint: disable=protected-access
 
 METS_HEROLD = assets.url_of('SBB0000F29300010000/data/mets.xml')
 FOLDER_KANT = assets.path_to('kant_aufklaerung_1784')
+DATA_KANT = {'mets.xml': (os.path.join(FOLDER_KANT, 'data', 'mets.xml'), 'text/xml'),
+             'INPUT_0017.tif': (os.path.join(FOLDER_KANT, 'data', 'OCR-D-IMG', 'INPUT_0017.tif'), 'image/tiff'),
+             'INPUT_0020.tif': (os.path.join(FOLDER_KANT, 'data', 'OCR-D-IMG', 'INPUT_0020.tif'), 'image/tiff'),
+             'PAGE_0017_ALTO.xml': (os.path.join(FOLDER_KANT, 'data', 'OCR-D-GT-ALTO', 'PAGE_0017_ALTO.xml'), 'text/xml'),
+             'PAGE_0020_ALTO.xml': (os.path.join(FOLDER_KANT, 'data', 'OCR-D-GT-ALTO', 'PAGE_0020_ALTO.xml'), 'text/xml'),
+             'PAGE_0017_PAGE.xml': (os.path.join(FOLDER_KANT, 'data', 'OCR-D-GT-PAGE', 'PAGE_0017_PAGE.xml'), 'text/xml'),
+             'PAGE_0020_PAGE.xml': (os.path.join(FOLDER_KANT, 'data', 'OCR-D-GT-PAGE', 'PAGE_0020_PAGE.xml'), 'text/xml'),
+             }
 
-# pylint: disable=redundant-unittest-assert, broad-except, deprecated-method, too-many-public-methods
 
-class TestResolver(TestCase):
+def _get_kant_data(key):
+    if key in DATA_KANT.keys():
+        (path, mime) = DATA_KANT[key]
+        with open(path, mode='rb') as _file:
+            return (_file.read(), mime)
 
-    def setUp(self):
-        initLogging()
-        self.resolver = Resolver()
-        super().setUp()
 
-    def test_workspace_from_url_bad(self):
-        with self.assertRaisesRegex(Exception, "Must pass 'mets_url'"):
-            self.resolver.workspace_from_url(None)
+def request_behavior(*args):
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.headers = {}
+    the_key = args[0].split('/')[-1]
+    if the_key in DATA_KANT:
+        (cnt, mime) = _get_kant_data(the_key)
+        resp.content = cnt
+        resp.headers = {'Content-Type': mime}
+    return resp
 
-    def test_workspace_from_url_tempdir(self):
-        self.resolver.workspace_from_url(
-            mets_basename='foo.xml',
-            mets_url='https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xml')
 
-    def test_workspace_from_url_download(self):
-        url_src = 'https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xml'
-        #url_src = 'http://digital.bibliothek.uni-halle.de/hd/oai/?verb=GetRecord&metadataPrefix=mets&mode=xml&identifier=9049'
-        with TemporaryDirectory() as dst_dir:
-            self.resolver.workspace_from_url(
-                url_src,
-                mets_basename='foo.xml',
-                dst_dir=dst_dir,
-                download=True)
+def test_workspace_from_url_bad():
+    with pytest.raises(Exception) as exc:
+        Resolver().workspace_from_url(None)
 
-    def test_workspace_from_url_no_clobber(self):
-        with TemporaryDirectory() as dst_dir:
-            src_mets = Path(assets.path_to('kant_aufklaerung_1784-binarized/data/mets.xml'))
-            dst_mets = Path(dst_dir, 'mets.xml')
-            dst_mets.write_text(src_mets.read_text())
-            self.resolver.workspace_from_url(
-                    'https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xml',
-                    clobber_mets=False,
-                    dst_dir=dst_dir)
+    # check exception
+    assert "Must pass 'mets_url'" in str(exc)
 
-    def test_workspace_from_url_404(self):
-        with self.assertRaisesRegex(Exception, "HTTP request failed"):
-            self.resolver.workspace_from_url(mets_url='https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xmlX')
 
-    def test_workspace_from_url_rel_dir(self):
-        with TemporaryDirectory() as dst_dir:
-            bogus_dst_dir = '../../../../../../../../../../../../../../../../%s'  % dst_dir[1:]
-            with pushd_popd(FOLDER_KANT):
-                ws1 = self.resolver.workspace_from_url('data/mets.xml', dst_dir=bogus_dst_dir)
-                self.assertEqual(ws1.mets_target, pjoin(dst_dir, 'mets.xml'))
-                self.assertEqual(ws1.directory, dst_dir)
+@mock.patch("requests.get")
+def test_workspace_from_url_kant(mock_request, tmp_path):
 
-    def test_workspace_from_url0(self):
-        workspace = self.resolver.workspace_from_url(METS_HEROLD)
-        #  print(workspace.mets)
-        input_files = workspace.mets.find_all_files(fileGrp='OCR-D-IMG')
-        #  print [str(f) for f in input_files]
-        image_file = input_files[0]
-        #  print(image_file)
-        f = workspace.download_file(image_file)
-        self.assertEqual('%s.tif' % f.ID, 'FILE_0001_IMAGE.tif')
-        self.assertEqual(f.local_filename, 'OCR-D-IMG/FILE_0001_IMAGE.tif')
-        #  print(f)
+    # arrange
+    url_src = 'https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xml'
+    mock_request.side_effect = request_behavior
+    dst_dir = tmp_path / 'workspace_kant'
+    dst_dir.mkdir()
 
-    # pylint: disable=protected-access
-    def test_resolve_image0(self):
-        workspace = self.resolver.workspace_from_url(METS_HEROLD)
-        input_files = workspace.mets.find_all_files(fileGrp='OCR-D-IMG')
-        f = input_files[0]
-        print(f.url)
-        img_pil1 = workspace._resolve_image_as_pil(f.url)
-        print(f.url)
-        self.assertEqual(img_pil1.size, (2875, 3749))
-        img_pil2 = workspace._resolve_image_as_pil(f.url, [[0, 0], [1, 1]])
-        print(f.url)
-        self.assertEqual(img_pil2.size, (1, 1))
-        img_pil2 = workspace._resolve_image_as_pil(f.url, [[0, 0], [1, 1]])
+    # act
+    resolver = Resolver()
+    resolver.workspace_from_url(
+        url_src, mets_basename='foo.xml', dst_dir=dst_dir)
 
-    # pylint: disable=protected-access
-    def test_resolve_image_grayscale(self):
-        workspace = self.resolver.workspace_from_url(pjoin(assets.url_of('kant_aufklaerung_1784-binarized'), 'data/mets.xml'))
-        img_url = 'OCR-D-IMG-NRM/OCR-D-IMG-NRM_0017.png'
-        img_pil1 = workspace.resolve_image_as_pil(img_url)
-        self.assertEqual(img_pil1.size, (1457, 2083))
-        img_pil2 = workspace._resolve_image_as_pil(img_url, [[0, 0], [1, 1]])
-        self.assertEqual(img_pil2.size, (1, 1))
+    # assert
+    local_path = dst_dir / 'foo.xml'
+    assert os.path.isfile(str(local_path))
+    # 1 time data was requested
+    assert mock_request.call_count == 1
 
-    # pylint: disable=protected-access
-    def test_resolve_image_bitonal(self):
-        workspace = self.resolver.workspace_from_url(pjoin(assets.url_of('kant_aufklaerung_1784-binarized'), 'data/mets.xml'))
-        img_url = 'OCR-D-IMG-1BIT/OCR-D-IMG-1BIT_0017.png'
-        img_pil1 = workspace._resolve_image_as_pil(img_url)
-        self.assertEqual(img_pil1.size, (1457, 2083))
-        img_pil2 = workspace._resolve_image_as_pil(img_url, [[0, 0], [1, 1]])
-        self.assertEqual(img_pil2.size, (1, 1))
 
-    def test_workspace_from_nothing(self):
-        ws1 = self.resolver.workspace_from_nothing(None)
-        self.assertIsNotNone(ws1.mets)
+@mock.patch("requests.get")
+def test_workspace_from_url_kant_with_resources(mock_request, tmp_path):
 
-    def test_workspace_from_nothing_makedirs(self):
-        with TemporaryDirectory() as tempdir:
-            non_existant_dir = Path(tempdir, 'target')
-            ws1 = self.resolver.workspace_from_nothing(non_existant_dir)
-            self.assertEqual(ws1.directory, non_existant_dir)
+    # arrange
+    url_src = 'https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xml'
+    mock_request.side_effect = request_behavior
+    dst_dir = tmp_path / 'workspace_kant'
+    dst_dir.mkdir()
 
-    def test_workspace_from_nothing_noclobber(self):
-        with TemporaryDirectory() as tempdir:
-            ws2 = self.resolver.workspace_from_nothing(tempdir)
-            self.assertEqual(ws2.directory, tempdir)
-            with self.assertRaisesRegex(Exception, "METS 'mets.xml' already exists in '%s' and clobber_mets not set" % tempdir):
-                # must fail because tempdir was just created
-                self.resolver.workspace_from_nothing(tempdir)
+    # act
+    resolver = Resolver()
+    resolver.workspace_from_url(
+        url_src,
+        mets_basename='kant_aufklaerung_1784.xml',
+        dst_dir=dst_dir,
+        download=True)
 
-    def test_download_to_directory_badargs_url(self):
-        with self.assertRaisesRegex(Exception, "'url' must be a string"):
-            self.resolver.download_to_directory(None, None)
+    # assert files present under local tmp_path
+    local_path_mets = dst_dir / 'kant_aufklaerung_1784.xml'
+    assert os.path.isfile(str(local_path_mets))
+    local_path_img1 = dst_dir / 'OCR-D-IMG' / 'INPUT_0017.tif'
+    assert os.path.isfile(str(local_path_img1))
+    local_path_page1 = dst_dir / 'OCR-D-GT-PAGE' / 'PAGE_0017_PAGE.xml'
+    assert os.path.isfile(str(local_path_page1))
 
-    def test_download_to_directory_badargs_directory(self):
-        with self.assertRaisesRegex(Exception, "'directory' must be a string"):
-            self.resolver.download_to_directory(None, 'foo')
+    # 1 METS/MODS + 2 images + 4 OCR files = 7 requests
+    assert mock_request.call_count == 7
 
-    def test_download_to_directory_default(self):
-        with copy_of_directory(FOLDER_KANT) as src:
-            with TemporaryDirectory() as dst:
-                fn = self.resolver.download_to_directory(dst, pjoin(src, 'data/mets.xml'))
-                self.assertEqual(fn, 'mets.xml')
-                self.assertTrue(Path(dst, fn).exists())
 
-    def test_download_to_directory_basename(self):
-        with copy_of_directory(FOLDER_KANT) as src:
-            with TemporaryDirectory() as dst:
-                fn = self.resolver.download_to_directory(dst, pjoin(src, 'data/mets.xml'), basename='foo')
-                self.assertEqual(fn, 'foo')
-                self.assertTrue(Path(dst, fn).exists())
+@mock.patch("requests.get")
+def test_workspace_from_url_kant_with_resources_existing_local(mock_request, tmp_path):
 
-    def test_download_to_directory_subdir(self):
-        with copy_of_directory(FOLDER_KANT) as src:
-            with TemporaryDirectory() as dst:
-                fn = self.resolver.download_to_directory(dst, pjoin(src, 'data/mets.xml'), subdir='baz')
-                self.assertEqual(fn, pjoin('baz', 'mets.xml'))
-                self.assertTrue(Path(dst, fn).exists())
+    # arrange
+    url_src = 'https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xml'
+    mock_request.side_effect = request_behavior
+    dst_dir = tmp_path / 'workspace_kant'
+    dst_dir.mkdir()
+    src_mets = Path(assets.path_to(
+        'kant_aufklaerung_1784-binarized/data/mets.xml'))
+    dst_mets = Path(dst_dir, 'mets.xml')
+    shutil.copyfile(src_mets, dst_mets)
+
+    # act
+    Resolver().workspace_from_url(url_src,
+                                  clobber_mets=False,
+                                  dst_dir=dst_dir)
+
+    # assert
+    # no real request was made, since mets already present
+    assert mock_request.call_count == 0
+
+
+@mock.patch("requests.get")
+def test_workspace_from_url_404(mock_request):
+    """Expected behavior when try create workspace from invalid online target
+    """
+
+    # arrange
+    url_404 = 'https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xmlX'
+    mock_request.side_effect = Exception('HTTP request failed')
+
+    with pytest.raises(Exception) as exc:
+        Resolver().workspace_from_url(mets_url=url_404)
+
+    # assert
+    assert "HTTP request failed" in str(exc)
+    assert mock_request.call_count == 1
+
+
+def test_workspace_from_url_with_rel_dir(tmp_path):
+    bogus_dst_dir = '../../../../../../../../../../../../../../../../%s' % str(tmp_path)[
+        1:]
+
+    # act
+    with pushd_popd(FOLDER_KANT):
+        ws1 = Resolver().workspace_from_url('data/mets.xml', dst_dir=bogus_dst_dir)
+
+    # assert
+    assert os.path.join(tmp_path, 'mets.xml') == ws1.mets_target
+    assert str(tmp_path) == ws1.directory
+
+
+def test_workspace_from_url0():
+
+    # act
+    workspace = Resolver().workspace_from_url(METS_HEROLD)
+    input_files = workspace.mets.find_all_files(fileGrp='OCR-D-IMG')
+    image_file = input_files[0]
+    f = workspace.download_file(image_file)
+
+    # assert
+    assert '%s.tif' % f.ID == 'FILE_0001_IMAGE.tif'
+    assert f.local_filename == 'OCR-D-IMG/FILE_0001_IMAGE.tif'
+
+
+def test_resolve_image0():
+    workspace = Resolver().workspace_from_url(METS_HEROLD)
+    input_files = workspace.mets.find_all_files(fileGrp='OCR-D-IMG')
+    f = input_files[0]
+    img_pil1 = workspace._resolve_image_as_pil(f.url)
+    assert img_pil1.size == (2875, 3749)
+    img_pil2 = workspace._resolve_image_as_pil(f.url, [[0, 0], [1, 1]])
+    assert img_pil2.size == (1, 1)
+
+
+@pytest.mark.parametrize(
+    "image_url,size1,size2",
+    [('OCR-D-IMG-NRM/OCR-D-IMG-NRM_0017.png', (1457, 2083), (1, 1)),
+     ('OCR-D-IMG-1BIT/OCR-D-IMG-1BIT_0017.png', (1457, 2083), (1, 1)),
+     ])
+def test_resolve_image_grayscale(image_url, size1, size2):
+    url_path = os.path.join(assets.url_of(
+        'kant_aufklaerung_1784-binarized'), 'data/mets.xml')
+    workspace = Resolver().workspace_from_url(url_path)
+    img_url = image_url
+    img_pil1 = workspace.resolve_image_as_pil(img_url)
+    assert img_pil1.size == size1
+    img_pil2 = workspace._resolve_image_as_pil(img_url, [[0, 0], [1, 1]])
+    assert img_pil2.size == size2
+
+
+def test_workspace_from_nothing():
+    ws1 = Resolver().workspace_from_nothing(None)
+    assert ws1.mets
+
+
+def test_workspace_from_nothing_makedirs(tmp_path):
+    non_existant_dir = tmp_path / 'target'
+    ws1 = Resolver().workspace_from_nothing(non_existant_dir)
+    assert ws1.directory == non_existant_dir
+
+
+def test_workspace_from_nothing_noclobber(tmp_path):
+    """Attempt to re-create workspace shall fail because already created
+    """
+
+    ws2 = Resolver().workspace_from_nothing(tmp_path)
+    assert ws2.directory == tmp_path
+
+    with pytest.raises(Exception) as exc:
+        Resolver().workspace_from_nothing(tmp_path)
+
+    # assert
+    the_msg = "METS 'mets.xml' already exists in '%s' and clobber_mets not set" % tmp_path
+    assert the_msg in str(exc)
+
+
+@pytest.mark.parametrize(
+    "url,basename,exc_msg",
+    [(None, None, "'url' must be a string"),
+     (None, 'foo', "'directory' must be a string")]
+)
+def test_download_to_directory_with_badargs(url, basename, exc_msg):
+
+    with pytest.raises(Exception) as exc:
+        Resolver().download_to_directory(url, basename)
+
+    # assert exception message contained
+    assert exc_msg in str(exc)
+
+
+@pytest.fixture(name='fixture_copy_kant')
+def _fixture_copy_kant(tmp_path):
+    temporary_phil = tmp_path / 'kant_aufklaerung_1784'
+    shutil.copytree(FOLDER_KANT, temporary_phil)
+    yield temporary_phil
+
+
+def test_download_to_directory_default(fixture_copy_kant):
+    tmp_root = fixture_copy_kant.parent
+    phil_data = fixture_copy_kant / 'data' / 'mets.xml'
+    fn = Resolver().download_to_directory(str(tmp_root), str(phil_data))
+    assert Path(tmp_root, fn).exists()
+    assert fn == 'mets.xml'
+
+
+def test_download_to_directory_basename(fixture_copy_kant):
+    tmp_root = fixture_copy_kant.parent
+    phil_data = fixture_copy_kant / 'data' / 'mets.xml'
+    fn = Resolver().download_to_directory(
+        str(tmp_root), str(phil_data), basename='foo')
+    assert Path(tmp_root, fn).exists()
+    assert fn == 'foo'
+
+
+def test_download_to_directory_subdir(fixture_copy_kant):
+    tmp_root = fixture_copy_kant.parent
+    phil_data = fixture_copy_kant / 'data' / 'mets.xml'
+    fn = Resolver().download_to_directory(
+        str(tmp_root), str(phil_data), subdir='baz')
+    assert Path(tmp_root, fn).exists()
+    assert fn == 'baz/mets.xml'
+
 
 if __name__ == '__main__':
     main(__file__)

--- a/tests/test_resolver_oai.py
+++ b/tests/test_resolver_oai.py
@@ -10,13 +10,16 @@ from ocrd.resolver import Resolver
 from ocrd_models.utils import extract_mets_from_oai_content
 from ocrd_utils import getLogger, initLogging, LOG_FORMAT
 
+
 @fixture(name="response_dir")
 def fixture_response_dir(tmpdir):
     src = './tests/data/response/oai_get_record_2200909.xml'
-    target_file = str(tmpdir.mkdir('responses').join('oai_get_record_2200909.xml'))
+    target_file = str(tmpdir.mkdir('responses').join(
+        'oai_get_record_2200909.xml'))
     copy(src, target_file)
     src2 = './tests/data/response/mets_kant_aufklaerung_1784.xml'
-    target_file2 = str(tmpdir.join('responses').join('mets_kant_aufklaerung_1784.xml'))
+    target_file2 = str(tmpdir.join('responses').join(
+        'mets_kant_aufklaerung_1784.xml'))
     copy(src2, target_file2)
     return dirname(target_file)
 
@@ -26,6 +29,7 @@ def fixture_oai_2200909_content(response_dir):
     data_path = join(response_dir, 'oai_get_record_2200909.xml')
     with open(data_path, 'rb') as f:
         return f.read()
+
 
 @fixture(name="plain_xml_response_content")
 def fixture_xml_kant_content(response_dir):
@@ -42,12 +46,14 @@ def test_extract_mets_from_oai_content(oai_response_content):
     assert result.startswith(expected_start)
     assert b'OAI-PHM' not in result
 
+
 def test_handle_response_mets(plain_xml_response_content):
     """Ensure plain XML/Text Response is not broken"""
 
     result = extract_mets_from_oai_content(plain_xml_response_content)
     expected_start = b'<?xml version="1.0"'
     assert result.startswith(expected_start)
+
 
 @mock.patch("requests.get")
 def test_handle_common_oai_response(mock_get, response_dir, oai_response_content):
@@ -93,10 +99,11 @@ def test_handle_response_for_invalid_content(mock_get, response_dir):
     # act
     resolver.download_to_directory(response_dir, url)
 
-    # assert behavior
+    # assert
     mock_get.assert_called_once_with(url)
     log_output = capt.getvalue()
     assert 'WARNING ocrd_models.utils.handle_oai_response' in log_output
+
 
 if __name__ == '__main__':
     main(__file__)


### PR DESCRIPTION
Refactoring
* tests/model/test_agent.py (fairly straight-forward-simple-example)
* tests/model/test_exif.py (use test params)
* tests/test_resolver.py (use mocks instead of requesting assets over network, reduces test execution drastically for poor networks, use params + fixtures as well)
* test/test_resolver_oai.py (just apply autopep8-formatting to file)

_all_ modules contain still the `main` - call at the end