### PR TITLE
Workspace pageId to page_id

### DIFF
--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -67,10 +67,10 @@ def workspace_cli(ctx, directory, mets, mets_basename, backup):
 def workspace_validate(ctx, mets_url, download, skip, page_textequiv_consistency, page_coordinate_consistency):
     """
     Validate a workspace
-    
+
     METS_URL can be a URL, an absolute path or a path relative to $PWD.
     If not given, use --mets accordingly.
-    
+
     Check that the METS and its referenced file contents
     abide by the OCR-D specifications.
     """
@@ -183,7 +183,7 @@ def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, ignore, check_
         except KeyError:
             log.error("Cannot guess mimetype from extension '%s' for '%s'. Set --mimetype explicitly" % (Path(fname).suffix, fname))
 
-    kwargs = {'fileGrp': file_grp, 'ID': file_id, 'mimetype': mimetype, 'pageId': page_id, 'force': force, 'ignore': ignore}
+    kwargs = {'fileGrp': file_grp, 'ID': file_id, 'mimetype': mimetype, 'page_id': page_id, 'force': force, 'ignore': ignore}
     log.debug("Adding '%s' (%s)", fname, kwargs)
     if not (fname.startswith('http://') or fname.startswith('https://')):
         if not fname.startswith(ctx.directory):
@@ -306,7 +306,7 @@ def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, file_grp
         file_id_ = file_id or safe_filename(str(file_path))
 
         # set up file info
-        file_dict = {'url': url, 'mimetype': mimetype, 'ID': file_id_, 'pageId': page_id, 'fileGrp': file_grp}
+        file_dict = {'url': url, 'mimetype': mimetype, 'ID': file_id_, 'page_id': page_id, 'fileGrp': file_grp}
 
         # guess mime type
         if not file_dict['mimetype']:
@@ -428,7 +428,7 @@ def workspace_find(ctx, file_grp, mimetype, page_id, file_id, output_field, down
 def workspace_remove_file(ctx, id, force, keep_file):  # pylint: disable=redefined-builtin
     """
     Delete files (given by their ID attribute ``ID``).
-    
+
     (If any ``ID`` starts with ``//``, then its remainder
      will be interpreted as a regular expression.)
     """
@@ -467,7 +467,7 @@ def rename_group(ctx, old, new):
 def remove_group(ctx, group, recursive, force, keep_files):
     """
     Delete fileGrps (given by their USE attribute ``GROUP``).
-    
+
     (If any ``GROUP`` starts with ``//``, then its remainder
      will be interpreted as a regular expression.)
     """
@@ -598,7 +598,7 @@ def merge(ctx, copy_files, filegrp_mapping, file_grp, file_id, page_id, mimetype
         fileGrp_mapping=filegrp_mapping,
         fileGrp=file_grp,
         ID=file_id,
-        pageId=page_id,
+        page_id=page_id,
         mimetype=mimetype,
     )
     workspace.save_mets()

--- a/ocrd/ocrd/processor/builtin/dummy_processor.py
+++ b/ocrd/ocrd/processor/builtin/dummy_processor.py
@@ -42,7 +42,7 @@ class DummyProcessor(Processor):
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.output_file_grp,
-                    pageId=input_file.pageId,
+                    page_id=input_file.pageId,
                     mimetype=input_file.mimetype,
                     local_filename=local_filename,
                     content=to_xml(pcgts).encode('utf-8'))
@@ -53,7 +53,7 @@ class DummyProcessor(Processor):
                     self.workspace.add_file(
                         ID=file_id,
                         file_grp=self.output_file_grp,
-                        pageId=input_file.pageId,
+                        page_id=input_file.pageId,
                         mimetype=input_file.mimetype,
                         local_filename=local_filename,
                         content=content)
