### PR TITLE
Fix the processor instance caching

### DIFF
--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -1,7 +1,7 @@
 """
 Helper methods for running and documenting processors
 """
-from os import environ
+from os import chdir, environ, getcwd
 from time import perf_counter, process_time
 from functools import lru_cache
 import json
@@ -95,6 +95,9 @@ def run_processor(
         instance_caching=instance_caching
     )
 
+    old_cwd = getcwd()
+    chdir(processor.workspace.directory)
+
     ocrd_tool = processor.ocrd_tool
     name = '%s v%s' % (ocrd_tool['executable'], processor.version)
     otherrole = ocrd_tool['steps'][0]
@@ -104,32 +107,44 @@ def run_processor(
     t0_cpu = process_time()
     if any(x in environ.get('OCRD_PROFILE', '') for x in ['RSS', 'PSS']):
         backend = 'psutil_pss' if 'PSS' in environ['OCRD_PROFILE'] else 'psutil'
-        mem_usage = memory_usage(proc=processor.process,
-                                # only run process once
-                                max_iterations=1,
-                                interval=.1, timeout=None, timestamps=True, 
-                                # include sub-processes
-                                multiprocess=True, include_children=True, 
-                                # get proportional set size instead of RSS
-                                backend=backend)
+        try:
+            mem_usage = memory_usage(proc=processor.process,
+                                     # only run process once
+                                     max_iterations=1,
+                                     interval=.1, timeout=None, timestamps=True,
+                                     # include sub-processes
+                                     multiprocess=True, include_children=True,
+                                     # get proportional set size instead of RSS
+                                     backend=backend)
+        except Exception as err:
+            log.exception("Failure in processor '%s'" % ocrd_tool['executable'])
+            return err
+        finally:
+            chdir(old_cwd)
         mem_usage_values = [mem for mem, _ in mem_usage]
         mem_output = 'memory consumption: '
         mem_output += ''.join(sparklines(mem_usage_values))
         mem_output += ' max: %.2f MiB min: %.2f MiB' % (max(mem_usage_values), min(mem_usage_values))
         logProfile.info(mem_output)
     else:
-        with pushd_popd(workspace.directory):
+        try:
             processor.process()
+        except Exception as err:
+            log.exception("Failure in processor '%s'" % ocrd_tool['executable'])
+            return err
+        finally:
+            chdir(old_cwd)
+
     t1_wall = perf_counter() - t0_wall
     t1_cpu = process_time() - t0_cpu
     logProfile.info("Executing processor '%s' took %fs (wall) %fs (CPU)( [--input-file-grp='%s' --output-file-grp='%s' --parameter='%s' --page-id='%s']" % (
         ocrd_tool['executable'],
         t1_wall,
         t1_cpu,
-        input_file_grp or '',
-        output_file_grp or '',
-        json.dumps(parameter) or '',
-        page_id or ''
+        processor.input_file_grp or '',
+        processor.output_file_grp or '',
+        json.dumps(processor.parameter) or '',
+        processor.page_id or ''
     ))
     workspace.mets.add_agent(
         name=name,
@@ -137,13 +152,14 @@ def run_processor(
         othertype='SOFTWARE',
         role='OTHER',
         otherrole=otherrole,
-        notes=[({'option': 'input-file-grp'}, input_file_grp or ''),
-               ({'option': 'output-file-grp'}, output_file_grp or ''),
-               ({'option': 'parameter'}, json.dumps(parameter or '')),
-               ({'option': 'page-id'}, page_id or '')]
+        notes=[({'option': 'input-file-grp'}, processor.input_file_grp or ''),
+               ({'option': 'output-file-grp'}, processor.output_file_grp or ''),
+               ({'option': 'parameter'}, json.dumps(processor.parameter or '')),
+               ({'option': 'page-id'}, processor.page_id or '')]
     )
     workspace.save_mets()
     return processor
+
 
 def run_cli(
         executable,

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -119,7 +119,7 @@ def run_processor(
                                      backend=backend)
         except Exception as err:
             log.exception("Failure in processor '%s'" % ocrd_tool['executable'])
-            return err
+            raise err
         finally:
             chdir(old_cwd)
         mem_usage_values = [mem for mem, _ in mem_usage]
@@ -132,7 +132,7 @@ def run_processor(
             processor.process()
         except Exception as err:
             log.exception("Failure in processor '%s'" % ocrd_tool['executable'])
-            return err
+            raise err
         finally:
             chdir(old_cwd)
 

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -88,13 +88,14 @@ def run_processor(
     processor = get_processor(
         processor_class=processorClass,
         parameter=parameter,
-        workspace=workspace,
+        workspace=None,
         ocrd_tool=ocrd_tool,
         page_id=page_id,
         input_file_grp=input_file_grp,
         output_file_grp=output_file_grp,
         instance_caching=instance_caching
     )
+    processor.workspace = workspace
     chdir(processor.workspace.directory)
 
     ocrd_tool = processor.ocrd_tool

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -84,6 +84,7 @@ def run_processor(
     log = getLogger('ocrd.processor.helpers.run_processor')
     log.debug("Running processor %s", processorClass)
 
+    old_cwd = getcwd()
     processor = get_processor(
         processor_class=processorClass,
         parameter=parameter,
@@ -94,8 +95,6 @@ def run_processor(
         output_file_grp=output_file_grp,
         instance_caching=instance_caching
     )
-    
-    old_cwd = getcwd()
     chdir(processor.workspace.directory)
 
     ocrd_tool = processor.ocrd_tool

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -84,8 +84,6 @@ def run_processor(
     log = getLogger('ocrd.processor.helpers.run_processor')
     log.debug("Running processor %s", processorClass)
 
-    old_cwd = getcwd()
-
     processor = get_processor(
         processor_class=processorClass,
         parameter=parameter,
@@ -96,7 +94,8 @@ def run_processor(
         output_file_grp=output_file_grp,
         instance_caching=instance_caching
     )
-
+    
+    old_cwd = getcwd()
     chdir(processor.workspace.directory)
 
     ocrd_tool = processor.ocrd_tool

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -14,7 +14,7 @@ from sparklines import sparklines
 
 from click import wrap_text
 from ocrd.workspace import Workspace
-from ocrd_utils import freeze_args, getLogger
+from ocrd_utils import freeze_args, getLogger, pushd_popd
 
 
 __all__ = [
@@ -118,7 +118,8 @@ def run_processor(
         mem_output += ' max: %.2f MiB min: %.2f MiB' % (max(mem_usage_values), min(mem_usage_values))
         logProfile.info(mem_output)
     else:
-        processor.process()
+        with pushd_popd(workspace.directory):
+            processor.process()
     t1_wall = perf_counter() - t0_wall
     t1_cpu = process_time() - t0_cpu
     logProfile.info("Executing processor '%s' took %fs (wall) %fs (CPU)( [--input-file-grp='%s' --output-file-grp='%s' --parameter='%s' --page-id='%s']" % (

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -84,6 +84,8 @@ def run_processor(
     log = getLogger('ocrd.processor.helpers.run_processor')
     log.debug("Running processor %s", processorClass)
 
+    old_cwd = getcwd()
+
     processor = get_processor(
         processor_class=processorClass,
         parameter=parameter,
@@ -95,7 +97,6 @@ def run_processor(
         instance_caching=instance_caching
     )
 
-    old_cwd = getcwd()
     chdir(processor.workspace.directory)
 
     ocrd_tool = processor.ocrd_tool

--- a/tests/processor/test_ocrd_dummy.py
+++ b/tests/processor/test_ocrd_dummy.py
@@ -2,6 +2,7 @@
 # pylint: disable=invalid-name,line-too-long
 
 from io import BytesIO
+import os
 from pathlib import Path
 
 from PIL import Image
@@ -18,6 +19,7 @@ class TestDummyProcessor(TestCase):
     def test_copies_ok(self):
         with copy_of_directory(assets.url_of('SBB0000F29300010000/data')) as wsdir:
             workspace = Workspace(Resolver(), wsdir)
+            os.chdir(workspace.directory)
             input_files = workspace.mets.find_all_files(fileGrp='OCR-D-IMG')
             self.assertEqual(len(input_files), 3)
             output_files = workspace.mets.find_all_files(fileGrp='OUTPUT')
@@ -53,6 +55,7 @@ class TestDummyProcessor(TestCase):
 
 def test_copy_file_false(tmpdir):
     workspace = Resolver().workspace_from_nothing(directory=tmpdir)
+    os.chdir(workspace.directory)
     for i in range(10):
         pil_image = Image.new('RGB', (100, 100))
         bhandle = BytesIO()


### PR DESCRIPTION
In #972, I missed using the context switch required for the cached processor instances to work correctly. Now I am able to reuse cached instances. According to my observations and testing, for both cached and non-cached, that additional line has no side effects. 