### PR TITLE
[test][fix] capsys fixture recognizes streams

### DIFF
--- a/tests/test_logging_conf.py
+++ b/tests/test_logging_conf.py
@@ -47,7 +47,8 @@ def test_configured_dateformat(logging_conf, capsys):
         # act
         test_logger.info("test logger initialized")
 
-        log_info_output = capsys.readouterr().err
+        (out, err) = capsys.readouterr()
+        log_info_output = out if out else err
         must_not_match = r"^\d{4}-\d{2}-\d{2}.*"
         assert not re.match(must_not_match, log_info_output)
         match_pattern = r"^\d{2}:\d{2}:\d{2}.*"
@@ -64,12 +65,14 @@ def test_configured_tensorflow_logger_present(logging_conf, capsys):
 
     # act info
     logger_under_test.info("tensorflow logger initialized")
-    log_info_output = capsys.readouterr().err
+    (out, err) = capsys.readouterr()
+    log_info_output = out if out else err
     assert not log_info_output
 
     # act error
     logger_under_test.error("tensorflow has error")
-    log_error_output = capsys.readouterr().err
+    (out, err) = capsys.readouterr()
+    log_error_output = out if out else err
     assert log_error_output
 
 
@@ -83,12 +86,14 @@ def test_configured_shapely_logger_present(logging_conf, capsys):
 
     # act info
     logger_under_test.info("shapely.geos logger initialized")
-    log_info_output = capsys.readouterr().err
-    assert not log_info_output
+    (out, err) = capsys.readouterr()
+    log_error_output = out if out else err
+    assert not log_error_output
 
     # act error
     logger_under_test.error("shapely alert")
-    log_error_output = capsys.readouterr().err
+    (out, err) = capsys.readouterr()
+    log_error_output = out if out else err
     assert log_error_output
 
 if __name__ == '__main__':


### PR DESCRIPTION
@bertsky I could not completely reproduce what has been mentioned here (https://github.com/OCR-D/core/pull/770):

> take the default ocrd_utils/ocrd_logging.conf and modify it in some places, say by defining a logger for qualname=PIL and level=ERROR (which will fail at 
> [core/tests/test_decorators.py](https://github.com/OCR-D/core/blob/9567190aaceba7f6d24d169633d698382065533a/tests/test_decorators.py#L64)
> Line 64 in [9567190](https://github.com/OCR-D/core/commit/9567190aaceba7f6d24d169633d698382065533a) self.assertEqual(logging.getLogger('PIL').getEffectiveLevel(), logging.INFO) ), or by setting the default consoleHandler to sys.stdout instead of stderr.

although I can confirm, that with the current test resources'  `ocrd_utils/ocrd_logging.conf` all three testcases of `tests/test_logging_conf.py` do fail when default consoleHandler'  `arg` is set to `(sys.stdout,)` instead of `(sys.stderr,)`. That's caused for the testcases go straight for `capsys.readouterr().err` which is obviously not present when the consoleHandler is set to `sys.stdout`. Therefore the new distinction in the tests. 

Maybe with the decorator-tests there's some wired interference with the click-handling ... 

