### PR TITLE
ocrd_tool help: remove default docstrings (used by bashlib's ocrd__usage)

### DIFF
--- a/ocrd/ocrd/cli/ocrd_tool.py
+++ b/ocrd/ocrd/cli/ocrd_tool.py
@@ -88,16 +88,6 @@ def ocrd_tool_tool(ctx, tool_name):
 # ocrd ocrd-tool tool description
 # ----------------------------------------------------------------------
 
-class BashProcessor(Processor):
-    @property
-    def moduledir(self):
-        return os.path.dirname(ctx.filename)
-    # set docstrings to empty
-    # fixme: override the module-level docstring, too
-    __doc__ = None
-    def process(self):
-        return super()
-
 @ocrd_tool_tool.command('description', help="Describe tool")
 @pass_ocrd_tool
 def ocrd_tool_tool_description(ctx):
@@ -106,6 +96,10 @@ def ocrd_tool_tool_description(ctx):
 @ocrd_tool_tool.command('list-resources', help="List tool's file resources")
 @pass_ocrd_tool
 def ocrd_tool_tool_list_resources(ctx):
+    class BashProcessor(Processor):
+        @property
+        def moduledir(self):
+            return os.path.dirname(ctx.filename)
     BashProcessor(None, ocrd_tool=ctx.json['tools'][ctx.tool_name],
                   list_resources=True)
 
@@ -113,12 +107,22 @@ def ocrd_tool_tool_list_resources(ctx):
 @click.argument('res_name')
 @pass_ocrd_tool
 def ocrd_tool_tool_show_resource(ctx, res_name):
+    class BashProcessor(Processor):
+        @property
+        def moduledir(self):
+            return os.path.dirname(ctx.filename)
     BashProcessor(None, ocrd_tool=ctx.json['tools'][ctx.tool_name],
                   show_resource=res_name)
 
 @ocrd_tool_tool.command('help', help="Generate help for processors")
 @pass_ocrd_tool
 def ocrd_tool_tool_params_help(ctx):
+    class BashProcessor(Processor):
+        # set docstrings to empty
+        # fixme: override the module-level docstring, too
+        __doc__ = None
+        def process(self):
+            return super()
     BashProcessor(None, ocrd_tool=ctx.json['tools'][ctx.tool_name],
                   show_help=True)
 

--- a/ocrd/ocrd/cli/ocrd_tool.py
+++ b/ocrd/ocrd/cli/ocrd_tool.py
@@ -88,6 +88,16 @@ def ocrd_tool_tool(ctx, tool_name):
 # ocrd ocrd-tool tool description
 # ----------------------------------------------------------------------
 
+class BashProcessor(Processor):
+    @property
+    def moduledir(self):
+        return os.path.dirname(ctx.filename)
+    # set docstrings to empty
+    # fixme: override the module-level docstring, too
+    __doc__ = None
+    def process(self):
+        return super()
+
 @ocrd_tool_tool.command('description', help="Describe tool")
 @pass_ocrd_tool
 def ocrd_tool_tool_description(ctx):
@@ -96,10 +106,6 @@ def ocrd_tool_tool_description(ctx):
 @ocrd_tool_tool.command('list-resources', help="List tool's file resources")
 @pass_ocrd_tool
 def ocrd_tool_tool_list_resources(ctx):
-    class BashProcessor(Processor):
-        @property
-        def moduledir(self):
-            return os.path.dirname(ctx.filename)
     BashProcessor(None, ocrd_tool=ctx.json['tools'][ctx.tool_name],
                   list_resources=True)
 
@@ -107,18 +113,14 @@ def ocrd_tool_tool_list_resources(ctx):
 @click.argument('res_name')
 @pass_ocrd_tool
 def ocrd_tool_tool_show_resource(ctx, res_name):
-    class BashProcessor(Processor):
-        @property
-        def moduledir(self):
-            return os.path.dirname(ctx.filename)
     BashProcessor(None, ocrd_tool=ctx.json['tools'][ctx.tool_name],
                   show_resource=res_name)
 
 @ocrd_tool_tool.command('help', help="Generate help for processors")
 @pass_ocrd_tool
 def ocrd_tool_tool_params_help(ctx):
-    Processor(None, ocrd_tool=ctx.json['tools'][ctx.tool_name],
-              show_help=True)
+    BashProcessor(None, ocrd_tool=ctx.json['tools'][ctx.tool_name],
+                  show_help=True)
 
 # ----------------------------------------------------------------------
 # ocrd ocrd-tool tool categories


### PR DESCRIPTION
Note: I have not found a way to bypass the module-level docstring yet.

This will be ocrd.cli.ocrd_tool, for example for bashlib based ocrd-page-transform:
```
Usage: ocrd-page-transform [OPTIONS]

  apply arbitrary XSL transformation file for PAGE-XML

  > OCR-D CLI: ocrd-tool.json management

  > .. click:: ocrd.cli.ocrd_tool:ocrd_tool_cli     :prog: ocrd ocrd-
  > tool     :nested: full

...
```

Still, that's better than before, when it also wrote the `Processor` and `Processor.process` docstring:
```
  > Processor base class and helper functions. A processor is a tool
  > that implements the uniform OCR-D command-line interface for run-
  > time data processing. That is, it executes a single workflow step,
  > or a combination of workflow steps, on the workspace (represented by
  > local METS). It reads input files for all or requested physical
  > pages of the input fileGrp(s), and writes output files for them into
  > the output fileGrp(s). It may take  a number of optional or
  > mandatory parameters. Process the :py:attr:`workspace`  from the
  > given :py:attr:`input_file_grp` to the given
  > :py:attr:`output_file_grp` for the given :py:attr:`page_id` under
  > the given :py:attr:`parameter`.

  > (This contains the main functionality and needs to be overridden by
  > subclasses.)
```
