### PR TITLE
Dockerfile: Remove unneeded installation of python3-pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get -y install software-properties-common \
     && apt-get update && apt-get -y install \
         ca-certificates \
         python3-dev \
-        python3-pip \
         python3-venv \
         gcc \
         make \


### PR DESCRIPTION
Fixes: f1527a2f605f3ea5 ("upgrade base image to 20.04")