### PR TITLE
bulk-add: Improve deriving file_id from other fields

### DIFF
--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -332,7 +332,7 @@ def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, file_grp
 
         # derive --file-id from filename if not --file-id not explicitly set
         if not file_id:
-            id_field = srcpath.name if file_path != srcpath else file_path.name
+            id_field = srcpath.stem if file_path != srcpath else file_path.stem
             file_dict['file_id'] = safe_filename('%s_%s' % (file_dict['file_grp'], id_field))
         if not mimetype:
             try:

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -304,13 +304,6 @@ def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, file_grp
         # set up file info
         file_dict = {'url': url, 'mimetype': mimetype, 'file_id': file_id, 'page_id': page_id, 'file_grp': file_grp}
 
-        # guess mime type
-        if not file_dict['mimetype']:
-            try:
-                file_dict['mimetype'] = EXT_TO_MIME[file_path.suffix]
-            except KeyError:
-                log.error("Cannot guess mimetype from extension '%s' for '%s'. Set --mimetype explicitly" % (file_path.suffix, file_path))
-
         # Flag to track whether 'url' should be 'src'
         url_is_src = False
 
@@ -320,8 +313,8 @@ def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, file_grp
                 if param_name == 'url':
                     url_is_src = True
                     continue
-                elif param_name == 'file_id':
-                    # XXX file_id might be unset so we derive it once the other
+                elif param_name in ['mimetype', 'file_id']:
+                    # auto-filled below once the other
                     # replacements have happened
                     continue
                 raise ValueError(f"OcrdFile attribute '{param_name}' unset ({file_dict})")
@@ -341,6 +334,11 @@ def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, file_grp
         if not file_id:
             id_field = srcpath.name if file_path != srcpath else file_path.name
             file_dict['file_id'] = safe_filename('%s_%s' % (file_dict['file_grp'], id_field))
+        if not mimetype:
+            try:
+                file_dict['mimetype'] = EXT_TO_MIME[srcpath.suffix]
+            except KeyError:
+                log.error("Cannot guess MIME type from extension '%s' for '%s'. Set --mimetype explicitly" % (srcpath.suffix, srcpath))
 
         # copy files if src != url
         if url_is_src:

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -218,7 +218,7 @@ def workspace_add_file(ctx, file_grp, file_id, mimetype, page_id, ignore, check_
 @click.option('-r', '--regex', help="Regular expression matching the FILE_GLOB filesystem paths to define named captures usable in the other parameters", required=True)
 @click.option('-m', '--mimetype', help="Media type of the file. If not provided, guess from filename", required=False)
 @click.option('-g', '--page-id', help="physical page ID of the file", required=False)
-@click.option('-i', '--file-id', help="ID of the file", required=False)
+@click.option('-i', '--file-id', help="ID of the file. If not provided, derive from fileGrp and filename", required=False)
 @click.option('-u', '--url', help="local filesystem path in the workspace directory (copied from source file if different)", required=False)
 @click.option('-G', '--file-grp', help="File group USE of the file", required=True)
 @click.option('-n', '--dry-run', help="Don't actually do anything to the METS or filesystem, just preview", default=False, is_flag=True)

--- a/ocrd_utils/ocrd_utils/str.py
+++ b/ocrd_utils/ocrd_utils/str.py
@@ -184,7 +184,7 @@ def safe_filename(url):
     """
     Sanitize input to be safely used as the basename of a local file.
     """
-    ret = re.sub(r'[^A-Za-z0-9_]+', '_', url)
+    ret = re.sub(r'[^\w]+', '_', url)
     ret = re.sub(r'^\.*', '', ret)
     ret = re.sub(r'\.\.*', '.', ret)
     #  print('safe filename: %s -> %s' % (url, ret))

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -495,7 +495,8 @@ class TestCli(TestCase):
                 '-u', "{{ url }}",
                 'a b c d e'])
             ws.reload_mets()
-            assert next(ws.mets.find_files()).ID == 'a_b_c_d_e'
+            print(out)
+            assert next(ws.mets.find_files()).ID == 'b_c'
             assert next(ws.mets.find_files()).url == 'd'
 
     def test_bulk_add_derive_url(self):

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -483,7 +483,7 @@ class TestCli(TestCase):
     def test_bulk_add_gen_id(self):
         with pushd_popd(tempdir=True) as wsdir:
             ws = self.resolver.workspace_from_nothing(directory=wsdir)
-            Path(wsdir, 'c').write_text('')
+            Path(wsdir, 'c.ext').write_text('')
             _, out, err = self.invoke_cli(workspace_cli, [
                 'bulk-add',
                 '-r', r'(?P<pageid>.*) (?P<filegrp>.*) (?P<src>.*) (?P<url>.*) (?P<mimetype>.*)',
@@ -493,7 +493,7 @@ class TestCli(TestCase):
                 # '-i', '{{ fileid }}',  # XXX skip --file-id
                 '-m', '{{ mimetype }}',
                 '-u', "{{ url }}",
-                'a b c d e'])
+                'a b c.ext d e'])
             ws.reload_mets()
             print(out)
             assert next(ws.mets.find_files()).ID == 'b_c'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,6 +24,7 @@ from ocrd_utils import (
 
     nth_url_segment,
     remove_non_path_from_url,
+    safe_filename,
 
     parse_json_string_or_file,
     set_json_key_value_overrides,
@@ -317,6 +318,10 @@ class TestUtils(TestCase):
         with self.assertRaisesRegex(ValueError, 'Unable to generate range'):
             generate_range('NONUMBER', 'ALSO_NONUMBER')
 
+    def test_safe_filename(self):
+        assert safe_filename('Hello world,!') == 'Hello_world_'
+        assert safe_filename(' Καλημέρα κόσμε,') == '_Καλημέρα_κόσμε_'
+        assert safe_filename(':コンニチハ:') == '_コンニチハ_'
 
 if __name__ == '__main__':
     main(__file__)


### PR DESCRIPTION
As raised in #922, if `--file-id` is not provided explicitly, `bulk-add` derived it from the `safe_filename(file_path)` and this had three problems:

* `safe_filename` allowed only a subset of ASCII, now all Unicode letters and digits
* `file_id` was derived from `file_path` even when the "file_path" was actually CSV data. Now it either derives it from `file_path` if it is an actual filepath or from the `srcpath` if not. 
* Derived `file_id` did not follow the convention of starting with the `file_grp`. It does now and also only uses the basename of either `file_path` or `srcpath`