### PR TITLE
workspace bagger: remove inplace flag

### DIFF
--- a/ocrd/ocrd/cli/zip.py
+++ b/ocrd/ocrd/cli/zip.py
@@ -39,13 +39,12 @@ def zip_cli():
               help='Basename of the METS file.',
               show_default=True)
 @click.option('-i', '--identifier', '--id', help="Ocrd-Identifier", required=True)
-@click.option('-I', '--in-place', help="Replace workspace with bag (like bagit.py does)", is_flag=True)
 @click.option('-m', '--mets', help="location of mets.xml in the bag's data dir", default="mets.xml")
 @click.option('-b', '--base-version-checksum', help="Ocrd-Base-Version-Checksum")
 @click.option('-t', '--tag-file', help="Add a non-payload file to bag", type=click.Path(file_okay=True, dir_okay=False, readable=True, resolve_path=True), multiple=True)
 @click.option('-Z', '--skip-zip', help="Create a directory but do not ZIP it", is_flag=True, default=False)
 @click.option('-j', '--processes', help="Number of parallel processes", type=int, default=1)
-def bag(directory, mets_basename, dest, identifier, in_place, mets, base_version_checksum, tag_file, skip_zip, processes):
+def bag(directory, mets_basename, dest, identifier, mets, base_version_checksum, tag_file, skip_zip, processes):
     """
     Bag workspace as OCRD-ZIP at DEST
     """
@@ -60,8 +59,7 @@ def bag(directory, mets_basename, dest, identifier, in_place, mets, base_version
         ocrd_base_version_checksum=base_version_checksum,
         processes=processes,
         tag_files=tag_file,
-        skip_zip=skip_zip,
-        in_place=in_place
+        skip_zip=skip_zip
     )
 
 # ----------------------------------------------------------------------

--- a/ocrd/ocrd/workspace_bagger.py
+++ b/ocrd/ocrd/workspace_bagger.py
@@ -37,12 +37,7 @@ class WorkspaceBagger():
         self.resolver = resolver
         self.strict = strict
 
-    def _serialize_bag(self, workspace, bagdir, dest, in_place, skip_zip):
-        if in_place:
-            if not exists(BACKUPDIR):
-                makedirs(BACKUPDIR)
-            backupdir = mkdtemp(dir=BACKUPDIR)
-            move(workspace.directory, backupdir)
+    def _serialize_bag(self, workspace, bagdir, dest, skip_zip):
         if skip_zip:
             move(bagdir, dest)
         else:
@@ -139,7 +134,6 @@ class WorkspaceBagger():
             ocrd_base_version_checksum=None,
             processes=1,
             skip_zip=False,
-            in_place=False,
             tag_files=None
            ):
         """
@@ -155,14 +149,8 @@ class WorkspaceBagger():
             ord_base_version_checksum (string): Ocrd-Base-Version-Checksum in bag-info.txt
             processes (integer): Number of parallel processes checksumming
             skip_zip (boolean): Whether to leave directory unzipped
-            in_place (boolean): Whether to **replace** the workspace with its BagIt variant
             tag_files (list<string>): Path names of additional tag files to be bagged at the root of the bag
         """
-        if in_place and (dest is not None):
-            raise Exception("Setting 'dest' and 'in_place' is a contradiction")
-        if in_place and not skip_zip:
-            raise Exception("Setting 'skip_zip' and not 'in_place' is a contradiction")
-
         if tag_files is None:
             tag_files = []
 
@@ -170,15 +158,13 @@ class WorkspaceBagger():
         bagdir = mkdtemp(prefix=TMP_BAGIT_PREFIX)
 
         if dest is None:
-            if in_place:
-                dest = workspace.directory
-            elif not skip_zip:
+            if not skip_zip:
                 dest = '%s.ocrd.zip' % workspace.directory
             else:
                 dest = '%s.ocrd' % workspace.directory
 
         log = getLogger('ocrd.workspace_bagger')
-        log.info("Bagging %s to %s (temp dir %s)", workspace.directory, '(in-place)' if in_place else dest, bagdir)
+        log.info("Bagging %s to %s (temp dir %s)", workspace.directory, dest, bagdir)
 
         # create data dir
         makedirs(join(bagdir, 'data'))
@@ -201,7 +187,7 @@ class WorkspaceBagger():
         bag.save()
 
         # ZIP it
-        self._serialize_bag(workspace, bagdir, dest, in_place, skip_zip)
+        self._serialize_bag(workspace, bagdir, dest, skip_zip)
 
         log.info('Created bag at %s', dest)
         return dest


### PR DESCRIPTION
As discussed in https://github.com/OCR-D/core/pull/951 and https://github.com/OCR-D/core/issues/363 this pull request removes the inplace flag from the workspace-bagger functionality.