### PR TITLE
Fix the cp command so that it also works on macOS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ spec: repo/spec
 assets: repo/assets
 	rm -rf $(TESTDIR)/assets
 	mkdir -p $(TESTDIR)/assets
-	cp -r -t $(TESTDIR)/assets repo/assets/data/*
+	cp -r repo/assets/data/* $(TESTDIR)/assets
 
 
 #


### PR DESCRIPTION
To make this `cp` command work on macOS, the `-t` was removed and 2 arguments were swapped.