### PR TITLE
resmgr: do not parse strings to dates in YAML, fix #867

### DIFF
--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -9,6 +9,12 @@ from urllib.parse import urlparse, unquote
 import requests
 from yaml import safe_load, safe_dump
 
+# https://github.com/OCR-D/core/issues/867
+# https://stackoverflow.com/questions/50900727/skip-converting-entities-while-loading-a-yaml-string-using-pyyaml
+import yaml.constructor
+yaml.constructor.SafeConstructor.yaml_constructors[u'tag:yaml.org,2002:timestamp'] = \
+    yaml.constructor.SafeConstructor.yaml_constructors[u'tag:yaml.org,2002:str']
+
 from ocrd_validators import OcrdResourceListValidator
 from ocrd_utils import getLogger
 from ocrd_utils.os import get_processor_resource_types, list_all_resources, pushd_popd

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -104,5 +104,21 @@ def test_default_resource_dir(tmp_path):
     assert mgr.xdg_config_home != mgr.xdg_data_home
     assert mgr.default_resource_dir == str(mgr.xdg_data_home / 'ocrd-resources')
 
+def test_date_as_string(tmp_path):
+    mgr = OcrdResourceManager(xdg_data_home=tmp_path)
+    test_list = tmp_path / 'test-list.yml'
+    with open(test_list, 'w', encoding='utf-8') as fout:
+        fout.write("""\
+    ocrd-eynollah-segment:
+      - url: https://qurator-data.de/eynollah/2022-04-05/models_eynollah_renamed.tar.gz
+        name: 2022-04-05
+        description: models for eynollah
+        type: tarball
+        path_in_archive: 'models_eynollah'
+        size: 1889719626
+        """)
+    mgr.load_resource_list(test_list)
+    mgr.list_available(executable='ocrd-eynollah-segment')
+
 if __name__ == "__main__":
     main(__file__)


### PR DESCRIPTION
This is a "convenience behavior" by the YAML parser, to try to parse strings as datetime. This PR stops this behavior.