### PR TITLE
Fix regressions from caching refactoring

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -414,7 +414,7 @@ class OcrdMets(OcrdXmlDocument):
         if files:
             if not recursive:
                 raise Exception("fileGrp %s is not empty and recursive wasn't set" % USE)
-            for f in files:
+            for f in list(files):
                 self.remove_one_file(ID=f.get('ID'), fileGrp=f.getparent().get('USE'))
 
         if self._cache_flag:

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -557,7 +557,7 @@ class OcrdMets(OcrdXmlDocument):
         List all page IDs (the ``@ID`` of each physical ``mets:structMap`` ``mets:div``)
         """
         if self._cache_flag:
-            return self._page_cache.values()
+            return list(self._page_cache.keys())
             
         return self._tree.getroot().xpath(
             'mets:structMap[@TYPE="PHYSICAL"]/mets:div[@TYPE="physSequence"]/mets:div[@TYPE="page"]/@ID',
@@ -685,7 +685,7 @@ class OcrdMets(OcrdXmlDocument):
             mets_div = self._tree.getroot().xpath(
                 'mets:structMap[@TYPE="PHYSICAL"]/mets:div[@TYPE="physSequence"]/mets:div[@TYPE="page"][@ID="%s"]' % ID,
                 namespaces=NS)
-        if mets_div is not None:
+        if mets_div:
             mets_div[0].getparent().remove(mets_div[0])
             if self._cache_flag:
                 del self._page_cache[ID]


### PR DESCRIPTION
In the process of merging #875 we introduced subtle bugs. These were not picked up because not all the fixtures in `test_ocrd_mets` had the caching on/off mechanism and also because we did not do `isinstance` tests.