### PR TITLE
Feat/rfct/pytest2

### DIFF
--- a/tests/model/test_ocrd_file.py
+++ b/tests/model/test_ocrd_file.py
@@ -95,7 +95,7 @@ def test_create_ocrd_file_with_defaults_basename_wo_extension(local_filename, wo
     assert f.basename_without_extension == wo_extension
 
 
-@pytest.mark.xfail(reason="not possible anymore as of Fri Sep  3 13:11:00 CEST 2021")
+@pytest.mark.skip(reason="not possible anymore as of Fri Sep  3 13:11:00 CEST 2021")
 def test_file_group_wo_parent():
     with pytest.raises(ValueError) as val_err:
         OcrdFile(None)
@@ -105,11 +105,8 @@ def test_file_group_wo_parent():
 def test_file_group_wo_parent_new_version():
     """Test for new error message
     """
-    with pytest.raises(ValueError) as val_err:
+    with pytest.raises(ValueError, match=r"Must provide mets:file element this OcrdFile represent"):
         OcrdFile(None)
-    assert "Must provide mets:file element this OcrdFile represent" in str(
-        val_err.value)
-
 
 def test_ocrd_file_equality():
     mets = OcrdMets.empty_mets()

--- a/tests/model/test_ocrd_file.py
+++ b/tests/model/test_ocrd_file.py
@@ -1,97 +1,138 @@
-from tests.base import TestCase, main, create_ocrd_file, create_ocrd_file_with_defaults
-from ocrd_models import OcrdMets
+# -*- coding: utf-8 -*-
 
-class TestOcrdFile(TestCase):
+import pytest
 
-    def test_ocrd_file_without_id(self):
-        with self.assertRaisesRegex(ValueError, "set ID"):
-            create_ocrd_file('FOO')
+from tests.base import (
+    main, 
+    create_ocrd_file, 
+    create_ocrd_file_with_defaults
+)
+from ocrd_models import (
+    OcrdMets,
+    OcrdFile,
+)
 
-    def test_ocrd_file_without_filegrp(self):
-        with self.assertRaisesRegex(ValueError, "set fileGrp"):
-            create_ocrd_file(None, ID='foo')
 
-    def test_loctype(self):
-        f = create_ocrd_file_with_defaults()
-        self.assertEqual(f.loctype, 'OTHER')
-        self.assertEqual(f.otherloctype, 'FILE')
-        f.otherloctype = 'foo'
-        self.assertEqual(f.otherloctype, 'foo')
-        f.loctype = 'URN'
-        self.assertEqual(f.loctype, 'URN')
-        self.assertEqual(f.otherloctype, None)
-        f.otherloctype = 'foo'
-        self.assertEqual(f.loctype, 'OTHER')
+def test_ocrd_file_without_id():
+    with pytest.raises(ValueError) as val_err:
+        create_ocrd_file('FOO')
 
-    def test_set_url(self):
-        f = create_ocrd_file_with_defaults()
-        f.url = None
-        f.url = 'http://foo'
-        f.url = 'http://bar'
-        self.assertEqual(f.url, 'http://bar')
+    assert "set ID" in str(val_err.value)
 
-    def test_constructor_url(self):
-        f = create_ocrd_file_with_defaults(url="foo")
-        self.assertEqual(f.url, 'foo')
-        self.assertEqual(f.local_filename, 'foo')
 
-    def test_set_id_none(self):
-        f = create_ocrd_file_with_defaults()
-        f.ID = 'foo12'
-        self.assertEqual(f.ID, 'foo12')
-        f.ID = None
-        self.assertEqual(f.ID, 'foo12')
+def test_ocrd_file_without_filegrp():
+    with pytest.raises(ValueError) as val_err:
+        create_ocrd_file(None, ID='foo')
+    assert "set fileGrp" in str(val_err.value)
 
-    def test_basename(self):
-        f = create_ocrd_file_with_defaults(local_filename='/tmp/foo/bar/foo.bar')
-        self.assertEqual(f.basename, 'foo.bar')
 
-    def test_basename_from_url(self):
-        f = create_ocrd_file_with_defaults(url="http://foo.bar/quux")
-        self.assertEqual(f.basename, 'quux')
+def test_set_loctype():
+    f = create_ocrd_file_with_defaults()
+    assert f.loctype == 'OTHER'
+    assert f.otherloctype == 'FILE'
+    f.otherloctype = 'foo'
+    assert f.otherloctype == 'foo'
+    f.loctype = 'URN'
+    assert f.loctype == 'URN'
+    assert f.otherloctype == None
+    f.otherloctype = 'foo'
+    assert f.loctype, 'OTHER'
 
-    def test_extension(self):
-        f = create_ocrd_file_with_defaults(local_filename='/tmp/foo/bar/foo.bar')
-        self.assertEqual(f.extension, '.bar')
 
-    def test_extension_tar(self):
-        f = create_ocrd_file_with_defaults(local_filename='/tmp/foo/bar/foo.tar.gz')
-        self.assertEqual(f.extension, '.tar.gz')
+def test_set_url():
+    f = create_ocrd_file_with_defaults()
+    f.url = None
+    f.url = 'http://foo'
+    f.url = 'http://bar'
+    assert f.url == 'http://bar'
 
-    def test_basename_without_extension(self):
-        f = create_ocrd_file_with_defaults(local_filename='/tmp/foo/bar/foo.bar')
-        self.assertEqual(f.basename_without_extension, 'foo')
 
-    def test_basename_without_extension_tar(self):
-        f = create_ocrd_file_with_defaults(local_filename='/tmp/foo/bar/foo.tar.gz')
-        self.assertEqual(f.basename_without_extension, 'foo')
+def test_constructor_url():
+    f = create_ocrd_file_with_defaults(url="foo")
+    assert f.url == 'foo'
+    assert f.local_filename == 'foo'
 
-    # XXX not possible anymore as of Fri Sep  3 13:11:00 CEST 2021
-    # def test_fileGrp_wo_parent(self):
-    #     with self.assertRaisesRegex(ValueError, "not related to METS"):
-    #         f = OcrdFile(None)
 
-    def test_ocrd_file_eq(self):
-        mets = OcrdMets.empty_mets()
-        f1 = mets.add_file('FOO', ID='FOO_1', mimetype='image/tiff')
-        self.assertEqual(f1 == f1, True)
-        self.assertEqual(f1 != f1, False)
-        f2 = mets.add_file('FOO', ID='FOO_2', mimetype='image/tiff')
-        self.assertEqual(f1 == f2, False)
-        f3 = create_ocrd_file_with_defaults(ID='TEMP_1', mimetype='image/tiff')
-        f4 = create_ocrd_file_with_defaults(ID='TEMP_1', mimetype='image/tif')
-        # be tolerant of different equivalent mimetypes
-        self.assertEqual(f3 == f4, True)
-        f5 = mets.add_file('TEMP', ID='TEMP_1', mimetype='image/tiff')
-        self.assertEqual(f3 == f5, True)
+def test_set_id_none():
+    f = create_ocrd_file_with_defaults()
+    f.ID = 'foo12'
+    assert f.ID == 'foo12'
+    f.ID = None
+    assert f.ID == 'foo12'
 
-    def test_fptr_changed_for_change_id(self):
-        mets = OcrdMets.empty_mets()
-        f1 = mets.add_file('FOO', ID='FOO_1', mimetype='image/tiff', pageId='p0001')
-        assert mets.get_physical_pages(for_fileIds=['FOO_1']) == ['p0001']
-        f1.ID = 'BAZ_1'
-        assert mets.get_physical_pages(for_fileIds=['FOO_1']) == [None]
-        assert mets.get_physical_pages(for_fileIds=['BAZ_1']) == ['p0001']
+
+def test_basename():
+    f = create_ocrd_file_with_defaults(local_filename='/tmp/foo/bar/foo.bar')
+    assert f.basename == 'foo.bar'
+
+
+def test_basename_from_url():
+    f = create_ocrd_file_with_defaults(url="http://foo.bar/quux")
+    assert f.basename == 'quux'
+
+
+@pytest.mark.parametrize("local_filename,extension",
+                         [('/tmp/foo/bar/foo.bar', '.bar'),
+                          ('/tmp/foo/bar/foo.tar.gz', '.tar.gz')]
+                         )
+def test_create_ocrd_file_with_defaults_extension(local_filename, extension):
+    """Behavior for ocrd_file_with_defaults
+    """
+
+    f = create_ocrd_file_with_defaults(local_filename=local_filename)
+    assert f.extension == extension
+
+
+@pytest.mark.parametrize("local_filename,wo_extension",
+                         [('/tmp/foo/bar/foo.bar', 'foo'),
+                          ('/tmp/foo/bar/foo.tar.gz', 'foo')]
+                         )
+def test_create_ocrd_file_with_defaults_basename_wo_extension(local_filename, wo_extension):
+    """Behavior for ocrd_file_with_defaults
+    """
+
+    f = create_ocrd_file_with_defaults(local_filename=local_filename)
+    assert f.basename_without_extension == wo_extension
+
+
+@pytest.mark.xfail(reason="not possible anymore as of Fri Sep  3 13:11:00 CEST 2021")
+def test_file_group_wo_parent():
+    with pytest.raises(ValueError) as val_err:
+        OcrdFile(None)
+    assert "not related to METS" in str(val_err.value)
+
+
+def test_file_group_wo_parent_new_version():
+    """Test for new error message
+    """
+    with pytest.raises(ValueError) as val_err:
+        OcrdFile(None)
+    assert "Must provide mets:file element this OcrdFile represent" in str(
+        val_err.value)
+
+
+def test_ocrd_file_equality():
+    mets = OcrdMets.empty_mets()
+    f1 = mets.add_file('FOO', ID='FOO_1', mimetype='image/tiff')
+    f2 = mets.add_file('FOO', ID='FOO_2', mimetype='image/tiff')
+    assert f1 != f2
+    f3 = create_ocrd_file_with_defaults(ID='TEMP_1', mimetype='image/tiff')
+    f4 = create_ocrd_file_with_defaults(ID='TEMP_1', mimetype='image/tif')
+    # be tolerant of different equivalent mimetypes
+    assert f3 == f4
+    f5 = mets.add_file('TEMP', ID='TEMP_1', mimetype='image/tiff')
+    assert f3 == f5
+
+
+def test_fptr_changed_for_change_id():
+    mets = OcrdMets.empty_mets()
+    f1 = mets.add_file('FOO', ID='FOO_1',
+                       mimetype='image/tiff', pageId='p0001')
+    assert mets.get_physical_pages(for_fileIds=['FOO_1']) == ['p0001']
+    f1.ID = 'BAZ_1'
+    assert mets.get_physical_pages(for_fileIds=['FOO_1']) == [None]
+    assert mets.get_physical_pages(for_fileIds=['BAZ_1']) == ['p0001']
+
 
 if __name__ == '__main__':
     main(__file__)

--- a/tests/model/test_ocrd_file.py
+++ b/tests/model/test_ocrd_file.py
@@ -3,8 +3,8 @@
 import pytest
 
 from tests.base import (
-    main, 
-    create_ocrd_file, 
+    main,
+    create_ocrd_file,
     create_ocrd_file_with_defaults
 )
 from ocrd_models import (
@@ -123,8 +123,7 @@ def test_ocrd_file_equality():
 
 def test_fptr_changed_for_change_id():
     mets = OcrdMets.empty_mets()
-    f1 = mets.add_file('FOO', ID='FOO_1',
-                       mimetype='image/tiff', pageId='p0001')
+    f1 = mets.add_file('FOO', ID='FOO_1', mimetype='image/tiff', pageId='p0001')
     assert mets.get_physical_pages(for_fileIds=['FOO_1']) == ['p0001']
     f1.ID = 'BAZ_1'
     assert mets.get_physical_pages(for_fileIds=['FOO_1']) == [None]

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -176,11 +176,20 @@ def test_add_file_id_already_exists(sbb_sample_01):
         'OUTPUT', ID='best-id-ever', mimetype="boop/beep", force=True)
     assert f._el == f2._el
 
+@pytest.mark.xfail(reason='check if 2x same ID are valid')
+def test_add_file_ignore(sbb_sample_01: OcrdMets):
+    """Behavior if ignore-Flag set to true:
+    delegate responsibility to overwrite existing files to user"""
 
-def test_add_file_ignore(sbb_sample_01):
-    sbb_sample_01.add_file('OUTPUT', ID='best-id-ever', mimetype="beep/boop")
-    sbb_sample_01.add_file('OUTPUT', ID='best-id-ever',
+    the_file = sbb_sample_01.add_file('OUTPUT', ID='best-id-ever', mimetype="beep/boop")
+    assert the_file.ID == 'best-id-ever'
+    the_same = sbb_sample_01.add_file('OUTPUT', ID='best-id-ever',
                            mimetype="boop/beep", ignore=True)
+    assert the_same.ID == 'best-id-ever'
+
+    # how many files inserted
+    the_files = list(sbb_sample_01.find_files(ID='best-id-ever'))
+    assert len(the_files) == 1
 
 
 def test_add_file_id_invalid(sbb_sample_01):

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -176,7 +176,7 @@ def test_add_file_id_already_exists(sbb_sample_01):
         'OUTPUT', ID='best-id-ever', mimetype="boop/beep", force=True)
     assert f._el == f2._el
 
-@pytest.mark.xfail(reason='check if 2x same ID are valid')
+@pytest.mark.xfail(reason='2x same ID is valid if ignore == True')
 def test_add_file_ignore(sbb_sample_01: OcrdMets):
     """Behavior if ignore-Flag set to true:
     delegate responsibility to overwrite existing files to user"""

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -1,265 +1,355 @@
+# -*- coding: utf-8 -*-
+
 from datetime import datetime
+
 from os.path import join
-from tests.base import TestCase, main, assets, copy_of_directory
+import shutil
+
+from tests.base import (
+    main,
+    assets,
+)
 
 from ocrd_utils import (
     VERSION,
     MIMETYPE_PAGE
 )
-from ocrd_models import OcrdMets
+from ocrd_models import (
+    OcrdMets
+)
 
-# pylint: disable=protected-access,deprecated-method,too-many-public-methods
-class TestOcrdMets(TestCase):
+import pytest
 
-    def setUp(self):
-        super().setUp()
-        self.mets = OcrdMets(filename=assets.url_of('SBB0000F29300010000/data/mets.xml'))
 
-    def test_unique_identifier(self):
-        self.assertEqual(self.mets.unique_identifier, 'http://resolver.staatsbibliothek-berlin.de/SBB0000F29300010000', 'Right identifier')
-        self.mets.unique_identifier = 'foo'
-        self.assertEqual(self.mets.unique_identifier, 'foo', 'Right identifier after change')
+@pytest.fixture(name='sbb_sample_01')
+def _fixture():
+    mets = OcrdMets(filename=assets.url_of(
+        'SBB0000F29300010000/data/mets.xml'))
+    yield mets
 
-    # pylint: disable=no-member
-    def test_unique_identifier_from_nothing(self):
-        mets = OcrdMets.empty_mets(datetime.now().isoformat())
-        self.assertEqual(mets.unique_identifier, None, 'no identifier')
-        mets.unique_identifier = 'foo'
-        self.assertEqual(mets.unique_identifier, 'foo', 'Right identifier after change')
-        as_string = mets.to_xml().decode('utf-8')
-        self.assertIn('ocrd/core v%s' % VERSION, as_string)
-        self.assertIn('CREATEDATE="%04u-%02u-%02uT' % (
-            datetime.now().year,
-            datetime.now().month,
-            datetime.now().day,
-        ), as_string)
 
-    def test_str(self):
-        mets = OcrdMets(content='<mets/>')
-        self.assertEqual(str(mets), 'OcrdMets[fileGrps=[],files=[]]')
+def test_unique_identifier():
+    mets = OcrdMets(filename=assets.url_of(
+        'SBB0000F29300010000/data/mets.xml'))
+    assert mets.unique_identifier == 'http://resolver.staatsbibliothek-berlin.de/SBB0000F29300010000', 'Right identifier'
+    mets.unique_identifier = 'foo'
+    assert mets.unique_identifier == 'foo', 'Right identifier after change'
 
-    #  def test_override_constructor_args(self):
-    #      id2file = {'foo': {}}
-    #      mets = OcrdMets(id2file, content='<mets/>')
-    #      self.assertEqual(mets._file_by_id, id2file)
 
-    def test_file_groups(self):
-        self.assertEqual(len(self.mets.file_groups), 17, '17 file groups')
+def test_unique_identifier_from_nothing():
+    mets = OcrdMets.empty_mets(datetime.now().isoformat())
+    assert mets.unique_identifier == None, 'no identifier'
+    mets.unique_identifier = 'foo'
+    assert mets.unique_identifier == 'foo', 'Right identifier after change is "foo"'
+    as_string = mets.to_xml().decode('utf-8')
+    assert 'ocrd/core v%s' % VERSION in as_string
+    assert 'CREATEDATE="%04u-%02u-%02uT' % (
+        datetime.now().year,
+        datetime.now().month,
+        datetime.now().day,
+    ) in as_string
 
-    def test_find_all_files(self):
-        self.assertEqual(len(self.mets.find_all_files()), 35, '35 files total')
-        self.assertEqual(len(self.mets.find_all_files(fileGrp='OCR-D-IMG')), 3, '3 files in "OCR-D-IMG"')
-        self.assertEqual(len(self.mets.find_all_files(fileGrp='//OCR-D-I.*')), 13, '13 files in "//OCR-D-I.*"')
-        self.assertEqual(len(self.mets.find_all_files(ID="FILE_0001_IMAGE")), 1, '1 files with ID "FILE_0001_IMAGE"')
-        self.assertEqual(len(self.mets.find_all_files(ID="//FILE_0005_.*")), 1, '1 files with ID "//FILE_0005_.*"')
-        self.assertEqual(len(self.mets.find_all_files(pageId='PHYS_0001')), 17, '17 files for page "PHYS_0001"')
-        self.assertEqual(len(self.mets.find_all_files(pageId='PHYS_0001-NOTEXIST')), 0, '0 pages for "PHYS_0001-NOTEXIST"')
-        self.assertEqual(len(self.mets.find_all_files(mimetype='image/tiff')), 13, '13 image/tiff')
-        self.assertEqual(len(self.mets.find_all_files(mimetype='//application/.*')), 22, '22 application/.*')
-        self.assertEqual(len(self.mets.find_all_files(mimetype=MIMETYPE_PAGE)), 20, '20 ' + MIMETYPE_PAGE)
-        self.assertEqual(len(self.mets.find_all_files(url='OCR-D-IMG/FILE_0005_IMAGE.tif')), 1, '1 xlink:href="OCR-D-IMG/FILE_0005_IMAGE.tif"')
-        self.assertEqual(len(self.mets.find_all_files(pageId='PHYS_0001..PHYS_0005')), 35, '35 files for page "PHYS_0001..PHYS_0005"')
 
-    def test_find_all_files_no_regex_for_pageid(self):
-        with self.assertRaisesRegex(Exception, "not support regex search for pageId"):
-            self.mets.find_all_files(pageId='//foo')
+def test_str():
+    mets = OcrdMets(content='<mets/>')
+    assert str(mets) == 'OcrdMets[fileGrps=[],files=[]]'
 
-    def test_find_all_files_local_only(self):
-        self.assertEqual(len(self.mets.find_all_files(pageId='PHYS_0001', local_only=True)), 3, '3 local files for page "PHYS_0001"')
 
-    def test_physical_pages(self):
-        self.assertEqual(len(self.mets.physical_pages), 3, '3 physical pages')
+@pytest.mark.xfail(reason='old test, was actually out-commented')
+def test_override_constructor_args():
+    id2file = {'foo': {}}
+    mets = OcrdMets(id2file, content='<mets/>')
+    assert mets._file_by_id == id2file
 
-    def test_physical_pages_from_empty_mets(self):
-        mets = OcrdMets(content="<mets></mets>")
-        self.assertEqual(len(mets.physical_pages), 0, 'no physical page')
-        mets.add_file('OUTPUT', ID="foo123", pageId="foobar")
-        self.assertEqual(len(mets.physical_pages), 1, '1 physical page')
 
-    def test_physical_pages_for_fileids(self):
-        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
-            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
-            self.assertEqual(mets.get_physical_pages(for_fileIds=['FILE_0002_IMAGE']), ['PHYS_0002'])
+def test_file_groups(sbb_sample_01):
+    assert len(sbb_sample_01.file_groups) == 17, '17 file groups shall be found'
 
-    def test_add_group(self):
-        mets = OcrdMets.empty_mets()
-        self.assertEqual(len(mets.file_groups), 0, '0 file groups')
-        mets.add_file_group('TEST')
-        self.assertEqual(len(mets.file_groups), 1, '1 file groups')
-        mets.add_file_group('TEST')
-        self.assertEqual(len(mets.file_groups), 1, '1 file groups')
 
-    def test_add_file(self):
-        mets = OcrdMets.empty_mets()
-        self.assertEqual(len(mets.file_groups), 0, '0 file groups')
-        self.assertEqual(len(list(mets.find_all_files(fileGrp='OUTPUT'))), 0, '0 files in "OUTPUT"')
-        f = mets.add_file('OUTPUT', ID="foo123", mimetype="bla/quux", pageId="foobar")
-        f2 = mets.add_file('OUTPUT', ID="foo1232", mimetype="bla/quux", pageId="foobar")
-        self.assertEqual(f.pageId, 'foobar', 'pageId set')
-        self.assertEqual(len(mets.file_groups), 1, '1 file groups')
-        self.assertEqual(len(list(mets.find_all_files(fileGrp='OUTPUT'))), 2, '2 files in "OUTPUT"')
-        mets.set_physical_page_for_file('barfoo', f, order='300', orderlabel="page 300")
-        self.assertEqual(f.pageId, 'barfoo', 'pageId changed')
-        mets.set_physical_page_for_file('quux', f2, order='302', orderlabel="page 302")
-        self.assertEqual(f2.pageId, 'quux', 'pageId changed')
-        mets.set_physical_page_for_file('barfoo', f2, order='301', orderlabel="page 301")
-        self.assertEqual(f2.pageId, 'barfoo', 'pageId changed')
-        self.assertEqual(len(mets.file_groups), 1, '1 file group')
+def test_find_all_files(sbb_sample_01):
+    assert len(sbb_sample_01.find_all_files()) == 35, '35 files total'
+    assert len(sbb_sample_01.find_all_files(
+        fileGrp='OCR-D-IMG')) == 3, '3 files in "OCR-D-IMG"'
+    assert len(sbb_sample_01.find_all_files(fileGrp='//OCR-D-I.*')
+               ) == 13, '13 files in "//OCR-D-I.*"'
+    assert len(sbb_sample_01.find_all_files(ID="FILE_0001_IMAGE")
+               ) == 1, '1 files with ID "FILE_0001_IMAGE"'
+    assert len(sbb_sample_01.find_all_files(ID="//FILE_0005_.*")
+               ) == 1, '1 files with ID "//FILE_0005_.*"'
+    assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001')
+               ) == 17, '17 files for page "PHYS_0001"'
+    assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001-NOTEXIST')
+               ) == 0, '0 pages for "PHYS_0001-NOTEXIST"'
+    assert len(sbb_sample_01.find_all_files(
+        mimetype='image/tiff')) == 13, '13 image/tiff'
+    assert len(sbb_sample_01.find_all_files(
+        mimetype='//application/.*')) == 22, '22 application/.*'
+    assert len(sbb_sample_01.find_all_files(
+        mimetype=MIMETYPE_PAGE)) == 20, '20 ' + MIMETYPE_PAGE
+    assert len(sbb_sample_01.find_all_files(url='OCR-D-IMG/FILE_0005_IMAGE.tif')
+               ) == 1, '1 xlink:href="OCR-D-IMG/FILE_0005_IMAGE.tif"'
+    assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001..PHYS_0005')
+               ) == 35, '35 files for page "PHYS_0001..PHYS_0005"'
 
