### PR TITLE
Allow images with up to 40k by 40k pixels, fix #735

### DIFF
--- a/ocrd_utils/ocrd_utils/image.py
+++ b/ocrd_utils/ocrd_utils/image.py
@@ -6,6 +6,10 @@ from PIL import Image, ImageStat, ImageDraw, ImageChops
 from .logging import getLogger
 from .introspect import membername
 
+# Allow processing of images with up to 1.6bn pixels
+# https://github.com/OCR-D/core/issues/735
+Image.MAX_IMAGE_PIXELS = 40_000 ** 2
+
 __all__ = [
     'adjust_canvas_to_rotation',
     'adjust_canvas_to_transposition',

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -6,5 +6,8 @@ def test_32bit_fill():
     img = Image.new('F', (200, 100), 1)
     rotate_image(img, 0.1, fill='background', transparency=False)
 
+def test_max_image_pixels():
+    assert Image.MAX_IMAGE_PIXELS == 40_000 ** 2
+
 if __name__ == '__main__':
     main([__file__])


### PR DESCRIPTION
This limit is pretty arbitrary but I have not come across any image even close to this large and it would be enough to handle the 2559x37192 image mentioned in https://github.com/tesseract-ocr/tesseract/issues/3184 - though `ocrd-tesserocr-recognize` would still fail currently because the MAX_IMAGE_PIXELS change here only relates to the Python API, not the tesseract API.