### PR TITLE
run_processor / get_processor: do not pass (empty) ocrd_tool

### DIFF
--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -35,7 +35,6 @@ def _get_workspace(workspace=None, resolver=None, mets_url=None, working_dir=Non
 
 def run_processor(
         processorClass,
-        ocrd_tool=None,
         mets_url=None,
         resolver=None,
         workspace=None,
@@ -59,7 +58,6 @@ def run_processor(
 
     Instantiate a Python object for :py:attr:`processorClass`, passing:
     - the workspace,
-    - :py:attr:`ocrd_tool`
     - :py:attr:`page_id`
     - :py:attr:`input_file_grp`
     - :py:attr:`output_file_grp`
@@ -88,7 +86,6 @@ def run_processor(
         processor_class=processorClass,
         parameter=parameter,
         workspace=workspace,
-        ocrd_tool=ocrd_tool,
         page_id=page_id,
         input_file_grp=input_file_grp,
         output_file_grp=output_file_grp,
@@ -303,7 +300,6 @@ def get_processor(
         processor_class,
         parameter: dict,
         workspace: Workspace = None,
-        ocrd_tool: dict = None,
         page_id: str = None,
         input_file_grp: List[str] = None,
         output_file_grp: List[str] = None,
@@ -322,7 +318,6 @@ def get_processor(
             return cached_processor
         return processor_class(
             workspace=workspace,
-            ocrd_tool=ocrd_tool,
             page_id=page_id,
             input_file_grp=input_file_grp,
             output_file_grp=output_file_grp,

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -3,7 +3,7 @@ import json
 from tempfile import TemporaryDirectory
 from os.path import join
 from tests.base import CapturingTestCase as TestCase, assets, main # pylint: disable=import-error, no-name-in-module
-from tests.data import DummyProcessor, DummyProcessorWithRequiredParameters, DummyProcessorWithOutput, IncompleteProcessor, DUMMY_TOOL
+from tests.data import DummyProcessor, DummyProcessorWithRequiredParameters, DummyProcessorWithOutput, IncompleteProcessor
 
 from ocrd_utils import MIMETYPE_PAGE, pushd_popd, initLogging, disableLogging
 from ocrd.resolver import Resolver
@@ -79,12 +79,12 @@ class TestProcessor(TestCase):
 
     def test_run_agent(self):
         no_agents_before = len(self.workspace.mets.agents)
-        run_processor(DummyProcessor, ocrd_tool=DUMMY_TOOL, workspace=self.workspace)
+        run_processor(DummyProcessor, workspace=self.workspace)
         self.assertEqual(len(self.workspace.mets.agents), no_agents_before + 1, 'one more agent')
         #  print(self.workspace.mets.agents[no_agents_before])
 
     def test_run_input(self):
-        run_processor(DummyProcessor, ocrd_tool=DUMMY_TOOL, workspace=self.workspace, input_file_grp="OCR-D-IMG")
+        run_processor(DummyProcessor, workspace=self.workspace, input_file_grp="OCR-D-IMG")
         assert len(self.workspace.mets.agents) > 0
         assert len(self.workspace.mets.agents[-1].notes) > 0
         assert ({'{https://ocr-d.de}option': 'input-file-grp'}, 'OCR-D-IMG') in self.workspace.mets.agents[-1].notes
@@ -94,7 +94,7 @@ class TestProcessor(TestCase):
             ws = self.resolver.workspace_from_nothing(directory=tempdir)
             ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar1', pageId='phys_0001')
             ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, ID='foobar2', pageId='phys_0002')
-            run_processor(DummyProcessorWithOutput, ocrd_tool=DUMMY_TOOL, workspace=ws,
+            run_processor(DummyProcessorWithOutput, workspace=ws,
                           input_file_grp="GRP1",
                           output_file_grp="OCR-D-OUT")
             assert len(ws.mets.find_all_files(fileGrp="OCR-D-OUT")) == 2
@@ -108,19 +108,19 @@ class TestProcessor(TestCase):
             ws.add_file('OCR-D-OUT', mimetype=MIMETYPE_PAGE, ID='OCR-D-OUT_phys_0001', pageId='phys_0001')
             ws.overwrite_mode = False
             with pytest.raises(Exception) as exc:
-                run_processor(DummyProcessorWithOutput, ocrd_tool=DUMMY_TOOL, workspace=ws,
+                run_processor(DummyProcessorWithOutput, workspace=ws,
                               input_file_grp="GRP1",
                               output_file_grp="OCR-D-OUT")
                 assert str(exc.value) == "File with ID='OCR-D-OUT_phys_0001' already exists"
             ws.overwrite_mode = True
-            run_processor(DummyProcessorWithOutput, ocrd_tool=DUMMY_TOOL, workspace=ws,
+            run_processor(DummyProcessorWithOutput, workspace=ws,
                           input_file_grp="GRP1",
                           output_file_grp="OCR-D-OUT")
             assert len(ws.mets.find_all_files(fileGrp="OCR-D-OUT")) == 2
 
     def test_run_cli(self):
         with TemporaryDirectory() as tempdir:
-            run_processor(DummyProcessor, ocrd_tool=DUMMY_TOOL, workspace=self.workspace)
+            run_processor(DummyProcessor, workspace=self.workspace)
             run_cli(
                 'echo',
                 mets_url=assets.url_of('SBB0000F29300010000/data/mets.xml'),

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 from os.path import join, exists
 
 from tests.base import CapturingTestCase as TestCase, assets, main, copy_of_directory # pylint: disable=import-error, no-name-in-module
-from tests.data import DummyProcessor, DUMMY_TOOL
+from tests.data import DummyProcessor
 
 from ocrd import Processor, Resolver
 from ocrd.decorators import (
@@ -131,7 +131,6 @@ class TestDecorators(TestCase):
             with self.assertRaisesRegex(Exception, 'already in METS'):
                 ocrd_cli_wrap_processor(
                     DummyProcessor,
-                    ocrd_tool=DUMMY_TOOL,
                     mets=ws.mets_target,
                     input_file_grp='IN-GRP',
                     output_file_grp='OUT-GRP',
@@ -139,7 +138,6 @@ class TestDecorators(TestCase):
             # with overwrite, it shouldn't fail
             ocrd_cli_wrap_processor(
                 DummyProcessor,
-                ocrd_tool=DUMMY_TOOL,
                 mets=ws.mets_target,
                 input_file_grp='IN-GRP',
                 output_file_grp='OUT-GRP',
@@ -155,7 +153,6 @@ class TestDecorators(TestCase):
     #         self.assertTrue(exists(join(ws.directory, 'ID4.tif')), 'files exist')
     #         ocrd_cli_wrap_processor(
     #             DummyProcessor,
-    #             ocrd_tool=DUMMY_TOOL,
     #             mets=ws.mets_target,
     #             parameter={"foo": 42},
     #             input_file_grp='IN-GRP',
@@ -177,7 +174,6 @@ class TestDecorators(TestCase):
     #         self.assertTrue(exists(join(ws.directory, 'ID4.tif')), 'files exist')
     #         ocrd_cli_wrap_processor(
     #             DummyProcessor,
-    #             ocrd_tool=DUMMY_TOOL,
     #             mets=ws.mets_target,
     #             parameter={"foo": 42},
     #             input_file_grp='IN-GRP',


### PR DESCRIPTION
Follow-up to premature #999: there are more places where we pass an empty `ocrd_tool` around that will never be used.

Reasoning (from [ocrd_tesserocr discussion](https://github.com/OCR-D/ocrd_tesserocr/pull/191#issuecomment-1470706375)):
> > That's despite ocrd==2.47.1. Where does the empty ocrd_tool come from???
> 
> Aha! It turns out that my https://github.com/OCR-D/core/pull/999 was premature: we also pass an unnecessary ocrd_tool in other places:
> 
> - run_processor kwarg: https://github.com/OCR-D/core/blob/cff8ddaefec72451795a5e0b4bdb7efc18223d99/ocrd/ocrd/processor/helpers.py#L38
> - run_processor calling get_processor: https://github.com/OCR-D/core/blob/cff8ddaefec72451795a5e0b4bdb7efc18223d99/ocrd/ocrd/processor/helpers.py#L91
> - get_processor kwarg: https://github.com/OCR-D/core/blob/cff8ddaefec72451795a5e0b4bdb7efc18223d99/ocrd/ocrd/processor/helpers.py#L306
> - get_processor calling constructor: https://github.com/OCR-D/core/blob/cff8ddaefec72451795a5e0b4bdb7efc18223d99/ocrd/ocrd/processor/helpers.py#L325
> 
> Now, the big story here is: none of these places is needed (or used) – neither currently, nor for https://github.com/OCR-D/core/pull/974 nor https://github.com/OCR-D/core/pull/884!
 
It's also clear now, why we never used this: you need **runtime information** (from the CLI) for this. Either we are already _on_ the CLI (Processor CLI decorator in all processor modules) or we have to make foreign CLI calls and parse the JSON response from the concrete Processor subclasses (which don't live in our venv, or we don't know the class name of, or are bashlib anyway).