-    def test_add_file_ID_already_exists(self):
-        f = self.mets.add_file('OUTPUT', ID='best-id-ever', mimetype="beep/boop")
-        self.assertEqual(f.ID, 'best-id-ever', "ID kept")
-        with self.assertRaisesRegex(Exception, "File with ID='best-id-ever' already exists"):
-            self.mets.add_file('OUTPUT', ID='best-id-ever', mimetype="boop/beep")
-        f2 = self.mets.add_file('OUTPUT', ID='best-id-ever', mimetype="boop/beep", force=True)
-        self.assertEqual(f._el, f2._el)
 
-    def test_add_file_ignore(self):
-        self.mets.add_file('OUTPUT', ID='best-id-ever', mimetype="beep/boop")
-        self.mets.add_file('OUTPUT', ID='best-id-ever', mimetype="boop/beep", ignore=True)
+def test_find_all_files_no_regex_for_pageid(sbb_sample_01):
+    with pytest.raises(Exception) as exc_obj:
+        sbb_sample_01.find_all_files(pageId='//foo')
 
-    def test_add_file_ID_invalid(self):
-        with self.assertRaisesRegex(Exception, "Invalid syntax for mets:file/@ID 1234:::"):
-            self.mets.add_file('OUTPUT', ID='1234:::', mimetype="beep/boop")
+    assert "not support regex search for pageId" in str(exc_obj.value)
 
