### PR TITLE
processor.module: fix namespace pkg case

### DIFF
--- a/ocrd/ocrd/processor/base.py
+++ b/ocrd/ocrd/processor/base.py
@@ -253,7 +253,7 @@ class Processor():
             if fqname:
                 fqname += '.'
             fqname += name
-            if sys.modules[fqname].__file__:
+            if getattr(sys.modules[fqname], '__file__', None):
                 return fqname
         # fall-back
         return self.__module__


### PR DESCRIPTION
Fixes a glitch following #917 which still breaks with namespace packages (e.g. `ocrd resmgr list-installed`)