### PR TITLE
Show resource subdir

### DIFF
--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -104,7 +104,7 @@ class Processor():
                 print(res)
             return
         if show_resource:
-            res_fname = list_resource_candidates(ocrd_tool['executable'], show_resource, is_file=True)
+            res_fname = list_resource_candidates(ocrd_tool['executable'], show_resource)
             if not res_fname:
                 initLogging()
                 logger = getLogger('ocrd.%s.__init__' % ocrd_tool['executable'])

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -27,6 +27,7 @@ from ocrd_utils import (
     list_resource_candidates,
     pushd_popd,
     list_all_resources,
+    are_processor_resources_directories,
 )
 from ocrd_validators import ParameterValidator
 from ocrd_models.ocrd_page import MetadataItemType, LabelType, LabelsType
@@ -99,16 +100,11 @@ class Processor():
             print(json.dumps(ocrd_tool, indent=True))
             return
         if list_resources:
-            for res in list_all_resources(ocrd_tool['executable']):
+            for res in list_all_resources(ocrd_tool['executable'], is_dir=are_processor_resources_directories(None, ocrd_tool)):
                 print(res)
             return
         if show_resource:
-            # XXX if a processor has at least one parameter with
-            # `content-type == text/directory`, assume ALL file parameters
-            # point to directories, not files
-            has_at_least_one_directory_parameter = next((True for p in ocrd_tool['parameters'].values()
-                if 'content-type' in p and p['content-type'] == 'text/directory'), False)
-            is_dir = has_at_least_one_directory_parameter
+            is_dir = are_processor_resources_directories(None, ocrd_tool)
             is_file = not(is_dir)
             res_fname = list_resource_candidates(ocrd_tool['executable'], show_resource, is_file=is_file, is_dir=is_dir)
             if not res_fname:

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -116,8 +116,16 @@ class Processor():
                 logger = getLogger('ocrd.%s.__init__' % ocrd_tool['executable'])
                 logger.error("Failed to resolve %s for processor %s" % (show_resource, ocrd_tool['executable']))
             else:
-                with open(res_fname[0], 'rb') as f:
-                    copyfileobj(f, sys.stdout.buffer)
+                fpath = Path(res_fname[0])
+                if fpath.is_dir():
+                    with pushd_popd(fpath):
+                        fileobj = io.BytesIO()
+                        with tarfile.open(fileobj=fileobj, mode='w:gz') as tarball:
+                            tarball.add('.')
+                        fileobj.seek(0)
+                        copyfileobj(fileobj, sys.stdout.buffer)
+                else:
+                    sys.stdout.buffer.write(fpath.read_bytes())
             return
         self.ocrd_tool = ocrd_tool
         if show_help:

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -27,7 +27,7 @@ from ocrd_utils import (
     list_resource_candidates,
     pushd_popd,
     list_all_resources,
-    are_processor_resources_directories,
+    get_processor_resource_types
 )
 from ocrd_validators import ParameterValidator
 from ocrd_models.ocrd_page import MetadataItemType, LabelType, LabelsType
@@ -100,13 +100,17 @@ class Processor():
             print(json.dumps(ocrd_tool, indent=True))
             return
         if list_resources:
-            for res in list_all_resources(ocrd_tool['executable'], is_dir=are_processor_resources_directories(None, ocrd_tool)):
+            has_dirs, has_files = get_processor_resource_types(None, ocrd_tool)
+            for res in list_all_resources(ocrd_tool['executable']):
+                if Path(res).is_dir() and not has_dirs:
+                    continue
+                if not Path(res).is_dir() and not has_files:
+                    continue
                 print(res)
             return
         if show_resource:
-            is_dir = are_processor_resources_directories(None, ocrd_tool)
-            is_file = not(is_dir)
-            res_fname = list_resource_candidates(ocrd_tool['executable'], show_resource, is_file=is_file, is_dir=is_dir)
+            has_dirs, has_files = get_processor_resource_types(None, ocrd_tool)
+            res_fname = list_resource_candidates(ocrd_tool['executable'], show_resource)
             if not res_fname:
                 initLogging()
                 logger = getLogger('ocrd.%s.__init__' % ocrd_tool['executable'])

--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -11,7 +11,7 @@ from yaml import safe_load, safe_dump
 
 from ocrd_validators import OcrdResourceListValidator
 from ocrd_utils import getLogger
-from ocrd_utils.os import are_processor_resources_directories, list_all_resources, pushd_popd
+from ocrd_utils.os import get_processor_resource_types, list_all_resources, pushd_popd
 from .constants import RESOURCE_LIST_FILENAME, RESOURCE_USER_LIST_COMMENT
 
 class OcrdResourceManager():
@@ -104,7 +104,12 @@ class OcrdResourceManager():
                     all_executables += [x for x in listdir(parent_dir) if x.startswith('ocrd-')]
         for this_executable in set(all_executables):
             reslist = []
-            for res_filename in list_all_resources(this_executable, is_dir=are_processor_resources_directories(this_executable)):
+            has_dirs, has_files = get_processor_resource_types(this_executable)
+            for res_filename in list_all_resources(this_executable):
+                if Path(res_filename).is_dir() and not has_dirs:
+                    continue
+                if Path(res_filename).is_file() and not has_files:
+                    continue
                 res_name = Path(res_filename).name
                 resdict = [x for x in self.database.get(this_executable, []) if x['name'] == res_name]
                 if not resdict:

--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from os.path import join
 from os import environ, listdir, getcwd, path
