### PR TITLE
Add resmgr Google Drive downloads

### DIFF
--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -8,6 +8,8 @@ from tarfile import open as open_tarfile
 from urllib.parse import urlparse, unquote
 from zipfile import ZipFile
 
+from mimetypes import guess_type
+from filetype import guess
 import requests
 from yaml import safe_load, safe_dump
 
@@ -317,7 +319,13 @@ class OcrdResourceManager():
                 Path('out').mkdir()
                 with pushd_popd('out'):
                     suffixes = ''.join(Path(nth_url_segment(url)).suffixes)
-                    mimetype = EXT_TO_MIME.get(suffixes, 'application/octet-stream')
+                    mimetype = guess(f'../{archive_fname}')
+                    if mimetype is None:
+                        mimetype = guess_type(f'../{archive_fname}')[0]
+                    else:
+                        mimetype = mimetype.mime
+                    if mimetype is None:
+                        mimetype = EXT_TO_MIME.get(suffixes, 'application/octet-stream')
                     log.info("Extracting %s archive to %s/out" % (mimetype, tempdir))
                     if mimetype == 'application/zip':
                         with ZipFile(f'../{archive_fname}', 'r') as zipf:

--- a/ocrd/requirements.txt
+++ b/ocrd/requirements.txt
@@ -11,3 +11,4 @@ Deprecated == 1.2.0
 memory-profiler >= 0.58.0
 sparklines >= 0.4.2
 filetype
+gdown

--- a/ocrd/requirements.txt
+++ b/ocrd/requirements.txt
@@ -10,3 +10,4 @@ pyyaml
 Deprecated == 1.2.0
 memory-profiler >= 0.58.0
 sparklines >= 0.4.2
+filetype


### PR DESCRIPTION
fixes #992 

But the supported URLs are somewhat limited IIUC. For our [example](https://drive.google.com/file/d/1olLQOXvt6nYbvW4pES3T_ABqSlWRq9mY), we have to append `/view`. Besides this `/file/d/.../view` pattern, gdown knows about `/presentation/d/.../edit` and `/uc?id=...` URLs.

Anyway – this seems least painful. Might have to extend when more cases arise.