### PR TITLE
Feat/rfct/pytest3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,7 @@ assets-server:
 test: assets
 	HOME=$(CURDIR)/ocrd_utils $(PYTHON) -m pytest --continue-on-collection-errors -k TestLogging $(TESTDIR)
 	HOME=$(CURDIR) $(PYTHON) -m pytest --continue-on-collection-errors -k TestLogging $(TESTDIR)
-	HOME=$(CURDIR) $(PYTHON) -m pytest --continue-on-collection-errors $(TESTDIR)/test_resource_manager.py
-	$(PYTHON) -m pytest --continue-on-collection-errors --ignore=$(TESTDIR)/test_logging.py --ignore=$(TESTDIR)/test_resource_manager.py $(TESTDIR)
+	$(PYTHON) -m pytest --continue-on-collection-errors --ignore=$(TESTDIR)/test_logging.py $(TESTDIR)
 
 test-profile:
 	$(PYTHON) -m cProfile -o profile $$(which pytest)

--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -86,7 +86,7 @@ class OcrdResourceManager():
         """
         if executable:
             return [(executable, self.database[executable])]
-        return [(x, y) for x, y in self.database.items()]
+        return self.database.items()
 
     def list_installed(self, executable=None):
         """
@@ -142,6 +142,7 @@ class OcrdResourceManager():
             f.write(RESOURCE_USER_LIST_COMMENT)
             f.write('\n')
             f.write(safe_dump(user_database))
+        self.load_resource_list(self.user_list)
         return resdict
 
     def find_resources(self, executable=None, name=None, url=None, database=None):
@@ -182,8 +183,9 @@ class OcrdResourceManager():
     def parameter_usage(self, name, usage='as-is'):
         if usage == 'as-is':
             return name
-        if usage == 'without-extension':
+        elif usage == 'without-extension':
             return Path(name).stem
+        raise ValueError("No such usage '%s'" % usage)
 
     def _download_impl(self, url, filename, progress_cb=None, size=None):
         log = getLogger('ocrd.resource_manager._download_impl')

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -114,8 +114,7 @@ from .constants import (
     LOG_FORMAT,
     LOG_TIMEFMT,
     VERSION,
-    XDG_CONFIG_HOME,
-    XDG_DATA_HOME)
+    )
 
 from .deprecate import (
     deprecated_alias)

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -5,6 +5,7 @@ import pathlib
 
 from ocrd.resource_manager import OcrdResourceManager
 
+from pytest import raises
 from tests.base import main
 
 CONST_RESOURCE_YML = 'resources.yml'
@@ -34,6 +35,7 @@ def test_resources_manager_from_environment(tmp_path, monkeypatch):
     # arrange
     monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path))
     monkeypatch.setenv('XDG_DATA_HOME', str(tmp_path))
+    monkeypatch.setenv('HOME', str(tmp_path))
 
     # act
     mgr = OcrdResourceManager()
@@ -48,6 +50,7 @@ def test_resources_manager_from_environment(tmp_path, monkeypatch):
     fpath = mgr.download(proc, CONST_RESOURCE_URL_LAYOUT, mgr.location_to_resource_dir('data'))
     assert fpath.exists()
     assert mgr.add_to_user_database(proc, fpath)
+    assert mgr.userdir == str(tmp_path)
 
 
 def test_resources_manager_config_explicite(tmp_path):
@@ -65,6 +68,16 @@ def test_resources_manager_config_explicite(tmp_path):
     fpath = mgr.download(proc, CONST_RESOURCE_URL_LAYOUT, mgr.location_to_resource_dir('data'))
     assert fpath.exists()
     assert mgr.add_to_user_database(proc, fpath)
