### PR TITLE
resmgr: support zip archives and non-folder archive contents

### DIFF
--- a/ocrd/requirements.txt
+++ b/ocrd/requirements.txt
@@ -10,3 +10,4 @@ pyyaml
 Deprecated == 1.2.0
 memory-profiler >= 0.58.0
 sparklines >= 0.4.2
+python-magic


### PR DESCRIPTION
With this PR, users can `ocrd resmgr download` resources in `application/zip` format as well as tarballs. Non-folder (i.e. file) contents of archives are now handled.