### PR TITLE
Update bagit-checksums / fix for #363

### DIFF
--- a/ocrd/ocrd/cli/zip.py
+++ b/ocrd/ocrd/cli/zip.py
@@ -118,10 +118,14 @@ def validate(src, **kwargs):
 @zip_cli.command('update')
 @click.argument('src', type=click.Path(dir_okay=True, readable=True, resolve_path=True), required=True)
 @click.argument('dest', type=click.Path(dir_okay=True, readable=True, writable=True, resolve_path=True), required=False)
-@click.option('-', '--overwrite', help="overwrite bag in SRC", type=bool, default=False)
+@click.option('-o', '--overwrite', help="overwrite bag in SRC", is_flag=True)
 def update(src, dest=None, overwrite=False):
     """
-    Recretae checksums of an OCRD-ZIP
+    Recreate files containing checksums (manifest-sha512.txt, tagmanifest-sha512.txt and
+    'Payload-Oxum' contained in bag-info.txt) of an OCRD-ZIP.
 
+    Open the bag (zip file or directory) ``src``, create or update its manifests/checksums and
+    output to (zip file or directory) ``dest``. It is also possible to output to ``src`` / overwrite
+    ``src`` in place when ``--overwrite``-flag is given.
     """
     WorkspaceBagger(Resolver()).recreate_checksums(src, dest=dest, overwrite=overwrite)

--- a/ocrd/ocrd/cli/zip.py
+++ b/ocrd/ocrd/cli/zip.py
@@ -110,3 +110,18 @@ def validate(src, **kwargs):
     print(report)
     if not report.is_valid:
         sys.exit(1)
+
+# ----------------------------------------------------------------------
+# ocrd zip update
+# ----------------------------------------------------------------------
+
+@zip_cli.command('update')
+@click.argument('src', type=click.Path(dir_okay=True, readable=True, resolve_path=True), required=True)
+@click.argument('dest', type=click.Path(dir_okay=True, readable=True, writable=True, resolve_path=True), required=False)
+@click.option('-', '--overwrite', help="overwrite bag in SRC", type=bool, default=False)
+def update(src, dest=None, overwrite=False):
+    """
+    Recretae checksums of an OCRD-ZIP
+
+    """
+    WorkspaceBagger(Resolver()).recreate_checksums(src, dest=dest, overwrite=overwrite)

--- a/ocrd/ocrd/workspace_bagger.py
+++ b/ocrd/ocrd/workspace_bagger.py
@@ -1,13 +1,15 @@
 from datetime import datetime
 from os import makedirs, chdir, walk
-from os.path import join, isdir, basename, exists, relpath, isfile
+from os.path import join, isdir, basename, exists, relpath
+from pathlib import Path
 from shutil import make_archive, rmtree, copyfile, move
-from tempfile import mkdtemp
+from tempfile import mkdtemp, TemporaryDirectory
 import re
 import tempfile
 import sys
 from bagit import Bag, make_manifests, _load_tag_file, _make_tag_file, _make_tagmanifest_file  # pylint: disable=no-name-in-module
 from distutils.dir_util import copy_tree
+from contextlib import nullcontext
 
 from ocrd_utils import (
     pushd_popd,
@@ -291,43 +293,36 @@ class WorkspaceBagger():
             raise Exception("Setting 'dest' and 'overwrite' is a contradiction")
         if not overwrite and not dest:
             raise Exception("For checksum recreation 'dest' must be provided")
-
-        if not exists(src):
+        src_path = Path(src)
+        if not src_path.exists():
             raise Exception("Path to bag not existing")
-        is_zipped = isfile(src)
+        is_zipped = src_path.is_file()
 
-        if is_zipped:
-            tmp_path = mkdtemp()
-            unzip_file_to_dir(src, tmp_path)
-            path_to_bag = tmp_path
-            if not exists(join(path_to_bag, "data")):
-                try:
-                    rmtree(tmp_path)
-                except OSError:
-                    pass
-                raise Exception("data-dir of bag not found")
-        else:
-            path_to_bag = src if overwrite else dest
-            if not exists(join(src, "data")):
-                raise Exception("data-dir of bag not found")
-            if not overwrite:
-                makedirs(dest, exist_ok=True)
-                # TODO: write test for copytree. Expected behaviour: src contains stuff. dest is a
-                #       non existing dir. afterwards dest has all files/folder contained in src but
-                #       not src itself. Same if dest exists
-                copy_tree(src, dest)
+        with TemporaryDirectory() if is_zipped else nullcontext() as tempdir:
+            if is_zipped:
+                unzip_file_to_dir(src, tempdir)
+                path_to_bag = Path(tempdir)
+                if not path_to_bag.joinpath("data").exists():
+                    raise FileNotFoundError("data directory of bag not found")
+            else:
+                path_to_bag = src_path if overwrite else Path(dest)
+                if not src_path.joinpath("data").exists():
+                    raise FileNotFoundError(f"data directory of bag not found at {src}")
+                if not overwrite:
+                    path_to_bag.mkdir(parents=True, exist_ok=True)
+                    copy_tree(src, dest)
 
-        with pushd_popd(path_to_bag):
-            n_bytes, n_files = make_manifests("data", 1, ["sha512"])
+            with pushd_popd(path_to_bag):
+                n_bytes, n_files = make_manifests("data", 1, ["sha512"])
 
-            bag_infos = _load_tag_file("bag-info.txt")
-            bag_infos["Payload-Oxum"] = f"{n_bytes}.{n_files}"
-            _make_tag_file("bag-info.txt", bag_infos)
-            _make_tagmanifest_file("sha512", ".")
+                bag_infos = _load_tag_file("bag-info.txt")
+                bag_infos["Payload-Oxum"] = f"{n_bytes}.{n_files}"
+                _make_tag_file("bag-info.txt", bag_infos)
+                _make_tagmanifest_file("sha512", ".")
 
-        if is_zipped:
-            name = basename(src)
-            if name.endswith(".zip"):
-                name = name[:-4]
-            zip_path = make_archive(name, "zip", path_to_bag)
-            move(zip_path, src if overwrite else dest)
+            if is_zipped:
+                name = src_path.name
+                if name.endswith(".zip"):
+                    name = name[:-4]
+                zip_path = make_archive(name, "zip", path_to_bag)
+                move(zip_path, src if overwrite else dest)

--- a/ocrd/ocrd/workspace_bagger.py
+++ b/ocrd/ocrd/workspace_bagger.py
@@ -9,7 +9,6 @@ import tempfile
 import sys
 from bagit import Bag, make_manifests, _load_tag_file, _make_tag_file, _make_tagmanifest_file  # pylint: disable=no-name-in-module
 from distutils.dir_util import copy_tree
-from contextlib import nullcontext
 
 from ocrd_utils import (
     pushd_popd,
@@ -298,7 +297,7 @@ class WorkspaceBagger():
             raise Exception("Path to bag not existing")
         is_zipped = src_path.is_file()
 
-        with TemporaryDirectory() if is_zipped else nullcontext() as tempdir:
+        with TemporaryDirectory() as tempdir:
             if is_zipped:
                 unzip_file_to_dir(src, tempdir)
                 path_to_bag = Path(tempdir)


### PR DESCRIPTION
Hi,
this PR contains the functionality to recreate bagit-checksums (tagmanifest-sha512.txt, manifest-sha512.txt, Payload-Oxum in bag-info.txt ). This is done with a new command: `ocrd zip update`.
The second thing this PR does is remove the `-I` flag from `ocrd zip bag`, because, as seen in the issue #363 the `-I`-flag is hard to understand and does not work as expected.