-    def test_filegrp_from_file(self):
-        f = self.mets.find_all_files(fileGrp='OCR-D-IMG')[0]
-        self.assertEqual(f.fileGrp, 'OCR-D-IMG')
 
-    def test_add_file_no_id(self):
-        with self.assertRaisesRegex(Exception, "Must set ID of the mets:file"):
-            self.mets.add_file('FOO')
+def test_find_all_files_local_only(sbb_sample_01):
+    assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001',
+               local_only=True)) == 3, '3 local files for page "PHYS_0001"'
 
-    def test_add_file_no_pageid(self):
-        f = self.mets.add_file('OUTPUT', mimetype="bla/quux", ID="foo3")
-        self.assertEqual(f.pageId, None, 'No pageId')
 
-    def test_file_pageid(self):
-        f = self.mets.find_all_files()[0]
-        self.assertEqual(f.pageId, 'PHYS_0001')
-        f.pageId = 'foo'
-        self.assertEqual(f.pageId, 'foo')
+def test_physical_pages(sbb_sample_01):
+    assert len(sbb_sample_01.physical_pages) == 3, '3 physical pages'
 
-    def test_agent(self):
-        #  Processor(workspace=self.workspace)
-        mets = self.mets
-        beforelen = len(mets.agents)
-        mets.add_agent('foo bar v0.0.1', 'OTHER', 'OTHER', 'YETOTHERSTILL')
-        #  print(['%s'%x for x in mets.agents])
-        self.assertEqual(len(mets.agents), beforelen + 1)
 