-import re
 from shutil import copytree
 from datetime import datetime
 from tarfile import open as open_tarfile

--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -12,7 +12,7 @@ from yaml import safe_load, safe_dump
 
 from ocrd_validators import OcrdResourceListValidator
 from ocrd_utils import getLogger
-from ocrd_utils.os import list_all_resources, pushd_popd
+from ocrd_utils.os import are_processor_resources_directories, list_all_resources, pushd_popd
 from ocrd_utils.constants import XDG_CONFIG_HOME, XDG_DATA_HOME
 
 from .constants import RESOURCE_LIST_FILENAME, RESOURCE_USER_LIST_COMMENT
@@ -76,7 +76,7 @@ class OcrdResourceManager():
                     all_executables += [x for x in listdir(parent_dir) if x.startswith('ocrd-')]
         for this_executable in set(all_executables):
             reslist = []
-            for res_filename in list_all_resources(this_executable):
+            for res_filename in list_all_resources(this_executable, is_dir=are_processor_resources_directories(this_executable)):
                 res_name = Path(res_filename).name
                 resdict = [x for x in self.database.get(this_executable, []) if x['name'] == res_name]
                 if not resdict:

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -164,7 +164,7 @@ from .logging import (
 
 from .os import (
     abspath,
-    are_processor_resources_directories,
+    get_processor_resource_types,
     list_all_resources,
     list_resource_candidates,
     atomic_write,

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -165,6 +165,7 @@ from .logging import (
 
 from .os import (
     abspath,
+    are_processor_resources_directories,
     list_all_resources,
     list_resource_candidates,
     atomic_write,

--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -117,6 +117,11 @@ def get_processor_resource_types(executable, ocrd_tool=None):
             return (True, True)
         result = run([executable, '--dump-json'], stdout=PIPE, check=True, universal_newlines=True)
         ocrd_tool = loads(result.stdout)
+    if not next((True for p in ocrd_tool['parameters'].values() if 'content-type' in p), False):
+        # None of the parameters for this processor are resources (or not
+        # the resource parametrs are not properly declared, so output both
+        # directories and files
+        return (True, True)
     has_dirs = next((True for p in ocrd_tool['parameters'].values() if p.get('content-type', None) == 'text/directory'), False)
     has_files = next((True for p in ocrd_tool['parameters'].values() if 'content-type' in p and p['content-type'] != 'text/directory'), False)
     return (has_dirs, has_files)

--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -117,8 +117,8 @@ def get_processor_resource_types(executable, ocrd_tool=None):
             return (True, True)
         result = run([executable, '--dump-json'], stdout=PIPE, check=True, universal_newlines=True)
         ocrd_tool = loads(result.stdout)
-    has_dirs = next((True for p in ocrd_tool['parameters'].values() if 'content-type' in p and p['content-type'] == 'text/directory'), False)
-    has_files = next((True for p in ocrd_tool['parameters'].values() if 'content-type' in p and p['content-type'] != 'text/directory'), False)
+    has_dirs = next((True for p in ocrd_tool['parameters'].values() if p.get('content-type', None) == 'text/directory'), False)
+    has_files = next((True for p in ocrd_tool['parameters'].values() if p.get('content-type', None) != 'text/directory'), False)
     return (has_dirs, has_files)
 
 # ht @pabs3

--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -98,6 +98,10 @@ def list_all_resources(executable):
     systemdir = join('/usr/local/share/ocrd-resources', executable)
     if isdir(systemdir):
         candidates += list(scandir(systemdir))
+    # recurse once
+    for parent in [Path(x) for x in candidates]:
+        if Path(parent).is_dir():
+            candidates += list(scandir(parent))
     return [x.path for x in candidates]
 
 # ht @pabs3

--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -118,7 +118,7 @@ def get_processor_resource_types(executable, ocrd_tool=None):
         result = run([executable, '--dump-json'], stdout=PIPE, check=True, universal_newlines=True)
         ocrd_tool = loads(result.stdout)
     has_dirs = next((True for p in ocrd_tool['parameters'].values() if p.get('content-type', None) == 'text/directory'), False)
-    has_files = next((True for p in ocrd_tool['parameters'].values() if p.get('content-type', None) != 'text/directory'), False)
+    has_files = next((True for p in ocrd_tool['parameters'].values() if 'content-type' in p and p['content-type'] != 'text/directory'), False)
     return (has_dirs, has_files)
 
 # ht @pabs3

--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -12,6 +12,7 @@ __all__ = [
 
 from tempfile import TemporaryDirectory
 import contextlib
+from distutils.spawn import find_executable as which
 from json import loads
 from os import getcwd, chdir, stat, chmod, umask, environ
 from pathlib import Path
@@ -118,7 +119,10 @@ def are_processor_resources_directories(executable, ocrd_tool=None):
     point to directories, not files
     """
     if not ocrd_tool:
-        ocrd_tool = loads(run([executable, '--dump-json'], stdout=PIPE, check=True, universal_newlines=True))
+        if not which(executable):
+            return False
+        result = run([executable, '--dump-json'], stdout=PIPE, check=True, universal_newlines=True)
+        ocrd_tool = loads(result.stdout)
     return next((True for p in ocrd_tool['parameters'].values() if 'content-type' in p and p['content-type'] == 'text/directory'), False)
 
 # ht @pabs3


### PR DESCRIPTION
This partially implements #750,. `ocrd-processor --list-resources` will show directories as well as files and will traverse one level down from the processor data location to support subdirectories like in tesseract (`script/Fraktur.traineddata` etc.)