+
+def test_resources_manager_config_explicit_invalid(tmp_path):
+
+    # act
+    (tmp_path / 'ocrd').mkdir()
+    (tmp_path / 'ocrd' / CONST_RESOURCE_YML).write_text('::INVALID::')
+
+    # assert
+    with raises(ValueError, match='is invalid'):
+        OcrdResourceManager(xdg_config_home=tmp_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -3,20 +3,20 @@
 import os
 import pathlib
 
+from ocrd.resource_manager import OcrdResourceManager
+
 from tests.base import main
 
 CONST_RESOURCE_YML = 'resources.yml'
 CONST_RESOURCE_URL_LAYOUT = 'https://ocr-d-repo.scc.kit.edu/models/dfki/layoutAnalysis/mapping_densenet.pickle'
 
-def test_resources_manager_config_default():
 
-    # arrange
-    from ocrd.resource_manager import OcrdResourceManager
+def test_resources_manager_config_default():
 
     # act
     mgr = OcrdResourceManager()
 
-    #
+    # assert
     default_config_dir = os.path.join(os.environ['HOME'], '.config', 'ocrd')
     f = pathlib.Path(default_config_dir) / CONST_RESOURCE_YML
     assert f.exists()
@@ -32,16 +32,13 @@ def test_resources_manager_config_default():
 def test_resources_manager_from_environment(tmp_path, monkeypatch):
 
     # arrange
-    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
-    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
-    from ocrd.resource_manager import OcrdResourceManager
     monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path))
     monkeypatch.setenv('XDG_DATA_HOME', str(tmp_path))
 
     # act
     mgr = OcrdResourceManager()
 
-    #
+    # assert
     f = tmp_path / 'ocrd' / CONST_RESOURCE_YML
     assert f.exists()
     assert f == mgr.user_list
@@ -55,13 +52,10 @@ def test_resources_manager_from_environment(tmp_path, monkeypatch):
 
 def test_resources_manager_config_explicite(tmp_path):
 
-    # arrange
-    from ocrd.resource_manager import OcrdResourceManager
-
     # act
     mgr = OcrdResourceManager(xdb_config_home=str(tmp_path), xdb_data_home=str(tmp_path))
 
-    #
+    # assert
     f = tmp_path / 'ocrd' / CONST_RESOURCE_YML
     assert f.exists()
     assert f == mgr.user_list

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -53,7 +53,7 @@ def test_resources_manager_from_environment(tmp_path, monkeypatch):
 def test_resources_manager_config_explicite(tmp_path):
 
     # act
-    mgr = OcrdResourceManager(xdb_config_home=str(tmp_path), xdb_data_home=str(tmp_path))
+    mgr = OcrdResourceManager(xdg_config_home=str(tmp_path))
 
     # assert
     f = tmp_path / 'ocrd' / CONST_RESOURCE_YML

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -1,40 +1,77 @@
-from contextlib import contextmanager
-from pathlib import Path
-from tests.base import TestCase, main # pylint: disable=import-error,no-name-in-module
+# -*- coding: utf-8 -*-
 
-from pytest import fixture
+import os
+import pathlib
 
-from ocrd_utils import pushd_popd, initLogging
-import ocrd_utils.constants
+from tests.base import main
 
-@contextmanager
-def monkey_patch_temp_xdg():
-    with pushd_popd(tempdir=True) as tempdir:
-        old_config = ocrd_utils.constants.XDG_CONFIG_HOME
-        old_data = ocrd_utils.constants.XDG_DATA_HOME
-        ocrd_utils.constants.XDG_CONFIG_HOME = tempdir
-        ocrd_utils.constants.XDG_DATA_HOME = tempdir
-        from ocrd.resource_manager import OcrdResourceManager
-        yield tempdir, OcrdResourceManager()
-        ocrd_utils.constants.XDG_CONFIG_HOME = old_config
-        ocrd_utils.constants.XDG_DATA_HOME = old_data
+CONST_RESOURCE_YML = 'resources.yml'
+CONST_RESOURCE_URL_LAYOUT = 'https://ocr-d-repo.scc.kit.edu/models/dfki/layoutAnalysis/mapping_densenet.pickle'
 