@@ -68,7 +68,7 @@ class DummyProcessor(Processor):
                     self.workspace.add_file(
                         ID=page_file_id,
                         file_grp=self.output_file_grp,
-                        pageId=input_file.pageId,
+                        page_id=input_file.pageId,
                         mimetype=MIMETYPE_PAGE,
                         local_filename=page_filename,
                         content=to_xml(pcgts).encode('utf-8'))

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -33,6 +33,7 @@ from ocrd_utils import (
     polygon_from_points,
     xywh_from_bbox,
     pushd_popd,
+    deprecated_alias,
     MIME_TO_EXT,
     MIME_TO_PIL,
     MIMETYPE_PAGE,
@@ -93,6 +94,7 @@ class Workspace():
         """
         self.mets = OcrdMets(filename=self.mets_target)
 
+    @deprecated_alias(pageId="page_id")
     def merge(self, other_workspace, copy_files=True, **kwargs):
         """
         Merge ``other_workspace`` into this one
@@ -114,6 +116,8 @@ class Workspace():
                     makedirs(str(fpath_dest.parent))
                 with open(str(fpath_src), 'rb') as fstream_in, open(str(fpath_dest), 'wb') as fstream_out:
                     copyfileobj(fstream_in, fstream_out)
+        if 'page_id' in kwargs:
+            kwargs['pageId'] = kwargs.pop('page_id')
         self.mets.merge(other_workspace.mets, after_add_cb=after_add_cb, **kwargs)
 
 
@@ -326,6 +330,7 @@ class Workspace():
             if Path(old).is_dir() and not listdir(old):
                 Path(old).rmdir()
 
+    @deprecated_alias(pageId="page_id")
     def add_file(self, file_grp, content=None, **kwargs):
         """
         Add a file to the :py:class:`ocrd_models.ocrd_mets.OcrdMets` of the workspace.
@@ -345,8 +350,8 @@ class Workspace():
             file_grp,
             kwargs.get('local_filename'),
             content is not None)
-        if 'pageId' not in kwargs:
-            raise ValueError("workspace.add_file must be passed a 'pageId' kwarg, even if it is None.")
+        if 'page_id' not in kwargs:
+            raise ValueError("workspace.add_file must be passed a 'page_id' kwarg, even if it is None.")
         if content is not None and 'local_filename' not in kwargs:
             raise Exception("'content' was set but no 'local_filename'")
         if self.overwrite_mode:
@@ -362,6 +367,7 @@ class Workspace():
                     kwargs['url'] = kwargs['local_filename']
 
             #  print(kwargs)
+            kwargs["pageId"] = kwargs.pop("page_id")
             ret = self.mets.add_file(file_grp, **kwargs)
 
             if content is not None:
@@ -997,7 +1003,7 @@ class Workspace():
         out = self.add_file(
             file_grp,
             ID=file_id,
-            pageId=page_id,
+            page_id=page_id,
             local_filename=file_path,
             mimetype=mimetype,
             content=image_bytes.getvalue(),

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -53,7 +53,7 @@ class TestCli(TestCase):
                 file_grp,
                 ID=ID,
                 content=content,
-                pageId=page_id,
+                page_id=page_id,
                 mimetype=mimetype,
                 local_filename=local_filename
             )
@@ -452,7 +452,7 @@ class TestCli(TestCase):
     def test_bulk_add_missing_param(self):
         with pushd_popd(tempdir=True) as wsdir:
             ws = self.resolver.workspace_from_nothing(directory=wsdir)
-            with pytest.raises(ValueError, match=r"OcrdFile attribute 'pageId' unset"):
+            with pytest.raises(ValueError, match=r"OcrdFile attribute 'page_id' unset"):
                 _, out, err = self.invoke_cli(workspace_cli, [
                     'bulk-add',
                     '-r', r'(?P<pageid>.*) (?P<filegrp>.*) (?P<fileid>.*) (?P<src>.*) (?P<url>.*) (?P<mimetype>.*)',

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -105,10 +105,10 @@ class TestProcessor(TestCase):
         class ZipTestProcessor(Processor): pass
         with pushd_popd(tempdir=True) as tempdir:
             ws = self.resolver.workspace_from_nothing(directory=tempdir)
-            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar1', pageId='phys_0001')
-            ws.add_file('GRP2', mimetype='application/alto+xml', ID='foobar2', pageId='phys_0001')
-            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar3', pageId='phys_0002')
-            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar4', pageId='phys_0002')
+            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar1', page_id='phys_0001')
+            ws.add_file('GRP2', mimetype='application/alto+xml', ID='foobar2', page_id='phys_0001')
+            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar3', page_id='phys_0002')
+            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar4', page_id='phys_0002')
             for page_id in [None, 'phys_0001,phys_0002']:
                 with self.subTest(page_id=page_id):
                     proc = ZipTestProcessor(workspace=ws, input_file_grp='GRP1,GRP2', page_id=page_id)
@@ -125,12 +125,12 @@ class TestProcessor(TestCase):
         class ZipTestProcessor(Processor): pass
         with pushd_popd(tempdir=True) as tempdir:
             ws = self.resolver.workspace_from_nothing(directory=tempdir)
-            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar1', pageId='phys_0001')
-            ws.add_file('GRP1', mimetype='image/png', ID='foobar1img1', pageId='phys_0001')
-            ws.add_file('GRP1', mimetype='image/png', ID='foobar1img2', pageId='phys_0001')
-            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar2', pageId='phys_0001')
-            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar3', pageId='phys_0002')
-            ws.add_file('GRP2', mimetype='image/tiff', ID='foobar4', pageId='phys_0002')
+            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar1', page_id='phys_0001')
+            ws.add_file('GRP1', mimetype='image/png', ID='foobar1img1', page_id='phys_0001')
+            ws.add_file('GRP1', mimetype='image/png', ID='foobar1img2', page_id='phys_0001')
+            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar2', page_id='phys_0001')
+            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar3', page_id='phys_0002')
+            ws.add_file('GRP2', mimetype='image/tiff', ID='foobar4', page_id='phys_0002')
             for page_id in [None, 'phys_0001,phys_0002']:
                 with self.subTest(page_id=page_id):
                     proc = ZipTestProcessor(workspace=ws, input_file_grp='GRP1,GRP2', page_id=page_id)
@@ -141,7 +141,7 @@ class TestProcessor(TestCase):
                     print("PAGE-filtered")
                     tuples = [(one.ID, two) for one, two in proc.zip_input_files(mimetype=MIMETYPE_PAGE)]
                     assert ('foobar3', None) in tuples
-            ws.add_file('GRP2', mimetype='image/tiff', ID='foobar4dup', pageId='phys_0002')
+            ws.add_file('GRP2', mimetype='image/tiff', ID='foobar4dup', page_id='phys_0002')
             for page_id in [None, 'phys_0001,phys_0002']:
                 with self.subTest(page_id=page_id):
                     proc = ZipTestProcessor(workspace=ws, input_file_grp='GRP1,GRP2', page_id=page_id)
@@ -152,7 +152,7 @@ class TestProcessor(TestCase):
                     assert ('foobar3', None) in tuples
                     with self.assertRaisesRegex(Exception, "No PAGE-XML for page .* in fileGrp .* but multiple matches."):
                         tuples = proc.zip_input_files(on_error='abort')
-            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar2dup', pageId='phys_0001')
+            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar2dup', page_id='phys_0001')
             for page_id in [None, 'phys_0001,phys_0002']:
                 with self.subTest(page_id=page_id):
                     proc = ZipTestProcessor(workspace=ws, input_file_grp='GRP1,GRP2', page_id=page_id)
@@ -164,8 +164,8 @@ class TestProcessor(TestCase):
         self.capture_out_err()
         with pushd_popd(tempdir=True) as tempdir:
             ws = self.resolver.workspace_from_nothing(directory=tempdir)
-            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar1', pageId=None)
-            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar2', pageId='phys_0001')
+            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar1', page_id=None)
+            ws.add_file('GRP2', mimetype=MIMETYPE_PAGE, ID='foobar2', page_id='phys_0001')
             for page_id in [None, 'phys_0001,phys_0002']:
                 with self.subTest(page_id=page_id):
                     proc = ZipTestProcessor(workspace=ws, input_file_grp='GRP1,GRP2', page_id=page_id)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -119,10 +119,10 @@ class TestDecorators(TestCase):
         resolver = Resolver()
         with TemporaryDirectory() as tempdir:
             ws = resolver.workspace_from_nothing(directory=tempdir)
-            ws.add_file('IN-GRP',  pageId='pID1', ID='fID1', mimetype='image/tiff', content='CONTENT', local_filename=join(tempdir, 'ID1.tif'))
-            ws.add_file('OUT-GRP', pageId='pID2', ID='fID2', mimetype='image/tiff', content='CONTENT', local_filename=join(tempdir, 'ID2.tif'))
-            ws.add_file('OUT-GRP', pageId='pID3', ID='fID3', mimetype='image/tiff', content='CONTENT', local_filename=join(tempdir, 'ID3.tif'))
-            ws.add_file('OUT-GRP', pageId='pID4', ID='fID4', mimetype='image/tiff', content='CONTENT', local_filename=join(tempdir, 'ID4.tif'))
+            ws.add_file('IN-GRP',  page_id='pID1', ID='fID1', mimetype='image/tiff', content='CONTENT', local_filename=join(tempdir, 'ID1.tif'))
+            ws.add_file('OUT-GRP', page_id='pID2', ID='fID2', mimetype='image/tiff', content='CONTENT', local_filename=join(tempdir, 'ID2.tif'))
+            ws.add_file('OUT-GRP', page_id='pID3', ID='fID3', mimetype='image/tiff', content='CONTENT', local_filename=join(tempdir, 'ID3.tif'))
+            ws.add_file('OUT-GRP', page_id='pID4', ID='fID4', mimetype='image/tiff', content='CONTENT', local_filename=join(tempdir, 'ID4.tif'))
             ws.save_mets()
             yield ws
 

--- a/tests/test_task_sequence.py
+++ b/tests/test_task_sequence.py
@@ -138,7 +138,7 @@ class TestOcrdWfStep(TestCase):
         with copy_of_directory(assets.path_to('kant_aufklaerung_1784/data')) as wsdir:
             with pushd_popd(wsdir):
                 ws = resolver.workspace_from_url('mets.xml')
-                ws.add_file('GRP0', content='', local_filename='GRP0/foo', ID='file0', mimetype=MIMETYPE_PAGE, pageId=None)
+                ws.add_file('GRP0', content='', local_filename='GRP0/foo', ID='file0', mimetype=MIMETYPE_PAGE, page_id=None)
                 ws.save_mets()
                 files_before = len(ws.mets.find_all_files())
                 run_tasks('mets.xml', 'DEBUG', None, [

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -66,7 +66,7 @@ def test_workspace_add_file(plain_workspace):
         ID='ID1',
         mimetype='image/tiff',
         content='CONTENT',
-        pageId=None,
+        page_id=None,
         local_filename=fpath
     )
     f = plain_workspace.mets.find_all_files()[0]
@@ -80,7 +80,7 @@ def test_workspace_add_file(plain_workspace):
 
 
 def test_workspace_add_file_basename_no_content(plain_workspace):
-    plain_workspace.add_file('GRP', ID='ID1', mimetype='image/tiff', pageId=None)
+    plain_workspace.add_file('GRP', ID='ID1', mimetype='image/tiff', page_id=None)
     f = next(plain_workspace.mets.find_files())
 
     # assert
@@ -89,7 +89,7 @@ def test_workspace_add_file_basename_no_content(plain_workspace):
 
 def test_workspace_add_file_binary_content(plain_workspace):
     fpath = join(plain_workspace.directory, 'subdir', 'ID1.tif')
-    plain_workspace.add_file('GRP', ID='ID1', content=b'CONTENT', local_filename=fpath, url='http://foo/bar', pageId=None)
+    plain_workspace.add_file('GRP', ID='ID1', content=b'CONTENT', local_filename=fpath, url='http://foo/bar', page_id=None)
 
     # assert
     assert exists(fpath)
@@ -98,7 +98,7 @@ def test_workspace_add_file_binary_content(plain_workspace):
 def test_workspacec_add_file_content_wo_local_filename(plain_workspace):
     # act
     with pytest.raises(Exception) as fn_exc:
-        plain_workspace.add_file('GRP', ID='ID1', content=b'CONTENT', pageId='foo1234')
+        plain_workspace.add_file('GRP', ID='ID1', content=b'CONTENT', page_id='foo1234')
 
     assert "'content' was set but no 'local_filename'" in str(fn_exc.value)
 
@@ -108,7 +108,7 @@ def test_workspacec_add_file_content_wo_pageid(plain_workspace):
     with pytest.raises(ValueError) as val_err:
         plain_workspace.add_file('GRP', ID='ID1', content=b'CONTENT', local_filename='foo')
 
-    assert "workspace.add_file must be passed a 'pageId' kwarg, even if it is None." in str(val_err.value)
+    assert "workspace.add_file must be passed a 'page_id' kwarg, even if it is None." in str(val_err.value)
 
 
 def test_workspace_str(plain_workspace):
@@ -260,7 +260,7 @@ def test_remove_file_force(sbb_data_workspace):
 
 
 def test_remove_file_remote_not_available_raises_exception(plain_workspace):
-    plain_workspace.add_file('IMG', ID='page1_img', mimetype='image/tiff', url='http://remote', pageId=None)
+    plain_workspace.add_file('IMG', ID='page1_img', mimetype='image/tiff', url='http://remote', page_id=None)
     with pytest.raises(Exception) as not_avail_exc:
         plain_workspace.remove_file('page1_img')
 
@@ -270,7 +270,7 @@ def test_remove_file_remote_not_available_raises_exception(plain_workspace):
 def test_remove_file_remote(plain_workspace):
 
     # act
-    plain_workspace.add_file('IMG', ID='page1_img', mimetype='image/tiff', url='http://remote', pageId=None)
+    plain_workspace.add_file('IMG', ID='page1_img', mimetype='image/tiff', url='http://remote', page_id=None)
 
     # must succeed because removal is enforced
     assert plain_workspace.remove_file('page1_img', force=True)
@@ -342,7 +342,7 @@ def test_remove_file_group_flat(plain_workspace):
     """
 
     # act
-    added_res = plain_workspace.add_file('FOO', ID='foo', mimetype='foo/bar', local_filename='file.ext', content='foo', pageId=None).url
+    added_res = plain_workspace.add_file('FOO', ID='foo', mimetype='foo/bar', local_filename='file.ext', content='foo', page_id=None).url
     # requires additional prepending of current path because not pushd_popd-magic at work
     added_path = Path(join(plain_workspace.directory, added_res))
 
@@ -382,8 +382,8 @@ def test_download_to_directory_from_workspace_download_file(plain_workspace):
     """
     https://github.com/OCR-D/core/issues/342
     """
-    f1 = plain_workspace.add_file('IMG', ID='page1_img', mimetype='image/tiff', local_filename='test.tif', content='', pageId=None)
-    f2 = plain_workspace.add_file('GT', ID='page1_gt', mimetype='text/xml', local_filename='test.xml', content='', pageId=None)
+    f1 = plain_workspace.add_file('IMG', ID='page1_img', mimetype='image/tiff', local_filename='test.tif', content='', page_id=None)
+    f2 = plain_workspace.add_file('GT', ID='page1_gt', mimetype='text/xml', local_filename='test.xml', content='', page_id=None)
 
     assert f1.url == 'test.tif'
     assert f2.url == 'test.xml'
@@ -577,7 +577,7 @@ def test_downsample_16bit_image(plain_workspace):
             tif_out.write(gzip_in.read())
 
     # act
-    plain_workspace.add_file('IMG', ID='foo', url=img_path, mimetype='image/tiff', pageId=None)
+    plain_workspace.add_file('IMG', ID='foo', url=img_path, mimetype='image/tiff', page_id=None)
 
     # assert
     pil_before = Image.open(img_path)


### PR DESCRIPTION
fix #862.
Change kwargs for ocrd-workspace-api. I changed `add_file` and `merge` because I think that where the only ones left accepting pageId.
I didn't change anything regarding to `Workspace.find_files` (offering new functionality), because I think maybe that would be a separate topic.