### PR TITLE
Workspace: also add automatic backup on init

### DIFF
--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -77,7 +77,11 @@ class Workspace():
         if mets is None:
             mets = OcrdMets(filename=self.mets_target)
         self.mets = mets
-        self.automatic_backup = automatic_backup
+        if automatic_backup:
+            self.automatic_backup = WorkspaceBackupManager(self)
+            self.automatic_backup.add()
+        else:
+            self.automatic_backup = None
         self.baseurl = baseurl
         #  print(mets.to_xml(xmllint=True).decode('utf-8'))
 
@@ -407,7 +411,7 @@ class Workspace():
         log = getLogger('ocrd.workspace.save_mets')
         log.debug("Saving mets '%s'", self.mets_target)
         if self.automatic_backup:
-            WorkspaceBackupManager(self).add()
+            self.automatic_backup.add()
         with atomic_write(self.mets_target) as f:
             f.write(self.mets.to_xml(xmllint=True).decode('utf-8'))
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -30,6 +30,7 @@ from ocrd_utils import polygon_mask, xywh_from_polygon, bbox_from_polygon, point
 from ocrd_modelfactory import page_from_file
 from ocrd.resolver import Resolver
 from ocrd.workspace import Workspace
+from ocrd.workspace_backup import WorkspaceBackupManager
 
 
 TMP_FOLDER = '/tmp/test-core-workspace'
@@ -147,7 +148,7 @@ def test_workspace_str(plain_workspace):
 def test_workspace_backup(plain_workspace):
 
     # act
-    plain_workspace.automatic_backup = True
+    plain_workspace.automatic_backup = WorkspaceBackupManager(plain_workspace)
     plain_workspace.save_mets()
     plain_workspace.reload_mets()
 


### PR DESCRIPTION
This improves the behaviour of the optional automatic workspace backup facility:

- does not instantiate the Manager each time
- already makes a backup at constructor time (before the first changes)