### PR TITLE
Allow fill=none

### DIFF
--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -496,7 +496,7 @@ class Workspace():
             page (:py:class:`ocrd_models.ocrd_page.PageType`): a PAGE `PageType` object
             page_id (string): its `@ID` in the METS physical `structMap`
         Keyword Args:
-            fill (string): a `PIL` color specifier
+            fill (string): a `PIL` color specifier, or `background` or `none`
             transparency (boolean): whether to add an alpha channel for masking
             feature_selector (string): a comma-separated list of `@comments` classes
             feature_filter (string): a comma-separated list of `@comments` classes
@@ -534,6 +534,8 @@ class Workspace():
         \b
         - if `"background"` (the default),
           then fill with the median color of the image;
+        - else if `"none"`, then avoid masking polygons where possible
+          (i.e. when cropping) or revert to the default (i.e. when rotating)
         - otherwise, use the given color, e.g. `"white"` or `(255,255,255)`.
 
         Moreover, if ``transparency`` is true, and unless the image already
@@ -733,7 +735,7 @@ class Workspace():
                - `"features"`: the ``AlternativeImage/@comments`` for the image, i.e.
                  names of all operations that lead up to this result, and
         Keyword Args:
-            fill (string): a `PIL` color specifier
+            fill (string): a `PIL` color specifier, or `background` or `none`
             transparency (boolean): whether to add an alpha channel for masking
             feature_selector (string): a comma-separated list of ``@comments`` classes
             feature_filter (string): a comma-separated list of ``@comments`` classes
@@ -762,6 +764,8 @@ class Workspace():
         \b
         - if `"background"` (the default),
           then fill with the median color of the image;
+        - else if `"none"`, then avoid masking polygons where possible
+          (i.e. when cropping) or revert to the default (i.e. when rotating)
         - otherwise, use the given color, e.g. `"white"` or `(255,255,255)`.
 
         Moreover, if `transparency` is true, and unless the image already

--- a/ocrd_utils/ocrd_utils/image.py
+++ b/ocrd_utils/ocrd_utils/image.py
@@ -486,7 +486,8 @@ def image_from_polygon(image, polygon, fill='background', transparency=False):
     of relative coordinates into the image, fill everything
     outside the polygon hull to a color according to ``fill``:
 
-    - if ``background`` (the default),
+    - if ``none`` then do not touch the colour channels at all,
+    - else if ``background`` (the default),
       then use the median color of the image;
     - otherwise use the given color, e.g. ``'white'`` or (255,255,255).
 
@@ -499,17 +500,20 @@ def image_from_polygon(image, polygon, fill='background', transparency=False):
     
     Return a new PIL.Image.
     """
-    mask = polygon_mask(image, polygon)
-    if fill == 'background':
-        background = ImageStat.Stat(image, mask=mask)
-        if len(background.bands) > 1:
-            background = tuple(background.median)
-        else:
-            background = background.median[0]
+    if fill == 'none' or fill is None:
+        new_image = image.copy()
     else:
-        background = fill
-    new_image = Image.new(image.mode, image.size, background)
-    new_image.paste(image, mask=mask)
+        mask = polygon_mask(image, polygon)
+        if fill == 'background':
+            background = ImageStat.Stat(image, mask=mask)
+            if len(background.bands) > 1:
+                background = tuple(background.median)
+            else:
+                background = background.median[0]
+        else:
+            background = fill
+        new_image = Image.new(image.mode, image.size, background)
+        new_image.paste(image, mask=mask)
     # ensure no information is lost by a adding transparency channel
     # initialized to fully transparent outside the polygon mask
     # (so consumers do not have to rely on background estimation,

--- a/ocrd_utils/ocrd_utils/image.py
+++ b/ocrd_utils/ocrd_utils/image.py
@@ -262,7 +262,7 @@ def rotate_image(image, angle, fill='background', transparency=False):
         # expose areas as transparent):
         image = image.copy()
         image.putalpha(255)
-    if fill == 'background':
+    if fill is None or fill in ['background', 'none']:
         background = ImageStat.Stat(image)
         if len(background.bands) > 1:
             background = background.median


### PR DESCRIPTION
This will enable callers to pass another value `"none"` or just `None` to the `fill` kwarg of various image functions, most importantly `Workspace.image_from_page` and `.image_from_segment`.

Obviously, for rotation, there **must** be a fill colour. But for cropping one might want to **not** polygon-mask the image sometimes. (One particular use-case is OCR input with raw images: it might be detrimental to quality to insert artificial background without any texture – even if trained that way.)

Note that this should not affect most existing code. The default is still `background`, and callers can independently set `transparency`. (Although I have not seen any OLR/OCR models with alpha channels yet.)