### PR TITLE
small bugfix in OcrdMets.find_files

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -167,7 +167,7 @@ class OcrdMets(OcrdXmlDocument):
                 pageIds_expanded = []
                 for pageId_ in pageIds:
                     if '..' in pageId_:
-                        pageIds_expanded += generate_range(*pageId_.split('..', 2))
+                        pageIds_expanded += generate_range(*pageId_.split('..', 1))
                 pageIds += pageIds_expanded
             for page in self._tree.getroot().xpath(
                 '//mets:div[@TYPE="page"]', namespaces=NS):


### PR DESCRIPTION
Minor bug: change maxsplits to 1, because `generate_range` expects exactly two params.

> If maxsplit is given, at most maxsplit splits are done (thus, the list will have at most maxsplit+1 elements

https://docs.python.org/3/library/stdtypes.html?highlight=split#str.split