-    def test_metshdr(self):
-        """
-        Test whether metsHdr is created on-demand
-        """
-        mets = OcrdMets(content="<mets></mets>")
-        self.assertFalse(mets._tree.getroot().getchildren())
-        mets.add_agent()
-        self.assertEqual(len(mets._tree.getroot().getchildren()), 1)
+def test_physical_pages_from_empty_mets():
+    mets = OcrdMets(content="<mets></mets>")
+    assert len(mets.physical_pages) == 0, 'no physical page'
+    mets.add_file('OUTPUT', ID="foo123", pageId="foobar")
+    assert len(mets.physical_pages) == 1, '1 physical page'
 
-    def test_nocontent_nofilename(self):
-        with self.assertRaisesRegex(Exception, "Must pass 'filename' or 'content' to"):
-            OcrdMets()
 
-    def test_encoding_entities(self):
-        mets = OcrdMets(content="""
-        <mets>
-          <metsHdr>
-            <agent>
-              <name>Őh śéé Áŕ</name>
-              <note>OCR-D</note>
-            </agent>
-          </metsHdr>
-        </mets>
-        """)
-        self.assertIn('Őh śéé Áŕ', mets.to_xml().decode('utf-8'))
+@pytest.fixture(name='sbb_directory_ocrd_mets')
+def _fixture_sbb(tmp_path):
+    src_path = assets.path_to('SBB0000F29300010000/data')
+    dst_path = tmp_path / 'SBB_directory'
+    shutil.copytree(src_path, dst_path)
+    mets_path = str(join(dst_path, 'mets.xml'))
+    yield OcrdMets(filename=mets_path)
 
-    def test_remove_page(self):
-        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
-            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
-            self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002', 'PHYS_0005'])
-            mets.remove_physical_page('PHYS_0001')
-            self.assertEqual(mets.physical_pages, ['PHYS_0002', 'PHYS_0005'])
+def test_physical_pages_for_fileids(sbb_directory_ocrd_mets):
+    assert sbb_directory_ocrd_mets.get_physical_pages(
+        for_fileIds=['FILE_0002_IMAGE']) == ['PHYS_0002']
 
-    def test_remove_physical_page_fptr(self):
-        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
-            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
-            self.assertEqual(mets.get_physical_pages(for_fileIds=['FILE_0002_IMAGE']), ['PHYS_0002'])
-            mets.remove_physical_page_fptr('FILE_0002_IMAGE')
-            self.assertEqual(mets.get_physical_pages(for_fileIds=['FILE_0002_IMAGE']), [None])
 
-    def test_remove_page_after_remove_file(self):
-        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
-            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
-            self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002', 'PHYS_0005'])
-            mets.remove_one_file('FILE_0005_IMAGE')
-            self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002'])
+def test_add_group():
+    mets = OcrdMets.empty_mets()
+    assert len(mets.file_groups) == 0, '0 file groups'
+    mets.add_file_group('TEST')
+    assert len(mets.file_groups) == 1, '1 file groups'
+    mets.add_file_group('TEST')
+    assert len(mets.file_groups) == 1, '1 file groups'
 
-    def test_remove_file_ocrdfile(self):
-        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
-            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
-            self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002', 'PHYS_0005'])
-            ocrd_file = mets.find_all_files(ID='FILE_0005_IMAGE')[0]
-            mets.remove_one_file(ocrd_file)
-            self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002'])
 
-    def test_remove_file_regex(self):
-        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
-            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
-            self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002', 'PHYS_0005'])
-            mets.remove_file('//FILE_0005.*')
-            self.assertEqual(mets.physical_pages, ['PHYS_0001', 'PHYS_0002'])
+def test_add_file():
+    mets = OcrdMets.empty_mets()
+    assert len(mets.file_groups) == 0, '0 file groups'
+    assert len(list(mets.find_all_files(fileGrp='OUTPUT'))
+               ) == 0, '0 files in "OUTPUT"'
+    f = mets.add_file('OUTPUT', ID="foo123",
+                      mimetype="bla/quux", pageId="foobar")
+    f2 = mets.add_file('OUTPUT', ID="foo1232",
+                       mimetype="bla/quux", pageId="foobar")
+    assert f.pageId == 'foobar', 'pageId set'
+    assert len(mets.file_groups) == 1, '1 file groups'
+    assert len(list(mets.find_all_files(fileGrp='OUTPUT'))
+               ) == 2, '2 files in "OUTPUT"'
+    mets.set_physical_page_for_file(
+        'barfoo', f, order='300', orderlabel="page 300")
+    assert f.pageId == 'barfoo', 'pageId changed'
+    mets.set_physical_page_for_file(
+        'quux', f2, order='302', orderlabel="page 302")
+    assert f2.pageId == 'quux', 'pageId changed'
+    mets.set_physical_page_for_file(
+        'barfoo', f2, order='301', orderlabel="page 301")
+    assert f2.pageId == 'barfoo', 'pageId changed'
+    assert len(mets.file_groups) == 1, '1 file group'
 
