### PR TITLE
ocrd validate: accept --mets-basename, bashlib: use that

### DIFF
--- a/ocrd/ocrd/cli/validate.py
+++ b/ocrd/ocrd/cli/validate.py
@@ -101,15 +101,17 @@ def validate_page(page, **kwargs):
 
 @validate_cli.command('tasks')
 @click.option('--workspace', nargs=1, required=False, help='Workspace directory these tasks are to be run. If omitted, only validate syntax')
+@click.option('-M', '--mets-basename', nargs=1, default='mets.xml', help='Baasename of the METS file, used in conjunction with --workspace')
 @click.option('--overwrite', is_flag=True, default=False, help='When checking against a concrete workspace, simulate overwriting output or page range.')
 @click.option('-g', '--page-id', help="ID(s) of the pages to process")
 @click.argument('tasks', nargs=-1, required=True)
-def validate_process(tasks, workspace, overwrite, page_id):
+def validate_process(tasks, workspace, mets_basename, overwrite, page_id):
     '''
     Validate a sequence of tasks passable to 'ocrd process'
     '''
     if workspace:
-        _inform_of_result(validate_tasks([ProcessorTask.parse(t) for t in tasks], Workspace(Resolver(), directory=workspace), page_id=page_id, overwrite=overwrite))
+        _inform_of_result(validate_tasks([ProcessorTask.parse(t) for t in tasks],
+            Workspace(Resolver(), directory=workspace, mets_basename=mets_basename), page_id=page_id, overwrite=overwrite))
     else:
         for t in [ProcessorTask.parse(t) for t in tasks]:
             _inform_of_result(t.validate())

--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -164,7 +164,7 @@ ocrd__parse_argv () {
     fi
 
     # check fileGrps
-    local _valopts=( --workspace "${ocrd__argv[working_dir]}" )
+    local _valopts=( --workspace "${ocrd__argv[working_dir]}" --mets-basename "$(basename ${ocrd__argv[mets_file]})" )
     if [[ ${ocrd__argv[overwrite]} = true ]]; then
         _valopts+=( --overwrite )
     fi


### PR DESCRIPTION
When calling a bashlib processor like `ocrd-olena-binarize` with a workspace backed by a METS not called `mets.xml`, this leads to an error because we call `ocrd validate tasks` at the end of the bashlb argument parsing and it only specifies the `--workspace` (directory) so fails to instantiate the workspace, or even uses the wrong file.

I would like to consolidate the options to a single `--mets` option like we did for the processors and `ocrd workspace` option, but that will probably best happen in conjunction with the METS server change.