### PR TITLE
Assets change

### DIFF
--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -576,11 +576,12 @@ def set_id(ctx, id):   # pylint: disable=redefined-builtin
 
 @workspace_cli.command('merge')
 @click.argument('METS_PATH')
+@click.option('--overwrite/--no-overwrite', is_flag=True, default=False, help="Overwrite in case of file name conflicts with data from METS_PATH")
 @click.option('--copy-files/--no-copy-files', is_flag=True, help="Copy files as well", default=True, show_default=True)
 @click.option('--fileGrp-mapping', help="JSON object mapping src to dest fileGrp")
 @mets_find_options
 @pass_workspace
-def merge(ctx, copy_files, filegrp_mapping, file_grp, file_id, page_id, mimetype, mets_path):   # pylint: disable=redefined-builtin
+def merge(ctx, overwrite, copy_files, filegrp_mapping, file_grp, file_id, page_id, mimetype, mets_path):   # pylint: disable=redefined-builtin
     """
     Merges this workspace with the workspace that contains ``METS_PATH``
 
@@ -595,6 +596,7 @@ def merge(ctx, copy_files, filegrp_mapping, file_grp, file_id, page_id, mimetype
     other_workspace = Workspace(ctx.resolver, directory=str(mets_path.parent), mets_basename=str(mets_path.name))
     workspace.merge(
         other_workspace,
+        overwrite=overwrite,
         copy_files=copy_files,
         fileGrp_mapping=filegrp_mapping,
         fileGrp=file_grp,

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -93,7 +93,7 @@ class Workspace():
         """
         self.mets = OcrdMets(filename=self.mets_target)
 
-    def merge(self, other_workspace, copy_files=True, **kwargs):
+    def merge(self, other_workspace, copy_files=True, overwrite=False, **kwargs):
         """
         Merge ``other_workspace`` into this one
 
@@ -108,7 +108,7 @@ class Workspace():
             fpath_src = Path(other_workspace.directory, f.url)
             fpath_dest = Path(self.directory, f.url)
             if fpath_src.exists():
-                if fpath_dest.exists():
+                if fpath_dest.exists() and not overwrite:
                     raise Exception("Copying %s to %s would overwrite the latter" % (fpath_src, fpath_dest))
                 if not fpath_dest.parent.is_dir():
                     makedirs(str(fpath_dest.parent))

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -276,7 +276,7 @@ class TestCli(TestCase):
             self.assertEqual(result.exit_code, 0)
 
             ws2 = self.resolver.workspace_from_url(join(tempdir, 'ws', 'mets.xml'))
-            self.assertEqual(len(ws2.mets.find_all_files()), 7)
+            self.assertEqual(len(ws2.mets.find_all_files()), 29)
 
     def test_clone_into_nonexisting_dir(self):
         """

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -85,7 +85,7 @@ def test_find_all_files_no_regex_for_pageid(sbb_sample_01):
 
 def test_find_all_files_local_only(sbb_sample_01):
     assert len(sbb_sample_01.find_all_files(pageId='PHYS_0001',
-               local_only=True)) == 3, '3 local files for page "PHYS_0001"'
+               local_only=True)) == 14, '14 local files for page "PHYS_0001"'
 
 
 def test_physical_pages(sbb_sample_01):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -289,7 +289,7 @@ def test_rename_file_group(tmp_path):
     ocrd_file.local_filename = join(tmp_path, relative_name)
     pcgts_before = page_from_file(ocrd_file)
     # before assert
-    assert pcgts_before.get_Page().imageFilename == 'OCR-D-IMG/OCR-D-IMG_0001.tif'
+    assert pcgts_before.get_Page().imageFilename == 'OCR-D-IMG/INPUT_0017.tif'
 
     # act
     workspace.rename_file_group('OCR-D-IMG', 'FOOBAR')
@@ -298,8 +298,8 @@ def test_rename_file_group(tmp_path):
     pcgts_after = page_from_file(next_ocrd_file)
 
     # assert
-    assert pcgts_after.get_Page().imageFilename == 'FOOBAR/FOOBAR_0001.tif'
-    assert Path(tmp_path / 'FOOBAR/FOOBAR_0001.tif').exists()
+    assert pcgts_after.get_Page().imageFilename == 'FOOBAR/INPUT_0017.tif'
+    assert Path(tmp_path / 'FOOBAR/INPUT_0017.tif').exists()
     assert not Path('OCR-D-IMG/OCR-D-IMG_0001.tif').exists()
     assert workspace.mets.get_physical_pages(for_fileIds=['OCR-D-IMG_0001']) == [None]
     assert workspace.mets.get_physical_pages(for_fileIds=['FOOBAR_0001']) == ['phys_0001']
@@ -538,11 +538,11 @@ def test_merge(tmp_path):
     assert len(ws1.mets.find_all_files()) == 6
 
     # act
-    ws1.merge(ws2)
+    ws1.merge(ws2, overwrite=True)
 
     # assert
     assert len(ws1.mets.find_all_files()) == 41
-    assert exists(join(dst_path1, 'OCR-D-IMG/FILE_0001_IMAGE.tif'))
+    assert exists(join(dst_path1, 'OCR-D-IMG/INPUT_0017.tif'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update the assets to include the latest fixes in the test data. This means that the SBB-sample now has fewer dangling files.

It also became apparent that the `ocrd workspace merge` functionality needs an `--overwrite` flag too in case both workspaces contain files named identically.