### PR TITLE
ocrd workspace bulk-add improvements

### DIFF
--- a/ocrd/ocrd/cli/bashlib.py
+++ b/ocrd/ocrd/cli/bashlib.py
@@ -65,6 +65,7 @@ def bashlib_constants(name):
             all_constants[k] = src.__dict__[k]
     if name in ['*', 'KEYS', '__all__']:
         print(sorted(all_constants.keys()))
+        sys.exit(0)
     if name not in all_constants:
         print("ERROR: name '%s' is not a known constant" % name, file=sys.stderr)
         sys.exit(1)

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -297,7 +297,11 @@ def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, file_grp
         file_paths += [Path(x.strip()) for x in sys.stdin.readlines()]
     else:
         for fglob in file_glob:
-            file_paths += [Path(x) for x in glob(fglob)]
+            expanded = glob(fglob)
+            if not expanded:
+                file_paths += [Path(fglob)]
+            else:
+                file_paths += [Path(x) for x in glob(fglob)]
 
     for i, file_path in enumerate(file_paths):
         log.info("[%4d/%d] %s" % (i, len(file_paths), file_path))
@@ -323,6 +327,8 @@ def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, file_grp
 
         # expand templates
         for param_name in file_dict:
+            if not file_dict[param_name]:
+                raise ValueError(f"OcrdFile attribute '{param_name}' unset ({file_dict})")
             for group_name in group_dict:
                 file_dict[param_name] = file_dict[param_name].replace('{{ %s }}' % group_name, group_dict[group_name])
 

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -18,7 +18,7 @@ import time
 import click
 
 from ocrd import Resolver, Workspace, WorkspaceValidator, WorkspaceBackupManager
-from ocrd_utils import getLogger, initLogging, pushd_popd, EXT_TO_MIME
+from ocrd_utils import getLogger, initLogging, pushd_popd, EXT_TO_MIME, safe_filename
 from ocrd.decorators import mets_find_options
 from . import command_with_replaced_help
 
@@ -237,7 +237,7 @@ def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, ignore, check_
 @click.option('-r', '--regex', help="Regular expression matching the FILE_GLOB filesystem paths to define named captures usable in the other parameters", required=True)
 @click.option('-m', '--mimetype', help="Media type of the file. If not provided, guess from filename", required=False)
 @click.option('-g', '--page-id', help="physical page ID of the file", required=False)
-@click.option('-i', '--file-id', help="ID of the file", required=True)
+@click.option('-i', '--file-id', help="ID of the file", required=False)
 @click.option('-u', '--url', help="local filesystem path in the workspace directory (copied from source file if different)", required=True)
 @click.option('-G', '--file-grp', help="File group USE of the file", required=True)
 @click.option('-n', '--dry-run', help="Don't actually do anything to the METS or filesystem, just preview", default=False, is_flag=True)
@@ -314,6 +314,10 @@ def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, file_grp
             log.error("File '%s' not matched by regex: '%s'" % (file_path, regex))
             sys.exit(1)
         group_dict = m.groupdict()
+
+        # derive --file-id from filename if not --file-id not explicitly set
+        if not file_id:
+            file_id = safe_filename(str(file_path))
 
         # set up file info
         file_dict = {'url': url, 'mimetype': mimetype, 'ID': file_id, 'pageId': page_id, 'fileGrp': file_grp}

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -229,7 +229,7 @@ def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, ignore, check_
     workspace.save_mets()
 
 # ----------------------------------------------------------------------
-# ocrd workspace add-bulk
+# ocrd workspace bulk-add
 # ----------------------------------------------------------------------
 
 # pylint: disable=broad-except
@@ -247,7 +247,7 @@ def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, ignore, check_
 @click.argument('file_glob', nargs=-1, required=True)
 @pass_workspace
 def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, file_grp, dry_run, file_glob, ignore, force, skip):
-    r"""
+    """
     Add files in bulk to an OCR-D workspace.
 
     FILE_GLOB can either be a shell glob expression or a list of files.

--- a/ocrd_utils/ocrd_utils/image.py
+++ b/ocrd_utils/ocrd_utils/image.py
@@ -6,6 +6,10 @@ from PIL import Image, ImageStat, ImageDraw, ImageChops
 from .logging import getLogger
 from .introspect import membername
 
