### PR TITLE
resmgr download: use list_available for dynamic discovery

### DIFF
--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -168,7 +168,7 @@ def get_processor_resource_types(executable, ocrd_tool=None):
         # if the processor in question is not installed, assume both files and directories
         if not which(executable):
             return ['*/*']
-    ocrd_tool = get_ocrd_tool_json(executable)
+        ocrd_tool = get_ocrd_tool_json(executable)
     if not next((True for p in ocrd_tool.get('parameters', {}).values() if 'content-type' in p), False):
         # None of the parameters for this processor are resources (or not
         # the resource parametrs are not properly declared, so output both

--- a/tests/cli/test_resmgr.py
+++ b/tests/cli/test_resmgr.py
@@ -27,13 +27,14 @@ def test_url_tool_name_unregistered(mgr_with_tmp_path):
     # add an unregistered resource
     url = 'https://github.com/tesseract-ocr/tessdata_best/raw/main/dzo.traineddata'
     name = 'dzo.traineddata'
-    r = runner.invoke(resmgr_cli, ['download', '-a', '--any-url', url, executable, name], env=env)
+    r = runner.invoke(resmgr_cli, ['download', '--allow-uninstalled', '--any-url', url, executable, name], env=env)
     mgr.load_resource_list(mgr.user_list)
     print(r.output)
     with open(mgr.user_list, 'r') as f:
         print(f.read())
 
     # assert
+    # print(mgr.list_installed('ocrd-tesserocr-recognize'))
     rsrcs = mgr.list_installed('ocrd-tesserocr-recognize')[0][1]
     assert len(rsrcs) == rsrcs_before + 1
     assert rsrcs[0]['name'] == name


### PR DESCRIPTION
An oversight in #800: `ocrd resmgr download` needs to use `OcrdResourceManager.list_available`, not `OcrdResourceManager.find_resources` because the latter only looks in the database, not inspecting the `--dump-json` output.