### PR TITLE
Resource manager respecting processor's moduledir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.38.0] - 2022-08-14
+
 Fixed:
 
   * `ocrd zip`: Properly respect `Ocrd-Mets`, #899
@@ -13,7 +15,7 @@ Fixed:
 
 Added:
 
-  * Processors allow profiling with `--profile` and `--profile-file`, #878, bertsky/core#4
+  * Processors support profiling with `--profile` and `--profile-file`, #878, bertsky/core#4
 
 Removed:
 
@@ -1524,6 +1526,7 @@ Fixed
 Initial Release
 
 <!-- link-labels -->
+[2.38.0]: ../../compare/v2.38.0..v2.37.0
 [2.37.0]: ../../compare/v2.37.0..v2.36.0
 [2.36.0]: ../../compare/v2.36.0..v2.35.0
 [2.35.0]: ../../compare/v2.35.0..v2.34.0

--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -26,6 +26,7 @@ def ocrd_cli_wrap_processor(
     mets=None,
     working_dir=None,
     dump_json=False,
+    dump_module_dir=False,
     help=False, # pylint: disable=redefined-builtin
     profile=False,
     profile_file=None,
@@ -38,10 +39,11 @@ def ocrd_cli_wrap_processor(
     if not sys.argv[1:]:
         processorClass(workspace=None, show_help=True)
         sys.exit(1)
-    if dump_json or help or version or show_resource or list_resources:
+    if dump_json or dump_module_dir or help or version or show_resource or list_resources:
         processorClass(
             workspace=None,
             dump_json=dump_json,
+            dump_module_dir=dump_module_dir,
             show_help=help,
             show_version=version,
             show_resource=show_resource,

--- a/ocrd/ocrd/decorators/ocrd_cli_options.py
+++ b/ocrd/ocrd/decorators/ocrd_cli_options.py
@@ -31,6 +31,7 @@ def ocrd_cli_options(f):
         parameter_option,
         parameter_override_option,
         option('-J', '--dump-json', help="Dump tool description as JSON and exit", is_flag=True, default=False),
+        option('-D', '--dump-module-dir', help="Print processor's 'moduledir' of resourcess", is_flag=True, default=False),
         loglevel_option,
         option('-V', '--version', help="Show version", is_flag=True, default=False),
         option('-h', '--help', help="This help message", is_flag=True, default=False),

--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -63,13 +63,14 @@ class Processor():
             show_help=False,
             show_version=False,
             dump_json=False,
+            dump_module_dir=False,
             version=None
     ):
         """
         Instantiate, but do not process. Unless ``list_resources`` or
         ``show_resource`` or ``show_help`` or ``show_version`` or
-        ``dump_json`` is true, setup for processing (parsing and
-        validating parameters, entering the workspace directory).
+        ``dump_json`` or ``dump_module_dir`` is true, setup for processing
+        (parsing and validating parameters, entering the workspace directory).
 
         Args:
              workspace (:py:class:`~ocrd.Workspace`): The workspace to process. \
@@ -95,12 +96,17 @@ class Processor():
                  this processor's version and OCR-D version. Exit afterwards.
              dump_json (boolean): If true, then instead of processing, print :py:attr:`ocrd_tool` \
                  on stdout.
+             dump_module_dir (boolean): If true, then instead of processing, print :py:attr:`moduledir` \
+                 on stdout.
         """
         self.ocrd_tool = ocrd_tool
         if parameter is None:
             parameter = {}
         if dump_json:
             print(json.dumps(ocrd_tool, indent=True))
+            return
+        if dump_module_dir:
+            print(self.moduledir)
             return
         if list_resources:
             for res in self.list_all_resources():

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -227,6 +227,7 @@ Options:
   -C, --show-resource RESNAME     Dump the content of processor resource RESNAME
   -L, --list-resources            List names of processor resources
   -J, --dump-json                 Dump tool description as JSON and exit
+  -D, --dump-module-dir           Output the 'module' directory with resources for this processor
   -h, --help                      This help message
   -V, --version                   Show version
 

--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -194,7 +194,7 @@ class OcrdResourceManager():
             }
             user_database[executable].append(resdict)
         else:
-            resdict = resources_found[0][1]
+            resdict = resources_found[0]
         self.save_user_list(user_database)
         self.load_resource_list(self.user_list)
         return resdict

--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -113,13 +113,13 @@ class OcrdResourceManager():
                         if exec_path.name not in database:
                             database[exec_path.name] = []
                         database[exec_path.name].append(resdict)
-                    # database = self._dedup_database(database)
+            database = self._dedup_database(database)
         found = False
         ret = []
         for k in database:
             if apply_glob([k], executable):
-                restuple = (executable, [])
                 found = True
+                restuple = (k, [])
                 ret.append(restuple)
                 for resdict in database[k]:
                     if name and resdict['name'] != name:
@@ -309,7 +309,7 @@ class OcrdResourceManager():
                     copytree(path_in_archive, str(fpath))
         return fpath
 
-    def _dedup_database(self, database=None):
+    def _dedup_database(self, database=None, dedup_key='name'):
         """
         Deduplicate resources by name
         """
@@ -318,9 +318,7 @@ class OcrdResourceManager():
         for executable, reslist in database.items():
             reslist_dedup = []
             for resdict in reslist:
-                if any(r['name'] == resdict['name'] for r in reslist_dedup):
-                    continue
-                else:
+                if not any(r[dedup_key] == resdict[dedup_key] for r in reslist_dedup):
                     reslist_dedup.append(resdict)
             database[executable] = reslist_dedup
         return database

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -168,6 +168,7 @@ from .os import (
     directory_size,
     get_processor_resource_types,
     get_ocrd_tool_json,
+    get_moduledir,
     list_all_resources,
     is_file_in_directory,
     list_resource_candidates,

--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -88,7 +88,7 @@ def get_ocrd_tool_json(executable):
 def get_moduledir(executable):
     moduledir = None
     try:
-        moduledir = run([executable, '--dump-module-dir'], encoding='utf-8', stdout=PIPE).stdout
+        moduledir = run([executable, '--dump-module-dir'], encoding='utf-8', stdout=PIPE).stdout.rstrip('\n')
     except (JSONDecodeError, OSError) as e:
         getLogger('ocrd_utils.get_moduledir').error(f'{executable} --dump-module-dir failed: {e}')
     return moduledir

--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -6,6 +6,7 @@ __all__ = [
     'directory_size',
     'is_file_in_directory',
     'get_ocrd_tool_json',
+    'get_moduledir',
     'get_processor_resource_types',
     'pushd_popd',
     'unzip_file_to_dir',
@@ -83,11 +84,14 @@ def get_ocrd_tool_json(executable):
         ocrd_tool['resource_locations'] = ['data', 'cwd', 'system', 'module']
     return ocrd_tool
 
-# def get_processor_resources_list(executable):
-#     """
-#     Get the list of resources that a processor is providing via
-#     ``-list-resources``
-#     """
+@lru_cache()
+def get_moduledir(executable):
+    moduledir = None
+    try:
+        moduledir = run([executable, '--dump-module-dir'], encoding='utf-8', stdout=PIPE).stdout
+    except (JSONDecodeError, OSError) as e:
+        getLogger('ocrd_utils.get_moduledir').error(f'{executable} --dump-module-dir failed: {e}')
+    return moduledir
 
 def list_resource_candidates(executable, fname, cwd=getcwd(), moduled=None, xdg_data_home=None):
     """

--- a/ocrd_utils/setup.py
+++ b/ocrd_utils/setup.py
@@ -5,7 +5,7 @@ install_requires = open('requirements.txt').read().split('\n')
 
 setup(
     name='ocrd_utils',
-    version='2.37.0',
+    version='2.38.0',
     description='OCR-D framework - shared code, helpers, constants',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/tests/cli/test_resmgr.py
+++ b/tests/cli/test_resmgr.py
@@ -29,23 +29,20 @@ def test_url_tool_name_unregistered(mgr_with_tmp_path):
     name = 'dzo.traineddata'
     r = runner.invoke(resmgr_cli, ['download', '--allow-uninstalled', '--any-url', url, executable, name], env=env)
     mgr.load_resource_list(mgr.user_list)
-    print(r.output)
-    with open(mgr.user_list, 'r') as f:
-        print(f.read())
 
-    # assert
-    # print(mgr.list_installed('ocrd-tesserocr-recognize'))
     rsrcs = mgr.list_installed('ocrd-tesserocr-recognize')[0][1]
     assert len(rsrcs) == rsrcs_before + 1
     assert rsrcs[0]['name'] == name
     assert rsrcs[0]['url'] == url
 
-    # add resource with different URL but sanem name
+    # add resource with different URL but same name
     url2 = url.replace('dzo', 'bos')
-    r = runner.invoke(resmgr_cli, ['download', '--overwrite', '-a', '--any-url', url2, executable, name], env=env)
+    r = runner.invoke(resmgr_cli, ['download', '--allow-uninstalled', '--any-url', url2, executable, name], env=env)
+    assert 'already exists and overwrite is False' in r.output
+    r = runner.invoke(resmgr_cli, ['download', '--overwrite', '--allow-uninstalled', '--any-url', url2, executable, name], env=env)
+    assert 'already exists and overwrite is False' not in r.output
     mgr.load_resource_list(mgr.user_list)
 
-    # assert
     rsrcs = mgr.list_installed('ocrd-tesserocr-recognize')[0][1]
     print(rsrcs)
     assert len(rsrcs) == rsrcs_before + 1

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -98,10 +98,10 @@ def test_find_resources(tmp_path):
     mgr = OcrdResourceManager(xdg_config_home=tmp_path)
 
     # assert
-    assert mgr.find_resources(executable='ocrd-foo') == []
+    assert mgr.list_available(executable='ocrd-foo') == [('ocrd-foo', [])]
     assert mgr.add_to_user_database('ocrd-foo', f, url='http://foo/bar')
-    assert 'ocrd-foo' in [x for x, _ in mgr.find_resources()]
-    assert 'ocrd-foo' in [x for x, _ in mgr.find_resources(url='http://foo/bar')]
+    assert 'ocrd-foo' in [x for x, _ in mgr.list_available()]
+    assert 'ocrd-foo' in [x for x, _ in mgr.list_available(url='http://foo/bar')]
 
 def test_parameter_usage(tmp_path):
     mgr = OcrdResourceManager(xdg_config_home=tmp_path)


### PR DESCRIPTION
This implements proper support for processor's moduledir:

* Processors have a new CLI option `--dump-module-dir` that prints the `moduledir` of the processor
* When downloading a model
  * unless `--location` is explicitly overridden, resmgr will inspect the `resource_location` in a processor's `ocrd-tool.json` and select the first one
  * if the location is `module`, will get the directory via `--dump-module-dir`
* For `list-installed`, looks up the directory via `--dump-module-dir` and will look in it as well.

This also removes the `find_resources` method which is mostly redundant with `list-available`

It is a draft because I introduced a bug where downloading a model duplicates all the entries for that executable. Will have to debug this further tomorrow.
