### PR TITLE
Add processor profiling

### DIFF
--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -27,6 +27,7 @@ def ocrd_cli_wrap_processor(
     working_dir=None,
     dump_json=False,
     help=False, # pylint: disable=redefined-builtin
+    profile=False,
     version=False,
     overwrite=False,
     show_resource=None,
@@ -85,4 +86,19 @@ def ocrd_cli_wrap_processor(
         report = WorkspaceValidator.check_file_grp(workspace, kwargs['input_file_grp'], '' if overwrite else kwargs['output_file_grp'], page_id)
         if not report.is_valid:
             raise Exception("Invalid input/output file grps:\n\t%s" % '\n\t'.join(report.errors))
+        if profile:
+            import cProfile
+            import pstats
+            import io
+            import atexit
+            print("Profiling...")
+            pr = cProfile.Profile()
+            pr.enable()
+            def exit():
+                pr.disable()
+                print("Profiling completed")
+                s = io.StringIO()
+                pstats.Stats(pr, stream=s).sort_stats("cumulative").print_stats()
+                print(s.getvalue())
+            atexit.register(exit)
         run_processor(processorClass, ocrd_tool, mets, workspace=workspace, **kwargs)

--- a/ocrd/ocrd/decorators/ocrd_cli_options.py
+++ b/ocrd/ocrd/decorators/ocrd_cli_options.py
@@ -34,6 +34,7 @@ def ocrd_cli_options(f):
         loglevel_option,
         option('-V', '--version', help="Show version", is_flag=True, default=False),
         option('-h', '--help', help="This help message", is_flag=True, default=False),
+        option('--profile', help="Enable profiling", is_flag=True, default=False),
     ]
     for param in params:
         param(f)

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -214,6 +214,7 @@ Options:
   -g, --page-id ID                Physical page ID(s) to process
   --overwrite                     Remove existing output pages/images
                                   (with --page-id, remove only those)
+  --profile                       Enable profiling
   -p, --parameter JSON-PATH       Parameters, either verbatim JSON string
                                   or JSON file path
   -P, --param-override KEY VAL    Override a single JSON object key-value pair,


### PR DESCRIPTION
Following a [recipe on Stackoverflow](https://stackoverflow.com/a/60474929/14474237), this adds an option to run with [cProfile](https://docs.python.org/3/library/profile.html) on the processor CLI via `--profile`.

Example output for `ocrd-cis-ocropy-segment --profile -I BINSBB -O OCROREGIONSXYMASK-BINSBB -P level-of-operation page -P maxseps 50`:
```
Profiling...
INFO processor.OcropySegment - INPUT FILE 0 / phys00005
INFO processor.OcropySegment - Page "BINSBB_0005" uses 319.000000 DPI
INFO processor.OcropySegment - computing line segmentation for page "BINSBB_0005"
...
Profiling completed
         760219 function calls (748005 primitive calls) in 157.335 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000  157.335  157.335 venv/lib/python3.6/site-packages/ocrd/processor/helpers.py:29(run_processor)
        1    0.000    0.000  157.333  157.333 venv/lib/python3.6/site-packages/ocrd/processor/helpers.py:87(run_api)
        1    0.000    0.000  157.332  157.332 ocrd_cis/ocropy/segment.py:250(process)
        1    0.030    0.030  156.889  156.889 ocrd_cis/ocropy/segment.py:513(_process_element)
     99/2    0.011    0.000  156.758   78.379 ocrd_cis/ocropy/ocrolib/toplevel.py:197(argument_checks)
        1    0.000    0.000  156.729  156.729 ocrd_cis/ocropy/common.py:1258(compute_segmentation)
        1   20.384   20.384  154.014  154.014 ocrd_cis/ocropy/common.py:513(compute_seplines)
     4087    2.329    0.001  118.519    0.029 ocrd_cis/ocropy/common.py:542(filterlabel)
     4116    0.048    0.000  110.745    0.027 ocrd_cis/ocropy/ocrolib/sl.py:180(unmask)
     4232  107.945    0.026  107.945    0.026 {method 'nonzero' of 'numpy.ndarray' objects}
35060/30500    2.842    0.000   12.653    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
    51306    6.322    0.000    6.322    0.000 {method 'reduce' of 'numpy.ufunc' objects}
       68    0.000    0.000    6.044    0.089 <__array_function__ internals>:2(unique)
       68    0.009    0.000    6.043    0.089 venv/lib/python3.6/site-packages/numpy/lib/arraysetops.py:151(unique)
       68    0.316    0.005    6.034    0.089 venv/lib/python3.6/site-packages/numpy/lib/arraysetops.py:298(_unique1d)
     8224    0.028    0.000    5.504    0.001 {method 'any' of 'numpy.ndarray' objects}
     8247    0.016    0.000    5.476    0.001 venv/lib/python3.6/site-packages/numpy/core/_methods.py:44(_any)
       68    5.248    0.077    5.248    0.077 {method 'sort' of 'numpy.ndarray' objects}
       19    1.517    0.080    4.740    0.249 ocrd_cis/ocropy/ocrolib/morph.py:218(spread_labels)
     4108    0.014    0.000    2.888    0.001 <__array_function__ internals>:2(count_nonzero)
     4108    0.013    0.000    2.859    0.001 venv/lib/python3.6/site-packages/numpy/core/numeric.py:402(count_nonzero)
     4108    2.846    0.001    2.846    0.001 {built-in method numpy.core._multiarray_umath.count_nonzero}
       19    2.626    0.138    2.626    0.138 {distanceTransformWithLabels}
        1    0.245    0.245    2.446    2.446 ocrd_cis/ocropy/common.py:453(compute_images)
        1    0.050    0.050    2.369    2.369 venv/lib/python3.6/site-packages/skimage/morphology/_skeletonize.py:364(medial_axis)
      227    0.001    0.000    1.474    0.006 ocrd_cis/ocropy/ocrolib/toplevel.py:154(checktype)
       88    0.000    0.000    1.474    0.017 ocrd_cis/ocropy/ocrolib/toplevel.py:237(CHK_)
      197    0.000    0.000    1.473    0.007 ocrd_cis/ocropy/ocrolib/toplevel.py:225(wrapper)
       69    0.001    0.000    1.291    0.019 ocrd_cis/ocropy/ocrolib/toplevel.py:349(ABINARY)
        9    0.000    0.000    1.291    0.143 venv/lib/python3.6/site-packages/scipy/ndimage/measurements.py:574(sum)
        9    0.003    0.000    1.291    0.143 venv/lib/python3.6/site-packages/scipy/ndimage/measurements.py:467(_stats)
       41    0.000    0.000    1.059    0.026 <__array_function__ internals>:2(bincount)
...
```