### PR TITLE
ocrd log: read from stdin if passed "-", fix #852

### DIFF
--- a/ocrd/ocrd/cli/log.py
+++ b/ocrd/ocrd/cli/log.py
@@ -36,6 +36,9 @@ def _bind_log_command(lvl):
     def _log_wrapper(ctx, msgs):
         if not msgs:
             ctx.log(lvl.upper(), '')
+        elif len(msgs) == 1 and msgs[0] == '-':
+            for stdin_line in click.get_text_stream('stdin'):
+                ctx.log(lvl.upper(), stdin_line.rstrip('\n'))
         else:
             msg = list(msgs) if '%s' in msgs[0] else ' '.join([x.replace('%', '%%') for x in msgs])
             ctx.log(lvl.upper(), msg)


### PR DESCRIPTION
So you can do

```
echo "foo bar
quux" | ocrd log warning -
```

and get

```
13:08:48.815 WARNING root - foo bar
13:08:48.815 WARNING root - quux
```