+# Allow processing of images with up to 1.6bn pixels
+# https://github.com/OCR-D/core/issues/735
+Image.MAX_IMAGE_PIXELS = 40_000 ** 2
+
 __all__ = [
     'adjust_canvas_to_rotation',
     'adjust_canvas_to_transposition',

--- a/ocrd_utils/ocrd_utils/str.py
+++ b/ocrd_utils/ocrd_utils/str.py
@@ -175,7 +175,9 @@ def safe_filename(url):
     """
     Sanitize input to be safely used as the basename of a local file.
     """
-    ret = re.sub('[^A-Za-z0-9]+', '.', url)
+    ret = re.sub(r'[^A-Za-z0-9]+', '.', url)
+    ret = re.sub(r'^\.*', '', ret)
+    ret = re.sub(r'\.\.*', '.', ret)
     #  print('safe filename: %s -> %s' % (url, ret))
     return ret
 

--- a/tests/cli/test_bashlib.py
+++ b/tests/cli/test_bashlib.py
@@ -1,6 +1,7 @@
 from tests.base import CapturingTestCase as TestCase, main, assets, copy_of_directory
 
 import yaml
+import pytest
 
 from ocrd.cli.bashlib import bashlib_cli
 
@@ -41,9 +42,9 @@ class TestBashlibCli(TestCase):
         self.assertTrue(len(out) >= 40)
 
     def test_constants_fail(self):
-        exit_code, _, err = self.invoke_cli(bashlib_cli, ['constants', '1234!@#$--'])
-        self.assertEqual(exit_code, 1)
-        self.assertEqual(err, "ERROR: name '1234!@#$--' is not a known constant\n")
+        exit_code, out, err = self.invoke_cli(bashlib_cli, ['constants', '1234!@#$--'])
+        assert exit_code == 1
+        assert err == "ERROR: name '1234!@#$--' is not a known constant\n"
 
 if __name__ == "__main__":
     main(__file__)

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -466,6 +466,22 @@ class TestCli(TestCase):
                 print('err', err)
                 assert 0
 
+    def test_bulk_add_gen_id(self):
+        with pushd_popd(tempdir=True) as wsdir:
+            ws = self.resolver.workspace_from_nothing(directory=wsdir)
+            Path(wsdir, 'c').write_text('')
+            _, out, err = self.invoke_cli(workspace_cli, [
+                'bulk-add',
+                '-r', r'(?P<pageid>.*) (?P<filegrp>.*) (?P<src>.*) (?P<url>.*) (?P<mimetype>.*)',
+                '-G', '{{ filegrp }}',
+                '-g', '{{ pageid }}',
+                # '-i', '{{ fileid }}',  # XXX skip --file-id
+                '-m', '{{ mimetype }}',
+                '-u', "{{ url }}",
+                'a b c d e'])
+            ws.reload_mets()
+            assert next(ws.mets.find_files()).ID == 'a.b.c.d.e'
+
     def test_bulk_add_stdin(self):
         resolver = Resolver()
         with pushd_popd(tempdir=True) as wsdir:

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -481,6 +481,24 @@ class TestCli(TestCase):
                 'a b c d e'])
             ws.reload_mets()
             assert next(ws.mets.find_files()).ID == 'a.b.c.d.e'
+            assert next(ws.mets.find_files()).url == 'd'
+
+    def test_bulk_add_derive_url(self):
+        with pushd_popd(tempdir=True) as wsdir:
+            ws = self.resolver.workspace_from_nothing(directory=wsdir)
+            Path(wsdir, 'srcdir').mkdir()
+            Path(wsdir, 'srcdir', 'src.xml').write_text('')
+            _, out, err = self.invoke_cli(workspace_cli, [
+                'bulk-add',
+                '-r', r'(?P<pageid>.*) (?P<filegrp>.*) (?P<src>.*)',
+                '-G', '{{ filegrp }}',
+                '-g', '{{ pageid }}',
+                # '-u', "{{ url }}", # XXX skip --url
+                'p0001 SEG srcdir/src.xml'])
+            # print('out', out)
+            # print('err', err)
+            ws.reload_mets()
+            assert next(ws.mets.find_files()).url == 'srcdir/src.xml'
 
     def test_bulk_add_stdin(self):
         resolver = Resolver()

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -449,6 +449,23 @@ class TestCli(TestCase):
                     self.assertEqual(len(ws.mets.find_all_files(pageId='PHYS_0001')), 2)
                     self.assertEqual(ws.mets.find_all_files(ID='FILE_OCR-D-PAGE_0001')[0].url, 'OCR-D-PAGE/FILE_0001.xml')
 
+    def test_bulk_add_missing_param(self):
+        with pushd_popd(tempdir=True) as wsdir:
+            ws = self.resolver.workspace_from_nothing(directory=wsdir)
+            with pytest.raises(ValueError, match=r"OcrdFile attribute 'pageId' unset"):
+                _, out, err = self.invoke_cli(workspace_cli, [
+                    'bulk-add',
+                    '-r', r'(?P<pageid>.*) (?P<filegrp>.*) (?P<fileid>.*) (?P<src>.*) (?P<url>.*) (?P<mimetype>.*)',
+                    '-G', '{{ filegrp }}',
+                    # '-g', '{{ pageid }}', # XXX skip --page-id
+                    '-i', '{{ fileid }}',
+                    '-m', '{{ mimetype }}',
+                    '-u', "{{ url }}",
+                    'a b c d e f', '1 2 3 4 5 6'])
+                print('out', out)
+                print('err', err)
+                assert 0
+
     def test_bulk_add_stdin(self):
         resolver = Resolver()
         with pushd_popd(tempdir=True) as wsdir:
@@ -479,6 +496,7 @@ class TestCli(TestCase):
                 f = next(ws.mets.find_files())
                 assert f.mimetype == 'image/png'
                 assert f.ID == 'FILE_0001_BIN.IMG-wolf'
+                assert f.url == 'BIN/FILE_0001_BIN.IMG-wolf.png'
 
 if __name__ == '__main__':
     main(__file__)

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -6,5 +6,8 @@ def test_32bit_fill():
     img = Image.new('F', (200, 100), 1)
     rotate_image(img, 0.1, fill='background', transparency=False)
 
+def test_max_image_pixels():
+    assert Image.MAX_IMAGE_PIXELS == 40_000 ** 2
+
 if __name__ == '__main__':
     main([__file__])


### PR DESCRIPTION
This implements the behaviors discussed in #641, #754 and #769:

* Support parsing the "file path" as a more complex list of values so that the "file path" can actually be "file path + url + mimetype + ..."
* If `FILE_GLOB` argument is `-` (single dash), read the data from STDIN
* `--file-id` is now optional, generated from the file path if omitted
* If `--url` is omitted, assume that the source file path is to be the URL of the OcrdFIle
* Provide more descriptive Exception when encountering empty/unset CLI options
* Do not convert any file paths to absolute to simplify regexes