### PR TITLE
resmgr download: module location must not use exe subdir

### DIFF
--- a/ocrd/ocrd/cli/resmgr.py
+++ b/ocrd/ocrd/cli/resmgr.py
@@ -159,7 +159,7 @@ def download(any_url, no_dynamic, resource_type, path_in_archive, allow_uninstal
                     path_in_archive=resdict.get('path_in_archive', path_in_archive),
                     overwrite=overwrite,
                     size=resdict['size'],
-                    no_subdir=location == 'cwd',
+                    no_subdir=location in ['cwd', 'module'],
                     basedir=basedir,
                     progress_cb=lambda delta: bar.update(delta)
                 )


### PR DESCRIPTION
Fixes ocrd_tesserocr CI