### PR TITLE
Processor.resolve_resource: support on-demand download of URL values

### DIFF
--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -10,7 +10,7 @@ import requests
 from yaml import safe_load, safe_dump
 
 from ocrd_validators import OcrdResourceListValidator
-from ocrd_utils import getLogger
+from ocrd_utils import getLogger, nth_url_segment
 from ocrd_utils.os import get_processor_resource_types, list_all_resources, pushd_popd
 from .constants import RESOURCE_LIST_FILENAME, RESOURCE_USER_LIST_COMMENT
 
@@ -235,8 +235,7 @@ class OcrdResourceManager():
         log = getLogger('ocrd.resource_manager.download')
         destdir = Path(basedir) if no_subdir else Path(basedir, executable)
         if not name:
-            url_parsed = urlparse(url)
-            name = Path(unquote(url_parsed.path)).name
+            name = nth_url_segment(url)
         fpath = Path(destdir, name)
         is_url = url.startswith('https://') or url.startswith('http://')
         if fpath.exists() and not overwrite:


### PR DESCRIPTION
With this in place, users can use URL directly for parameter values:

```
ocrd-tesserocr-recognize -P model https://github.com/tesseract-ocr/tessdata_best/raw/main/bos.traineddata
```

and it should download on demand the first time it encounters and registers the URL in the user resource_list.yml. Subsequent calls will use the cached download.

**In practice though** I cannot seem to find an example where this works:

* `ocrd_{tesserocr,cis-ocropy}` have a different mechanism of model storage. It's still compatible with `ocrd resmgr download` in tesserocr's case but does not use the `self.resolve_resource` method this PR extends
* `ocrd_calamari` requires a directory of files, or an archive which is too complex to do on demand in a generalized way IMHO
* `ocrd-page-transform` is a bashlib processor and won't support this.

So if anybody has a good idea on how to test and/or generalize this to make it available to all the processors, pls let me know.