-    def test_rename_file_group0(self):
-        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
-            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
-            with self.assertRaisesRegex(FileNotFoundError, "No such fileGrp 'FOOBAR'"):
-                mets.rename_file_group('FOOBAR', 'FOOBAR')
-            assert 'FOOBAR' not in mets.file_groups
-            mets.rename_file_group('OCR-D-GT-PAGE', 'FOOBAR')
-            assert 'OCR-D-GT-PAGE' not in mets.file_groups
-            assert 'FOOBAR' in mets.file_groups
 
-    def test_remove_file_group0(self):
-        """
-        Test removal of filegrp
-        """
-        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
-            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
-            self.assertEqual(len(mets.file_groups), 17)
-            self.assertEqual(len(mets.find_all_files()), 35)
-            #  print()
-            #  before = sorted([x.ID for x in mets.find_all_files()])
-            with self.assertRaisesRegex(Exception, "not empty"):
-                mets.remove_file_group('OCR-D-GT-ALTO')
-            mets.remove_file_group('OCR-D-GT-PAGE', recursive=True)
-            #  print([x for x in before if x not in sorted([x.ID for x in mets.find_all_files()])])
-            self.assertEqual(len(mets.file_groups), 16)
-            self.assertEqual(len(mets.find_all_files()), 33)
+def test_add_file_id_already_exists(sbb_sample_01):
+    f = sbb_sample_01.add_file(
+        'OUTPUT', ID='best-id-ever', mimetype="beep/boop")
+    assert f.ID == 'best-id-ever', "ID kept"
+    with pytest.raises(Exception) as exc:
+        sbb_sample_01.add_file(
+            'OUTPUT', ID='best-id-ever', mimetype="boop/beep")
 
-    def test_remove_file_group_regex(self):
-        """
-        Test removal of filegrp
-        """
-        with copy_of_directory(assets.path_to('SBB0000F29300010000/data')) as tempdir:
-            mets = OcrdMets(filename=join(tempdir, 'mets.xml'))
-            self.assertEqual(len(mets.file_groups), 17)
-            self.assertEqual(len(mets.find_all_files()), 35)
-            mets.remove_file_group('//OCR-D-GT-.*', recursive=True)
-            self.assertEqual(len(mets.file_groups), 15)
-            self.assertEqual(len(mets.find_all_files()), 31)
+    assert "File with ID='best-id-ever' already exists" in str(exc)
 
-    def test_merge(self):
-        assert len(self.mets.file_groups) == 17
-        other_mets = OcrdMets(filename=assets.path_to('kant_aufklaerung_1784/data/mets.xml'))
-        self.mets.merge(other_mets, fileGrp_mapping={'OCR-D-IMG': 'FOO'})
-        assert len(self.mets.file_groups) == 18
+    f2 = sbb_sample_01.add_file(
+        'OUTPUT', ID='best-id-ever', mimetype="boop/beep", force=True)
+    assert f._el == f2._el
 
-    def test_invalid_filegrp(self):
-        """https://github.com/OCR-D/core/issues/746"""
-        mets = OcrdMets(content="<mets></mets>")
-        with self.assertRaisesRegex(ValueError, "Invalid syntax for mets:fileGrp/@USE"):
-            mets.add_file('1:! bad filegrp', ID="foo123", pageId="foobar")
+
+def test_add_file_ignore(sbb_sample_01):
+    sbb_sample_01.add_file('OUTPUT', ID='best-id-ever', mimetype="beep/boop")
+    sbb_sample_01.add_file('OUTPUT', ID='best-id-ever',
+                           mimetype="boop/beep", ignore=True)
+
+
+def test_add_file_id_invalid(sbb_sample_01):
+    with pytest.raises(Exception) as exc:
+        sbb_sample_01.add_file('OUTPUT', ID='1234:::', mimetype="beep/boop")
+    assert "Invalid syntax for mets:file/@ID 1234:::" in str(exc)
+
+
+def test_filegrp_from_file(sbb_sample_01):
+    f = sbb_sample_01.find_all_files(fileGrp='OCR-D-IMG')[0]
+    assert f.fileGrp == 'OCR-D-IMG'
+
+
+def test_add_file_no_id(sbb_sample_01):
+    with pytest.raises(Exception) as exc:
+        sbb_sample_01.add_file('FOO')
+    assert "Must set ID of the mets:file" in str(exc)
+
+
+def test_add_file_no_pageid(sbb_sample_01):
+    f = sbb_sample_01.add_file('OUTPUT', mimetype="bla/quux", ID="foo3")
+    assert not f.pageId, 'No pageId available, dude!'
+
+
+def test_file_pageid(sbb_sample_01):
+    f = sbb_sample_01.find_all_files()[0]
+    assert f.pageId == 'PHYS_0001'
+    f.pageId = 'foo'
+    assert f.pageId == 'foo'
+
+
+def test_agent(sbb_sample_01):
+    beforelen = len(sbb_sample_01.agents)
+    sbb_sample_01.add_agent('foo bar v0.0.1', 'OTHER',
+                            'OTHER', 'YETOTHERSTILL')
+    assert len(sbb_sample_01.agents) == beforelen + 1
+
+
+def test_metshdr():
+    """
+    Test whether metsHdr is created on-demand
+    """
+    mets = OcrdMets(content="<mets></mets>")
+    assert not mets._tree.getroot().getchildren()
+    mets.add_agent()
+    assert len(mets._tree.getroot().getchildren()) == 1
+
+
+def test_nocontent_nofilename_exception():
+    with pytest.raises(Exception) as exc:
+        OcrdMets()
+    assert "Must pass 'filename' or 'content' to" in str(exc)
+
+
+def test_encoding_entities():
+    mets = OcrdMets(content="""
+    <mets>
+        <metsHdr>
+        <agent>
+            <name>Őh śéé Áŕ</name>
+            <note>OCR-D</note>
+        </agent>
+        </metsHdr>
+    </mets>
+    """)
+    assert 'Őh śéé Áŕ' in mets.to_xml().decode('utf-8')
+
+
+def test_remove_page(sbb_directory_ocrd_mets):
+    assert sbb_directory_ocrd_mets.physical_pages, ['PHYS_0001', 'PHYS_0002', 'PHYS_0005']
+    sbb_directory_ocrd_mets.remove_physical_page('PHYS_0001')
+    assert sbb_directory_ocrd_mets.physical_pages, ['PHYS_0002', 'PHYS_0005']
+
+
+def test_remove_physical_page_fptr(sbb_directory_ocrd_mets):
+    assert sbb_directory_ocrd_mets.get_physical_pages(
+        for_fileIds=['FILE_0002_IMAGE']), ['PHYS_0002']
+    sbb_directory_ocrd_mets.remove_physical_page_fptr('FILE_0002_IMAGE')
+    assert sbb_directory_ocrd_mets.get_physical_pages(for_fileIds=['FILE_0002_IMAGE']), [None]
+
+
+def test_remove_page_after_remove_file(sbb_directory_ocrd_mets):
+    assert sbb_directory_ocrd_mets.physical_pages, ['PHYS_0001', 'PHYS_0002', 'PHYS_0005']
+    sbb_directory_ocrd_mets.remove_one_file('FILE_0005_IMAGE')
+    assert sbb_directory_ocrd_mets.physical_pages, ['PHYS_0001', 'PHYS_0002']
+
+
+def test_remove_file_ocrdfile(sbb_directory_ocrd_mets):
+    assert sbb_directory_ocrd_mets.physical_pages, ['PHYS_0001', 'PHYS_0002', 'PHYS_0005']
+    ocrd_file = sbb_directory_ocrd_mets.find_all_files(ID='FILE_0005_IMAGE')[0]
+    sbb_directory_ocrd_mets.remove_one_file(ocrd_file)
+    assert sbb_directory_ocrd_mets.physical_pages, ['PHYS_0001', 'PHYS_0002']
+
+
+def test_remove_file_regex(sbb_directory_ocrd_mets):
+    assert sbb_directory_ocrd_mets.physical_pages, ['PHYS_0001', 'PHYS_0002', 'PHYS_0005']
+    sbb_directory_ocrd_mets.remove_file('//FILE_0005.*')
+    assert sbb_directory_ocrd_mets.physical_pages, ['PHYS_0001', 'PHYS_0002']
+
+
+def test_rename_non_existent_filegroup_exception(sbb_directory_ocrd_mets):
+    with pytest.raises(FileNotFoundError) as fnf_exc:
+        sbb_directory_ocrd_mets.rename_file_group('FOOBAR', 'FOOBAR')
+    # assert
+    assert "No such fileGrp 'FOOBAR'" in str(fnf_exc)
+
+
+def test_rename_file_group0(sbb_directory_ocrd_mets):
+    assert 'FOOBAR' not in sbb_directory_ocrd_mets.file_groups
+
+    # act
+    sbb_directory_ocrd_mets.rename_file_group('OCR-D-GT-PAGE', 'FOOBAR')
+
+    # assert
+    assert 'OCR-D-GT-PAGE' not in sbb_directory_ocrd_mets.file_groups
+    assert 'FOOBAR' in sbb_directory_ocrd_mets.file_groups
+
+
+def test_remove_non_empty_filegroup_exception(sbb_directory_ocrd_mets):
+    with pytest.raises(Exception) as exc:
+        sbb_directory_ocrd_mets.remove_file_group('OCR-D-GT-ALTO')
+    assert "not empty" in str(exc)
+
+
+def test_remove_file_group0(sbb_directory_ocrd_mets):
+    """
+    Test removal of filegrp
+    """
+
+    assert len(sbb_directory_ocrd_mets.file_groups) == 17
+    assert len(sbb_directory_ocrd_mets.find_all_files()) == 35
+
+    sbb_directory_ocrd_mets.remove_file_group('OCR-D-GT-PAGE', recursive=True)
+    assert len(sbb_directory_ocrd_mets.file_groups) == 16
+    assert len(sbb_directory_ocrd_mets.find_all_files()) == 33
+
+
+def test_remove_file_group_regex(sbb_directory_ocrd_mets):
+    """
+    Test removal of filegrp
+    """
+ 
+    assert len(sbb_directory_ocrd_mets.file_groups) == 17
+    assert len(sbb_directory_ocrd_mets.find_all_files()) == 35
+
+    # act
+    sbb_directory_ocrd_mets.remove_file_group('//OCR-D-GT-.*', recursive=True)
+
+    # assert
+    assert len(sbb_directory_ocrd_mets.file_groups) == 15
+    assert len(sbb_directory_ocrd_mets.find_all_files()) == 31
+
+
+def test_merge(sbb_sample_01):
+    assert len(sbb_sample_01.file_groups) == 17
+    other_mets = OcrdMets(filename=assets.path_to(
+        'kant_aufklaerung_1784/data/mets.xml'))
+    sbb_sample_01.merge(other_mets, fileGrp_mapping={'OCR-D-IMG': 'FOO'})
+    assert len(sbb_sample_01.file_groups) == 18
+
+
+def test_invalid_filegrp():
+    """addresses https://github.com/OCR-D/core/issues/746"""
+
+    mets = OcrdMets(content="<mets></mets>")
+    with pytest.raises(ValueError) as val_err:
+        mets.add_file('1:! bad filegrp', ID="foo123", pageId="foobar")
+        
+    assert "Invalid syntax for mets:fileGrp/@USE" in str(val_err.value)
 
 if __name__ == '__main__':
     main(__file__)

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -29,8 +29,7 @@ def _fixture():
 
 
 def test_unique_identifier():