-def test_config_created():
-    with monkey_patch_temp_xdg() as (tempdir, mgr):
-        f = Path(tempdir, 'ocrd', 'resources.yml')
-        assert f.exists()
-        assert f == mgr.user_list
-        ret = mgr.add_to_user_database('ocrd-foo', f)
-        ret = mgr.add_to_user_database('ocrd-foo', f)
-        assert ret
-        mgr.list_installed()
-        proc = 'ocrd-anybaseocr-layout-analysis'
-        url = 'https://ocr-d-repo.scc.kit.edu/models/dfki/layoutAnalysis/mapping_densenet.pickle'
-        fpath = mgr.download(proc, url, mgr.location_to_resource_dir('data'))
-        assert fpath.exists()
-        ret = mgr.add_to_user_database(proc, fpath)
-        ret = mgr.add_to_user_database(proc, fpath)
-        assert ret
+def test_resources_manager_config_default():
+
+    # arrange
+    from ocrd.resource_manager import OcrdResourceManager
+
+    # act
+    mgr = OcrdResourceManager()
+
+    #
+    default_config_dir = os.path.join(os.environ['HOME'], '.config', 'ocrd')
+    f = pathlib.Path(default_config_dir) / CONST_RESOURCE_YML
+    assert f.exists()
+    assert f == mgr.user_list
+    assert mgr.add_to_user_database('ocrd-foo', f)
+    mgr.list_installed()
+    proc = 'ocrd-anybaseocr-layout-analysis'
+    fpath = mgr.download(proc, CONST_RESOURCE_URL_LAYOUT, mgr.location_to_resource_dir('data'))
+    assert fpath.exists()
+    assert mgr.add_to_user_database(proc, fpath)
+
+
+def test_resources_manager_from_environment(tmp_path, monkeypatch):
+
+    # arrange
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    from ocrd.resource_manager import OcrdResourceManager
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path))
+    monkeypatch.setenv('XDG_DATA_HOME', str(tmp_path))
+
+    # act
+    mgr = OcrdResourceManager()
+
+    #
+    f = tmp_path / 'ocrd' / CONST_RESOURCE_YML
+    assert f.exists()
+    assert f == mgr.user_list
+    assert mgr.add_to_user_database('ocrd-foo', f)
+    mgr.list_installed()
+    proc = 'ocrd-anybaseocr-layout-analysis'
+    fpath = mgr.download(proc, CONST_RESOURCE_URL_LAYOUT, mgr.location_to_resource_dir('data'))
+    assert fpath.exists()
+    assert mgr.add_to_user_database(proc, fpath)
+
+
+def test_resources_manager_config_explicite(tmp_path):
+
+    # arrange
+    from ocrd.resource_manager import OcrdResourceManager
+
+    # act
+    mgr = OcrdResourceManager(xdb_config_home=str(tmp_path), xdb_data_home=str(tmp_path))
+
+    #
+    f = tmp_path / 'ocrd' / CONST_RESOURCE_YML
+    assert f.exists()
+    assert f == mgr.user_list
+    assert mgr.add_to_user_database('ocrd-foo', f)
+    mgr.list_installed()
+    proc = 'ocrd-anybaseocr-layout-analysis'
+    fpath = mgr.download(proc, CONST_RESOURCE_URL_LAYOUT, mgr.location_to_resource_dir('data'))
+    assert fpath.exists()
+    assert mgr.add_to_user_database(proc, fpath)
+
 
 if __name__ == "__main__":
     main(__file__)


### PR DESCRIPTION
This refactoring of test_resource_manager is also meant as proposal to reduce the environmental and internal dependencies in the ocrd-modules.

As @kba pointed out, there's actually a strong dependency between the resource_manager-module to the time, when the constants `XDG_CONFIG_HOME` and `XDG_DATA_HOME` are loaded / evaluated.
The trouble with testing the resource_manager originates from the - somehow intransparent - relationship to the execution environment i.e. context - intransparent to the caller in the moment of execution, which makes it difficult to test any depending functionalities, since testing is a rather artificial execution. The rather plain "workaround" for this bias is the possibility to pass these this info to the objects which require them, as properties or at initialization time. I found myself often ending up in implementations like this, which only exist to ease testing purposes and nothing else.

This way there's no need to run the three resource_manager tests separate from regular unit tests.

Personally, I tried even to go further this line, which simply results in having no "constant" values for `HOME` or the xdg-stuff, but rather evaluated both only when they are *really* required, but this interferes with other modules - os.py and bashlib.py, the latter which I do not yet understand.

