### PR TITLE
New JSON-Schema constructs for ocrd-tool.json validator

### DIFF
--- a/ocrd_validators/ocrd_validators/bagit-profile.yml
+++ b/ocrd_validators/ocrd_validators/bagit-profile.yml
@@ -1,5 +1,5 @@
 BagIt-Profile-Info:
-  BagIt-Profile-Identifier: https://ocr-d.de/bagit-profile.json
+  BagIt-Profile-Identifier: https://ocr-d.de/en/spec/bagit-profile.json
   BagIt-Profile-Version: '1.2.0'
   Source-Organization: OCR-D
   External-Description: BagIt profile for OCR data
@@ -14,10 +14,6 @@ Bag-Info:
   Ocrd-Mets:
     required: false
     default: 'mets.xml'
-  Ocrd-Manifestation-Depth:
-    required: false
-    default: partial
-    values: ["partial", "full"]
   Ocrd-Identifier:
     required: true
   Ocrd-Checksum:
@@ -34,7 +30,7 @@ Tag-Files-Allowed:
   - sources.csv
   - metadata/*.xml
   - metadata/*.txt
-Allow-Fetch.txt: true
+Allow-Fetch.txt: false
 Serialization: required
 Accept-Serialization: application/zip
 Accept-BagIt-Version:

--- a/ocrd_validators/ocrd_validators/json_validator.py
+++ b/ocrd_validators/ocrd_validators/json_validator.py
@@ -3,7 +3,7 @@ Validating JSON-Schema
 """
 import json
 
-from jsonschema import Draft4Validator, validators # pylint: disable=import-error
+from jsonschema import Draft6Validator, validators # pylint: disable=import-error
 
 from ocrd_models import ValidationReport
 
@@ -28,7 +28,7 @@ def extend_with_default(validator_class):
     return validators.extend(validator_class, {"properties": set_defaults})
 
 
-DefaultValidatingDraft4Validator = extend_with_default(Draft4Validator)
+DefaultValidatingDraft6Validator = extend_with_default(Draft6Validator)
 
 #
 # -------------------------------------------------
@@ -52,13 +52,13 @@ class JsonValidator():
             obj = json.loads(obj)
         return JsonValidator(schema)._validate(obj) # pylint: disable=protected-access
 
-    def __init__(self, schema, validator_class=Draft4Validator):
+    def __init__(self, schema, validator_class=Draft6Validator):
         """
         Construct a JsonValidator.
 
         Args:
             schema (dict):
-            validator_class (Draft4Validator|DefaultValidatingDraft4Validator):
+            validator_class (Draft6Validator|DefaultValidatingDraft6Validator):
         """
         self.validator = validator_class(schema)
 

--- a/ocrd_validators/ocrd_validators/ocrd_tool.schema.yml
+++ b/ocrd_validators/ocrd_validators/ocrd_tool.schema.yml
@@ -41,13 +41,13 @@ properties:
             type: array
             items:
               type: string
-              pattern: '^OCR-D-[A-Z0-9-]+$'
+              # pattern: '^OCR-D-[A-Z0-9-]+$'
           output_file_grp:
             description: Output fileGrp@USE this tool produces by default
             type: array
             items:
               type: string
-              pattern: '^OCR-D-[A-Z0-9-]+$'
+              # pattern: '^OCR-D-[A-Z0-9-]+$'
           parameters:
             description: Object describing the parameters of a tool. Keys are parameter names, values sub-schemas.
             type: object
@@ -73,6 +73,30 @@ properties:
                     description: Subtype, such as `float` for type `number` or `uri` for type `string`.
                   description:
                     description: Concise description of syntax and semantics of this parameter
+                  items:
+                    type: object
+                    description: describe the items of an array further
+                  minimum:
+                    type: number
+                    description: Minimum value for number parameters, including the minimum
+                  maximum:
+                    type: number
+                    description: Maximum value for number parameters, including the maximum
+                  exclusiveMinimum:
+                    type: number
+                    description: Minimum value for number parameters, excluding the minimum
+                  exclusiveMaximum:
+                    type: number
+                    description: Maximum value for number parameters, excluding the maximum
+                  multipleOf:
+                    type: number
+                    description: For number values, those values must be multiple of this number
+                  properties:
+                    type: object
+                    description: Describe the properties of an object value
+                  additionalProperties:
+                    type: boolean
+                    description: Whether an object value may contain properties not explicitly defined
                   required:
                     type: boolean
                     description: Whether this parameter is required
@@ -83,7 +107,15 @@ properties:
                     description: List the allowed values if a fixed list.
                   content-type:
                     type: string
-                    description: "If parameter is reference to file: Media type of the file"
+                    default: 'application/octet-stream'
+                    description: >
+                      The media type of resources this processor expects for
+                      this parameter. Most processors use files for resources
+                      (e.g.  `*.traineddata` for `ocrd-tesserocr-recognize`)
+                      while others use directories of files (e.g. `default` for
+                      `ocrd-eynollah-segment`).  If a parameter requires
+                      directories, it must set `content-type` to
+                      `text/directory`.
                   cacheable:
                     type: boolean
                     description: "If parameter is reference to file: Whether the file should be cached, e.g. because it is large and won't change."
@@ -126,3 +158,52 @@ properties:
                 - layout/segmentation/word
                 - layout/segmentation/classification
                 - layout/analysis
+          resource_locations:
+            type: array
+            description: The locations in the filesystem this processor supports for resource lookup
+            default: ['data', 'cwd', 'system', 'module']
+            items:
+              type: string
+              enum: ['data', 'cwd', 'system', 'module']
+          resources:
+            type: array
+            description: Resources for this processor
+            items:
+              type: object
+              additionalProperties: false
+              required:
+                - url
+                - description
+                - name
+                - size
+              properties:
+                url:
+                  type: string
+                  description: URLs of all components of this resource
+                description:
+                  type: string
+                  description: A description of the resource
+                name:
+                  type: string
+                  description: Name to store the resource as
+                type:
+                  type: string
+                  enum: ['file', 'directory', 'archive']
+                  default: file
+                  description: Type of the URL
+                parameter_usage:
+                  type: string
+                  description: Defines how the parameter is to be used
+                  enum: ['as-is', 'without-extension']
+                  default: 'as-is'
+                path_in_archive:
+                  type: string
+                  description: if type is archive, the resource is at this location in the archive
+                  default: '.'
+                version_range:
+                  type: string
+                  description: Range of supported versions, syntax like in PEP 440
+                  default: '>= 0.0.1'
+                size:
+                  type: number
+                  description: Size of the resource in bytes

--- a/ocrd_validators/ocrd_validators/parameter_validator.py
+++ b/ocrd_validators/ocrd_validators/parameter_validator.py
@@ -1,7 +1,7 @@
 """
 Validate parameters against ocrd-tool.json.
 """
-from .json_validator import JsonValidator, DefaultValidatingDraft4Validator
+from .json_validator import JsonValidator, DefaultValidatingDraft6Validator
 
 #
 # -------------------------------------------------
@@ -45,4 +45,4 @@ class ParameterValidator(JsonValidator):
             "required": required,
             "additionalProperties": False,
             "properties": p
-        }, DefaultValidatingDraft4Validator)
+        }, DefaultValidatingDraft6Validator)

--- a/ocrd_validators/ocrd_validators/resource_list_validator.py
+++ b/ocrd_validators/ocrd_validators/resource_list_validator.py
@@ -4,7 +4,7 @@ Validating ``resource_list.yml``.
 See `specs <https://ocr-d.de/en/spec/cli#processor-resources>`_.
 """
 from .constants import RESOURCE_LIST_SCHEMA
-from .json_validator import JsonValidator, DefaultValidatingDraft4Validator
+from .json_validator import JsonValidator, DefaultValidatingDraft6Validator
 
 #
 # -------------------------------------------------
@@ -20,5 +20,5 @@ class OcrdResourceListValidator(JsonValidator):
         """
         Validate against ``resource_list.schema.yml`` schema.
         """
-        return JsonValidator(schema, validator_class=DefaultValidatingDraft4Validator)._validate(obj)
+        return JsonValidator(schema, validator_class=DefaultValidatingDraft6Validator)._validate(obj)
 

--- a/tests/validator/test_json_validator.py
+++ b/tests/validator/test_json_validator.py
@@ -1,5 +1,5 @@
 from tests.base import TestCase, main
-from ocrd_validators.json_validator import JsonValidator, DefaultValidatingDraft4Validator
+from ocrd_validators.json_validator import JsonValidator, DefaultValidatingDraft6Validator
 
 class TestParameterValidator(TestCase):
 
@@ -15,7 +15,7 @@ class TestParameterValidator(TestCase):
                 }
             }
         }
-        self.defaults_validator = JsonValidator(self.schema, DefaultValidatingDraft4Validator)
+        self.defaults_validator = JsonValidator(self.schema, DefaultValidatingDraft6Validator)
         super().setUp()
 
     def test_validate_string(self):

--- a/tests/validator/test_parameter_validator.py
+++ b/tests/validator/test_parameter_validator.py
@@ -45,6 +45,28 @@ class TestParameterValidator(TestCase):
         self.assertTrue(report.is_valid)
         self.assertEqual(obj, {'baz': '23', "num-param": 1})
 
+def test_min_max():
+    validator = ParameterValidator({
+        "parameters": {
+            "num-param": {
+                "type": "number",
+                "exclusiveMinimum": 10,
+                "maximum": 100,
+                "multipleOf": 2
+            }
+        }
+    })
+    report = validator.validate({'num-param': 23})
+    assert not report.is_valid
+    assert 'is not a multiple of 2' in report.errors[0]
+    report = validator.validate({'num-param': 102})
+    assert not report.is_valid
+    assert 'is greater than the maximum of' in report.errors[0]
+    report = validator.validate({'num-param': 8})
+    assert not report.is_valid
+    assert 'is less than or equal to the minimum of' in report.errors[0]
+
+
 
 if __name__ == '__main__':
-    main()
+    main(__name__)


### PR DESCRIPTION
In particular, needed to upgrade from the draft 4 to draft 6 implementation to support `exclusiveM{in,ax}imum`.