-    mets = OcrdMets(filename=assets.url_of(
-        'SBB0000F29300010000/data/mets.xml'))
+    mets = OcrdMets(filename=assets.url_of('SBB0000F29300010000/data/mets.xml'))
     assert mets.unique_identifier == 'http://resolver.staatsbibliothek-berlin.de/SBB0000F29300010000', 'Right identifier'
     mets.unique_identifier = 'foo'
     assert mets.unique_identifier == 'foo', 'Right identifier after change'
@@ -43,11 +42,7 @@ def test_unique_identifier_from_nothing():
     assert mets.unique_identifier == 'foo', 'Right identifier after change is "foo"'
     as_string = mets.to_xml().decode('utf-8')
     assert 'ocrd/core v%s' % VERSION in as_string
-    assert 'CREATEDATE="%04u-%02u-%02uT' % (
-        datetime.now().year,
-        datetime.now().month,
-        datetime.now().day,
-    ) in as_string
+    assert 'CREATEDATE="%04u-%02u-%02uT' % (datetime.now().year, datetime.now().month, datetime.now().day,) in as_string
 
 
 def test_str():
@@ -68,28 +63,17 @@ def test_file_groups(sbb_sample_01):
 
 def test_find_all_files(sbb_sample_01):
     assert len(sbb_sample_01.find_all_files()) == 35, '35 files total'
-    assert len(sbb_sample_01.find_all_files(
-        fileGrp='OCR-D-IMG')) == 3, '3 files in "OCR-D-IMG"'
-    assert len(sbb_sample_01.find_all_files(fileGrp='//OCR-D-I.*')
-               ) == 13, '13 files in "//OCR-D-I.*"'
-    assert len(sbb_sample_01.find_all_files(ID="FILE_0001_IMAGE")
-               ) == 1, '1 files with ID "FILE_0001_IMAGE"'
-    assert len(sbb_sample_01.find_all_files(ID="//FILE_0005_.*")
-               ) == 1, '1 files with ID "//FILE_0005_.*"'
-    assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001')
-               ) == 17, '17 files for page "PHYS_0001"'
-    assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001-NOTEXIST')
-               ) == 0, '0 pages for "PHYS_0001-NOTEXIST"'
-    assert len(sbb_sample_01.find_all_files(
-        mimetype='image/tiff')) == 13, '13 image/tiff'
-    assert len(sbb_sample_01.find_all_files(
-        mimetype='//application/.*')) == 22, '22 application/.*'
-    assert len(sbb_sample_01.find_all_files(
-        mimetype=MIMETYPE_PAGE)) == 20, '20 ' + MIMETYPE_PAGE
-    assert len(sbb_sample_01.find_all_files(url='OCR-D-IMG/FILE_0005_IMAGE.tif')
-               ) == 1, '1 xlink:href="OCR-D-IMG/FILE_0005_IMAGE.tif"'
-    assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001..PHYS_0005')
-               ) == 35, '35 files for page "PHYS_0001..PHYS_0005"'
+    assert len(sbb_sample_01.find_all_files(fileGrp='OCR-D-IMG')) == 3, '3 files in "OCR-D-IMG"'
+    assert len(sbb_sample_01.find_all_files(fileGrp='//OCR-D-I.*')) == 13, '13 files in "//OCR-D-I.*"'
+    assert len(sbb_sample_01.find_all_files(ID="FILE_0001_IMAGE")) == 1, '1 files with ID "FILE_0001_IMAGE"'
+    assert len(sbb_sample_01.find_all_files(ID="//FILE_0005_.*")) == 1, '1 files with ID "//FILE_0005_.*"'
+    assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001')) == 17, '17 files for page "PHYS_0001"'
+    assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001-NOTEXIST')) == 0, '0 pages for "PHYS_0001-NOTEXIST"'
+    assert len(sbb_sample_01.find_all_files(mimetype='image/tiff')) == 13, '13 image/tiff'
+    assert len(sbb_sample_01.find_all_files(mimetype='//application/.*')) == 22, '22 application/.*'
+    assert len(sbb_sample_01.find_all_files(mimetype=MIMETYPE_PAGE)) == 20, '20 ' + MIMETYPE_PAGE
+    assert len(sbb_sample_01.find_all_files(url='OCR-D-IMG/FILE_0005_IMAGE.tif')) == 1, '1 xlink:href="OCR-D-IMG/FILE_0005_IMAGE.tif"'
+    assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001..PHYS_0005')) == 35, '35 files for page "PHYS_0001..PHYS_0005"'
 
 
 def test_find_all_files_no_regex_for_pageid(sbb_sample_01):
@@ -123,6 +107,7 @@ def _fixture_sbb(tmp_path):
     mets_path = str(join(dst_path, 'mets.xml'))
     yield OcrdMets(filename=mets_path)
 
