### PR TITLE
Processor builder outside the run_processor + cached version

### DIFF
--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -13,7 +13,7 @@ from memory_profiler import memory_usage
 from sparklines import sparklines
 
 from click import wrap_text
-from ocrd import Workspace
+from ocrd.workspace import Workspace
 from ocrd.processor import Processor
 from ocrd_utils import freeze_args, getLogger
 

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -65,7 +65,7 @@ def run_processor(
     - :py:attr:`output_file_grp`
     - :py:attr:`parameter` (after applying any :py:attr:`parameter_override` settings)
 
-    Warning: Avoid setting the `cached_processor` flag to True. It may have unexpected side effects.
+    Warning: Avoid setting the `instance_caching` flag to True. It may have unexpected side effects.
     This flag is used for an experimental feature we would like to adopt in future.
 
     Run the processor on the workspace (creating output files in the filesystem).

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -81,6 +81,7 @@ def run_processor(
         processor_class=processorClass,
         parameter=parameter,
         workspace=workspace,
+        ocrd_tool=ocrd_tool,
         page_id=page_id,
         input_file_grp=input_file_grp,
         output_file_grp=output_file_grp,

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -14,7 +14,6 @@ from sparklines import sparklines
 
 from click import wrap_text
 from ocrd.workspace import Workspace
-from ocrd.processor.base import Processor
 from ocrd_utils import freeze_args, getLogger
 
 
@@ -282,7 +281,7 @@ Default Wiring:
 # TODO: Decide how much maxsize is optimal as a default
 @freeze_args
 @lru_cache(maxsize=32)
-def get_cached_processor(parameter: dict, processor_class: Type[Processor]):
+def get_cached_processor(parameter: dict, processor_class):
     """
     Call this function to get back an instance of a processor.
     The results are cached based on the parameters.
@@ -300,7 +299,7 @@ def get_cached_processor(parameter: dict, processor_class: Type[Processor]):
 
 
 def get_processor(
-        processor_class: Type[Processor],
+        processor_class,
         parameter: dict,
         workspace: Workspace = None,
         ocrd_tool: dict = None,

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -280,10 +280,8 @@ Default Wiring:
 
 
 # Taken from https://github.com/OCR-D/core/pull/884
-# TODO: Decide how much maxsize is optimal as a default
-# TODO: The max size should be configurable with, e.g., with an environment variable?
 @freeze_args
-@lru_cache(maxsize=32)  
+@lru_cache(maxsize=environ.get('OCRD_MAX_PROCESSOR_CACHE', 128))  
 def get_cached_processor(parameter: dict, processor_class):
     """
     Call this function to get back an instance of a processor.

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -14,7 +14,6 @@ from sparklines import sparklines
 
 from click import wrap_text
 from ocrd.workspace import Workspace
-from ocrd.processor import Processor
 from ocrd_utils import freeze_args, getLogger
 
 
@@ -300,7 +299,7 @@ def get_cached_processor(parameter: dict, processor_class: Type[Processor]):
 
 
 def get_processor(
-        processor_class: Type[Processor],
+        processor_class,
         parameter: dict,
         workspace: Workspace = None,
         ocrd_tool: dict = None,

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -3,8 +3,7 @@ Helper methods for running and documenting processors
 """
 from os import environ
 from time import perf_counter, process_time
-from functools import lru_cache, wraps
-from frozendict import frozendict
+from functools import lru_cache
 import json
 import inspect
 from subprocess import run, PIPE
@@ -12,7 +11,8 @@ from memory_profiler import memory_usage
 from sparklines import sparklines
 
 from click import wrap_text
-from ocrd_utils import getLogger
+from ocrd_utils import getLogger, freeze_args
+
 
 __all__ = [
     'generate_processor_help',
@@ -270,20 +270,6 @@ Default Wiring:
     ocrd_tool.get('input_file_grp', 'NONE'),
     ocrd_tool.get('output_file_grp', 'NONE')
 )
-
-
-# Taken from https://github.com/OCR-D/core/pull/884
-def freeze_args(func):
-    """
-    Transform mutable dictionary into immutable. Useful to be compatible with cache.
-    Code taken from `this post <https://stackoverflow.com/a/53394430/1814420>`_
-    """
-    @wraps(func)
-    def wrapped(*args, **kwargs):
-        args = tuple([frozendict(arg) if isinstance(arg, dict) else arg for arg in args])
-        kwargs = {k: frozendict(v) if isinstance(v, dict) else v for k, v in kwargs.items()}
-        return func(*args, **kwargs)
-    return wrapped
 
 
 # Taken from https://github.com/OCR-D/core/pull/884

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -48,7 +48,7 @@ def run_processor(
         parameter=None,
         parameter_override=None,
         working_dir=None,
-        cached_processor=False  # TODO don't set this yet!
+        instance_caching=False  # TODO don't set this yet!
 ): # pylint: disable=too-many-locals
     """
     Instantiate a Pythonic processor, open a workspace, run the processor and save the workspace.
@@ -92,7 +92,7 @@ def run_processor(
         page_id=page_id,
         input_file_grp=input_file_grp,
         output_file_grp=output_file_grp,
-        cached_processor=cached_processor
+        instance_caching=instance_caching
     )
 
     ocrd_tool = processor.ocrd_tool
@@ -309,10 +309,10 @@ def get_processor(
         page_id: str = None,
         input_file_grp: List[str] = None,
         output_file_grp: List[str] = None,
-        cached_processor: bool = False,
+        instance_caching: bool = False,
 ):
     if processor_class:
-        if cached_processor:
+        if instance_caching:
             cached_processor = get_cached_processor(
                 parameter=parameter,
                 processor_class=processor_class

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -48,7 +48,7 @@ def run_processor(
         parameter=None,
         parameter_override=None,
         working_dir=None,
-        cached_processor=False
+        cached_processor=False  # TODO don't set this yet!
 ): # pylint: disable=too-many-locals
     """
     Instantiate a Pythonic processor, open a workspace, run the processor and save the workspace.
@@ -64,6 +64,9 @@ def run_processor(
     - :py:attr:`input_file_grp`
     - :py:attr:`output_file_grp`
     - :py:attr:`parameter` (after applying any :py:attr:`parameter_override` settings)
+
+    Warning: Avoid setting the `cached_processor` flag to True. It may have unexpected side effects.
+    This flag is used for an experimental feature we would like to adopt in future.
 
     Run the processor on the workspace (creating output files in the filesystem).
 
@@ -82,7 +85,6 @@ def run_processor(
     log.debug("Running processor %s", processorClass)
 
     processor = get_processor(
-        # TODO: Warning: processorClass of type Object gets auto casted to Type[Processor]
         processor_class=processorClass,
         parameter=parameter,
         workspace=workspace,
@@ -279,8 +281,9 @@ Default Wiring:
 
 # Taken from https://github.com/OCR-D/core/pull/884
 # TODO: Decide how much maxsize is optimal as a default
+# TODO: The max size should be configurable with, e.g., with an environment variable?
 @freeze_args
-@lru_cache(maxsize=32)
+@lru_cache(maxsize=32)  
 def get_cached_processor(parameter: dict, processor_class):
     """
     Call this function to get back an instance of a processor.

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -14,6 +14,7 @@ from sparklines import sparklines
 
 from click import wrap_text
 from ocrd.workspace import Workspace
+from ocrd.processor.base import Processor
 from ocrd_utils import freeze_args, getLogger
 
 
@@ -299,7 +300,7 @@ def get_cached_processor(parameter: dict, processor_class: Type[Processor]):
 
 
 def get_processor(
-        processor_class,
+        processor_class: Type[Processor],
         parameter: dict,
         workspace: Workspace = None,
         ocrd_tool: dict = None,

--- a/ocrd/requirements.txt
+++ b/ocrd/requirements.txt
@@ -11,4 +11,3 @@ Deprecated == 1.2.0
 memory-profiler >= 0.58.0
 sparklines >= 0.4.2
 python-magic
-frozendict>=2.3.4

--- a/ocrd/requirements.txt
+++ b/ocrd/requirements.txt
@@ -11,3 +11,4 @@ Deprecated == 1.2.0
 memory-profiler >= 0.58.0
 sparklines >= 0.4.2
 python-magic
+frozendict>=2.3.4

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -151,8 +151,10 @@ from .image import (
     xywh_from_polygon)
 
 from .introspect import (
+    freeze_args,
     set_json_key_value_overrides,
-    membername)
+    membername
+)
 
 from .logging import (
     disableLogging,

--- a/ocrd_utils/ocrd_utils/introspect.py
+++ b/ocrd_utils/ocrd_utils/introspect.py
@@ -2,6 +2,23 @@
 Utility functions to simplify access to data structures.
 """
 import json
+from functools import wraps
+from frozendict import frozendict
+
+
+# Taken from https://github.com/OCR-D/core/pull/884
+def freeze_args(func):
+    """
+    Transform mutable dictionary into immutable. Useful to be compatible with cache.
+    Code taken from `this post <https://stackoverflow.com/a/53394430/1814420>`_
+    """
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        args = tuple([frozendict(arg) if isinstance(arg, dict) else arg for arg in args])
+        kwargs = {k: frozendict(v) if isinstance(v, dict) else v for k, v in kwargs.items()}
+        return func(*args, **kwargs)
+    return wrapped
+
 
 def membername(class_, val):
     """Convert a member variable/constant into a member name string."""

--- a/ocrd_utils/requirements.txt
+++ b/ocrd_utils/requirements.txt
@@ -5,3 +5,4 @@ numpy
 atomicwrites >= 1.3.0
 importlib_metadata;python_version<'3.8'
 importlib_resources;python_version<'3.8'
+frozendict>=2.3.4


### PR DESCRIPTION
I have created a separate method to get the desired processor class. Both cached and non-cached types are supported. By default, the non-cached processor is returned to preserve the current state. It's possible to try the cached version by setting the additional flag parameter to True. 