### PR TITLE
add RESOURCE_LOCATIONS==module (for resmgr CLI)

### DIFF
--- a/ocrd_utils/ocrd_utils/constants.py
+++ b/ocrd_utils/ocrd_utils/constants.py
@@ -112,4 +112,4 @@ else:
 XDG_DATA_HOME = environ['XDG_DATA_HOME'] if 'XDG_DATA_HOME' in environ else join(HOME, '.local', 'share')
 XDG_CONFIG_HOME = environ['XDG_CONFIG_HOME'] if 'XDG_CONFIG_HOME' in environ else join(HOME, '.config')
 
-RESOURCE_LOCATIONS = ['data', 'cwd', 'system']
+RESOURCE_LOCATIONS = ['data', 'cwd', 'system', 'module']


### PR DESCRIPTION
Another glitch that went under the radar. It must be possible to choose `ocrd resmgr download -l module` (even if `module` may already be the default, but it should at least appear as a CLI option).