+
 def test_physical_pages_for_fileids(sbb_directory_ocrd_mets):
     assert sbb_directory_ocrd_mets.get_physical_pages(
         for_fileIds=['FILE_0002_IMAGE']) == ['PHYS_0002']
@@ -140,40 +125,30 @@ def test_add_group():
 def test_add_file():
     mets = OcrdMets.empty_mets()
     assert len(mets.file_groups) == 0, '0 file groups'
-    assert len(list(mets.find_all_files(fileGrp='OUTPUT'))
-               ) == 0, '0 files in "OUTPUT"'
-    f = mets.add_file('OUTPUT', ID="foo123",
-                      mimetype="bla/quux", pageId="foobar")
-    f2 = mets.add_file('OUTPUT', ID="foo1232",
-                       mimetype="bla/quux", pageId="foobar")
+    assert len(list(mets.find_all_files(fileGrp='OUTPUT'))) == 0, '0 files in "OUTPUT"'
+    f = mets.add_file('OUTPUT', ID="foo123", mimetype="bla/quux", pageId="foobar")
+    f2 = mets.add_file('OUTPUT', ID="foo1232", mimetype="bla/quux", pageId="foobar")
     assert f.pageId == 'foobar', 'pageId set'
     assert len(mets.file_groups) == 1, '1 file groups'
-    assert len(list(mets.find_all_files(fileGrp='OUTPUT'))
-               ) == 2, '2 files in "OUTPUT"'
-    mets.set_physical_page_for_file(
-        'barfoo', f, order='300', orderlabel="page 300")
+    assert len(list(mets.find_all_files(fileGrp='OUTPUT'))) == 2, '2 files in "OUTPUT"'
+    mets.set_physical_page_for_file('barfoo', f, order='300', orderlabel="page 300")
     assert f.pageId == 'barfoo', 'pageId changed'
-    mets.set_physical_page_for_file(
-        'quux', f2, order='302', orderlabel="page 302")
+    mets.set_physical_page_for_file('quux', f2, order='302', orderlabel="page 302")
     assert f2.pageId == 'quux', 'pageId changed'
-    mets.set_physical_page_for_file(
-        'barfoo', f2, order='301', orderlabel="page 301")
+    mets.set_physical_page_for_file('barfoo', f2, order='301', orderlabel="page 301")
     assert f2.pageId == 'barfoo', 'pageId changed'
     assert len(mets.file_groups) == 1, '1 file group'
 
 
 def test_add_file_id_already_exists(sbb_sample_01):
-    f = sbb_sample_01.add_file(
-        'OUTPUT', ID='best-id-ever', mimetype="beep/boop")
+    f = sbb_sample_01.add_file('OUTPUT', ID='best-id-ever', mimetype="beep/boop")
     assert f.ID == 'best-id-ever', "ID kept"
     with pytest.raises(Exception) as exc:
-        sbb_sample_01.add_file(
-            'OUTPUT', ID='best-id-ever', mimetype="boop/beep")
+        sbb_sample_01.add_file('OUTPUT', ID='best-id-ever', mimetype="boop/beep")
 
     assert "File with ID='best-id-ever' already exists" in str(exc)
 
-    f2 = sbb_sample_01.add_file(
-        'OUTPUT', ID='best-id-ever', mimetype="boop/beep", force=True)
+    f2 = sbb_sample_01.add_file('OUTPUT', ID='best-id-ever', mimetype="boop/beep", force=True)
     assert f._el == f2._el
 
 @pytest.mark.xfail(reason='2x same ID is valid if ignore == True')
@@ -183,8 +158,7 @@ def test_add_file_ignore(sbb_sample_01: OcrdMets):
 
     the_file = sbb_sample_01.add_file('OUTPUT', ID='best-id-ever', mimetype="beep/boop")
     assert the_file.ID == 'best-id-ever'
-    the_same = sbb_sample_01.add_file('OUTPUT', ID='best-id-ever',
-                           mimetype="boop/beep", ignore=True)
+    the_same = sbb_sample_01.add_file('OUTPUT', ID='best-id-ever', mimetype="boop/beep", ignore=True)
     assert the_same.ID == 'best-id-ever'
 
     # how many files inserted
@@ -223,8 +197,7 @@ def test_file_pageid(sbb_sample_01):
 
 def test_agent(sbb_sample_01):
     beforelen = len(sbb_sample_01.agents)
-    sbb_sample_01.add_agent('foo bar v0.0.1', 'OTHER',
-                            'OTHER', 'YETOTHERSTILL')
+    sbb_sample_01.add_agent('foo bar v0.0.1', 'OTHER', 'OTHER', 'YETOTHERSTILL')
     assert len(sbb_sample_01.agents) == beforelen + 1
 
 
@@ -265,8 +238,7 @@ def test_remove_page(sbb_directory_ocrd_mets):
 
 
 def test_remove_physical_page_fptr(sbb_directory_ocrd_mets):
-    assert sbb_directory_ocrd_mets.get_physical_pages(
-        for_fileIds=['FILE_0002_IMAGE']), ['PHYS_0002']
+    assert sbb_directory_ocrd_mets.get_physical_pages(for_fileIds=['FILE_0002_IMAGE']), ['PHYS_0002']
     sbb_directory_ocrd_mets.remove_physical_page_fptr('FILE_0002_IMAGE')
     assert sbb_directory_ocrd_mets.get_physical_pages(for_fileIds=['FILE_0002_IMAGE']), [None]
 
@@ -331,7 +303,7 @@ def test_remove_file_group_regex(sbb_directory_ocrd_mets):
     """
     Test removal of filegrp
     """
- 
+
     assert len(sbb_directory_ocrd_mets.file_groups) == 17
     assert len(sbb_directory_ocrd_mets.find_all_files()) == 35
 
@@ -345,8 +317,7 @@ def test_remove_file_group_regex(sbb_directory_ocrd_mets):
 
 def test_merge(sbb_sample_01):
     assert len(sbb_sample_01.file_groups) == 17
-    other_mets = OcrdMets(filename=assets.path_to(
-        'kant_aufklaerung_1784/data/mets.xml'))
+    other_mets = OcrdMets(filename=assets.path_to('kant_aufklaerung_1784/data/mets.xml'))
     sbb_sample_01.merge(other_mets, fileGrp_mapping={'OCR-D-IMG': 'FOO'})
     assert len(sbb_sample_01.file_groups) == 18
 
@@ -357,8 +328,9 @@ def test_invalid_filegrp():
     mets = OcrdMets(content="<mets></mets>")
     with pytest.raises(ValueError) as val_err:
         mets.add_file('1:! bad filegrp', ID="foo123", pageId="foobar")
-        
+
     assert "Invalid syntax for mets:fileGrp/@USE" in str(val_err.value)
+
 
 if __name__ == '__main__':
     main(__file__)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -185,20 +185,16 @@ def test_resolve_image0():
     assert img_pil2.size == (1, 1)
 
 
