### PR TITLE
bashlib parse_argv: must validate with params

### DIFF
--- a/ocrd/bashlib/src/parse_argv.bash
+++ b/ocrd/bashlib/src/parse_argv.bash
@@ -78,7 +78,7 @@ ocrd__parse_argv () {
     if [[ -n "${ocrd__argv[page_id]:-}" ]]; then
         _valopts+=( --page-id "${ocrd__argv[page_id]}" )
     fi
-    _valopts+=( "${OCRD_TOOL_NAME#ocrd-} -I ${ocrd__argv[input_file_grp]} -O ${ocrd__argv[output_file_grp]} ${__parameters[*]} ${__parameter_overrides[*]}" )
+    _valopts+=( "${OCRD_TOOL_NAME#ocrd-} -I ${ocrd__argv[input_file_grp]} -O ${ocrd__argv[output_file_grp]} ${__parameters[*]@Q} ${__parameter_overrides[*]@Q}" )
     ocrd validate tasks "${_valopts[@]}" || exit $?
 
     # check parameters

--- a/ocrd/bashlib/src/parse_argv.bash
+++ b/ocrd/bashlib/src/parse_argv.bash
@@ -78,7 +78,7 @@ ocrd__parse_argv () {
     if [[ -n "${ocrd__argv[page_id]:-}" ]]; then
         _valopts+=( --page-id "${ocrd__argv[page_id]}" )
     fi
-    _valopts+=( "${OCRD_TOOL_NAME#ocrd-} -I ${ocrd__argv[input_file_grp]} -O ${ocrd__argv[output_file_grp]}" )
+    _valopts+=( "${OCRD_TOOL_NAME#ocrd-} -I ${ocrd__argv[input_file_grp]} -O ${ocrd__argv[output_file_grp]} ${__parameters[*]} ${__parameter_overrides[*]}" )
     ocrd validate tasks "${_valopts[@]}" || exit $?
 
     # check parameters

--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -180,7 +180,7 @@ ocrd__parse_argv () {
     if [[ -n "${ocrd__argv[page_id]:-}" ]]; then
         _valopts+=( --page-id "${ocrd__argv[page_id]}" )
     fi
-    _valopts+=( "${OCRD_TOOL_NAME#ocrd-} -I ${ocrd__argv[input_file_grp]} -O ${ocrd__argv[output_file_grp]}" )
+    _valopts+=( "${OCRD_TOOL_NAME#ocrd-} -I ${ocrd__argv[input_file_grp]} -O ${ocrd__argv[output_file_grp]} ${__parameters[*]@Q} ${__parameter_overrides[*]@Q}" )
     ocrd validate tasks "${_valopts[@]}" || exit $?
 
     # check parameters


### PR DESCRIPTION
This is needed for processors that have _required_ parameters – otherwise the ocrd__wrapped `ocrd validate tasks` will fail.