-# @pytest.mark.skip(reason='usage unclear - neither #image_from_page nor #image_from_segment are drop-in replacements')
 @pytest.mark.parametrize(
-    "image_url,data_key,page_id,size1,size2",
-    [('OCR-D-IMG-NRM/OCR-D-IMG-NRM_0017.png', 'INPUT_0017.tif', 'P_0017', (1457, 2083), (1, 1)),
-     ('OCR-D-IMG-1BIT/OCR-D-IMG-1BIT_0017.png', 'INPUT_0020.tif', 'P_0020', (1457, 2083), (1, 1)),
+    "image_url,size_pil",
+    [('OCR-D-IMG-NRM/OCR-D-IMG-NRM_0017.png', (1, 1)),
+     ('OCR-D-IMG-1BIT/OCR-D-IMG-1BIT_0017.png', (1, 1)),
      ])
-def test_resolve_image_grayscale(image_url, data_key, page_id, size1, size2):
+def test_resolve_image_as_pil(image_url, size_pil):
     url_path = assets.url_of('kant_aufklaerung_1784-binarized/data/mets.xml')
     workspace = Resolver().workspace_from_url(url_path)
-    pil_image = Image(url_path)
-    img_pil1 = workspace.image_from_segment('segment', pil_image, [[0, 0], [size1[0], size1[1]]])
-    assert img_pil1.size == size1
-    img_pil2 = workspace._resolve_image_as_pil(image_url, [[0, 0], [1, 1]])
-    assert img_pil2.size == size2
+    img_pil = workspace._resolve_image_as_pil(image_url, [[0, 0], [1, 1]])
+    assert img_pil.size == size_pil
 
 
 def test_resolve_image_as_pil_deprecated():

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -198,15 +198,14 @@ def test_resolve_image0():
     assert img_pil2.size == (1, 1)
 
 
-@pytest.mark.skip(reason='usage unclear - neither #image_from_page nor #image_from_segment are drop-in replacements')
+# @pytest.mark.skip(reason='usage unclear - neither #image_from_page nor #image_from_segment are drop-in replacements')
 @pytest.mark.parametrize(
     "image_url,data_key,page_id,size1,size2",
     [('OCR-D-IMG-NRM/OCR-D-IMG-NRM_0017.png', 'INPUT_0017.tif', 'P_0017', (1457, 2083), (1, 1)),
      ('OCR-D-IMG-1BIT/OCR-D-IMG-1BIT_0017.png', 'INPUT_0020.tif', 'P_0020', (1457, 2083), (1, 1)),
      ])
 def test_resolve_image_grayscale(image_url, data_key, page_id, size1, size2):
-    url_path = os.path.join(assets.url_of(
-        'kant_aufklaerung_1784-binarized'), 'data/mets.xml')
+    url_path = assets.url_of('kant_aufklaerung_1784-binarized/data/mets.xml')
     workspace = Resolver().workspace_from_url(url_path)
     pil_image = Image(url_path)
     img_pil1 = workspace.image_from_segment('segment', pil_image, [[0, 0], [size1[0], size1[1]]])

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -18,16 +18,12 @@ from ocrd_models.ocrd_page import OcrdPage
 import pytest
 
 from tests.base import (
-    assets, 
+    assets,
     main
 )
 
 from ocrd.resolver import Resolver
 from ocrd_utils import pushd_popd
-
-from ocrd_modelfactory import (
-    page_from_file
-)
 
 
 # set pylint once on module level
@@ -83,8 +79,7 @@ def test_workspace_from_url_kant(mock_request, tmp_path):
 
     # act
     resolver = Resolver()
-    resolver.workspace_from_url(
-        url_src, mets_basename='foo.xml', dst_dir=dst_dir)
+    resolver.workspace_from_url(url_src, mets_basename='foo.xml', dst_dir=dst_dir)
 
     # assert
     local_path = dst_dir / 'foo.xml'
@@ -104,11 +99,7 @@ def test_workspace_from_url_kant_with_resources(mock_request, tmp_path):
 
     # act
     resolver = Resolver()
-    resolver.workspace_from_url(
-        url_src,
-        mets_basename='kant_aufklaerung_1784.xml',
-        dst_dir=dst_dir,
-        download=True)
+    resolver.workspace_from_url(url_src, mets_basename='kant_aufklaerung_1784.xml', dst_dir=dst_dir, download=True)
 
     # assert files present under local tmp_path
     local_path_mets = dst_dir / 'kant_aufklaerung_1784.xml'
@@ -130,15 +121,12 @@ def test_workspace_from_url_kant_with_resources_existing_local(mock_request, tmp
     mock_request.side_effect = request_behavior
     dst_dir = tmp_path / 'workspace_kant'
     dst_dir.mkdir()
-    src_mets = Path(assets.path_to(
-        'kant_aufklaerung_1784-binarized/data/mets.xml'))
+    src_mets = Path(assets.path_to('kant_aufklaerung_1784-binarized/data/mets.xml'))
     dst_mets = Path(dst_dir, 'mets.xml')
     shutil.copyfile(src_mets, dst_mets)
 
     # act
-    Resolver().workspace_from_url(url_src,
-                                  clobber_mets=False,
-                                  dst_dir=dst_dir)
+    Resolver().workspace_from_url(url_src, clobber_mets=False, dst_dir=dst_dir)
 
     # assert
     # no real request was made, since mets already present
@@ -163,8 +151,7 @@ def test_workspace_from_url_404(mock_request):
 
 
 def test_workspace_from_url_with_rel_dir(tmp_path):
-    bogus_dst_dir = '../../../../../../../../../../../../../../../../%s' % str(tmp_path)[
-        1:]
+    bogus_dst_dir = '../../../../../../../../../../../../../../../../%s' % str(tmp_path)[1:]
 
     # act
     with pushd_popd(FOLDER_KANT):
@@ -215,8 +202,7 @@ def test_resolve_image_grayscale(image_url, data_key, page_id, size1, size2):
 
 
 def test_resolve_image_as_pil_deprecated():
-    url_path = os.path.join(assets.url_of(
-        'kant_aufklaerung_1784-binarized'), 'data/mets.xml')
+    url_path = os.path.join(assets.url_of('kant_aufklaerung_1784-binarized'), 'data/mets.xml')
     workspace = Resolver().workspace_from_url(url_path)
     with pytest.warns(DeprecationWarning) as record:
         workspace.resolve_image_as_pil('OCR-D-IMG-NRM/OCR-D-IMG-NRM_0017.png')
@@ -252,11 +238,10 @@ def test_workspace_from_nothing_noclobber(tmp_path):
     assert the_msg in str(exc)
 
 
-@pytest.mark.parametrize(
-    "url,basename,exc_msg",
-    [(None, None, "'url' must be a string"),
-     (None, 'foo', "'directory' must be a string")]
-)
+@pytest.mark.parametrize("url,basename,exc_msg",
+                         [(None, None, "'url' must be a string"),
+                          (None, 'foo', "'directory' must be a string")]
+                         )
 def test_download_to_directory_with_badargs(url, basename, exc_msg):
 
     with pytest.raises(Exception) as exc:
@@ -284,8 +269,7 @@ def test_download_to_directory_default(fixture_copy_kant):
 def test_download_to_directory_basename(fixture_copy_kant):
     tmp_root = fixture_copy_kant.parent
     phil_data = fixture_copy_kant / 'data' / 'mets.xml'
-    fn = Resolver().download_to_directory(
-        str(tmp_root), str(phil_data), basename='foo')
+    fn = Resolver().download_to_directory(str(tmp_root), str(phil_data), basename='foo')
     assert Path(tmp_root, fn).exists()
     assert fn == 'foo'
 
@@ -293,8 +277,7 @@ def test_download_to_directory_basename(fixture_copy_kant):
 def test_download_to_directory_subdir(fixture_copy_kant):
     tmp_root = fixture_copy_kant.parent
     phil_data = fixture_copy_kant / 'data' / 'mets.xml'
-    fn = Resolver().download_to_directory(
-        str(tmp_root), str(phil_data), subdir='baz')
+    fn = Resolver().download_to_directory(str(tmp_root), str(phil_data), subdir='baz')
     assert Path(tmp_root, fn).exists()
     assert fn == 'baz/mets.xml'
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,10 @@
 envlist = py3{5,6.0}
 skipsdist = True
 
+[pycodestyle]
+max_line_length = 150
+ignore = E501
+
 [testenv]
 whitelist_externals= make
 deps =


### PR DESCRIPTION
Besides rather straight-forward re-construction some cases puzzle me (the testcases are marked and require reviews): 

* test_ocrd_mets.py # `test_add_file_ignore`
  when inserting the file with the ignore-flag, it looks like 2 file entries with same ID are created, which seems suspicious because this interferes with the regular IDREF-constraint of unique identifiers IMHO
* test_resolver.py # `test_resolve_image_grayscale`
  Tried to express and handle the deprecation warning appropriately, but failed to turn into modern usage within reasonable amount of time. Both methods mentioned in the deprecation warning (`workspace.image_from_page and ` and `workspace.image_from_segment`) are not drop-in replacements, the usage is IMHO completely different and not self-explanatory from the documentation. Looks like there are required completely different objects, API, etc.
 
