### PR TITLE
allow plain paths in page_from_file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PIP ?= pip
 LOG_LEVEL = INFO
 PYTHONIOENCODING=utf8
 TESTDIR = tests
+PYTEST_ARGS = --continue-on-collection-errors
 
 SPHINX_APIDOC = 
 
@@ -42,6 +43,7 @@ help:
 	@echo "    DOCKER_BASE_IMAGE  Docker base image. Default: '$(DOCKER_BASE_IMAGE)'."
 	@echo "    DOCKER_ARGS        Additional arguments to docker build. Default: '$(DOCKER_ARGS)'"
 	@echo "    PIP_INSTALL        pip install command. Default: $(PIP_INSTALL)"
+	@echo "    PYTEST_ARGS        arguments for pytest. Default: $(PYTEST_ARGS)"
 
 # END-EVAL
 
@@ -149,9 +151,9 @@ assets: repo/assets
 .PHONY: test
 # Run all unit tests
 test: assets
-	HOME=$(CURDIR)/ocrd_utils $(PYTHON) -m pytest --continue-on-collection-errors -k TestLogging $(TESTDIR)
-	HOME=$(CURDIR) $(PYTHON) -m pytest --continue-on-collection-errors -k TestLogging $(TESTDIR)
-	$(PYTHON) -m pytest --continue-on-collection-errors --durations=10 --ignore=$(TESTDIR)/test_logging.py --ignore-glob="$(TESTDIR)/**/*bench*.py" $(TESTDIR)
+	HOME=$(CURDIR)/ocrd_utils $(PYTHON) -m pytest $(PYTEST_ARGS) -k TestLogging $(TESTDIR)
+	HOME=$(CURDIR) $(PYTHON) -m pytest $(PYTEST_ARGS) -k TestLogging $(TESTDIR)
+	$(PYTHON) -m pytest $(PYTEST_ARGS) --durations=10 --ignore=$(TESTDIR)/test_logging.py --ignore-glob="$(TESTDIR)/**/*bench*.py" $(TESTDIR)
 
 benchmark:
 	$(PYTHON) -m pytest $(TESTDIR)/model/test_ocrd_mets_bench.py

--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -8,8 +8,6 @@ from tarfile import open as open_tarfile
 from urllib.parse import urlparse, unquote
 from zipfile import ZipFile
 
-from mimetypes import guess_type
-from filetype import guess
 import requests
 from gdown.parse_url import parse_url as gparse_url
 from gdown.download import get_url_from_gdrive_confirmation
@@ -22,7 +20,7 @@ yaml.constructor.SafeConstructor.yaml_constructors[u'tag:yaml.org,2002:timestamp
     yaml.constructor.SafeConstructor.yaml_constructors[u'tag:yaml.org,2002:str']
 
 from ocrd_validators import OcrdResourceListValidator
-from ocrd_utils import getLogger, directory_size, get_moduledir, EXT_TO_MIME, nth_url_segment
+from ocrd_utils import getLogger, directory_size, get_moduledir, EXT_TO_MIME, nth_url_segment, guess_media_type
 from ocrd_utils.os import get_processor_resource_types, list_all_resources, pushd_popd, get_ocrd_tool_json
 from .constants import RESOURCE_LIST_FILENAME, RESOURCE_USER_LIST_COMMENT
 
@@ -330,14 +328,7 @@ class OcrdResourceManager():
                     self._copy_impl(url, archive_fname, progress_cb)
                 Path('out').mkdir()
                 with pushd_popd('out'):
-                    suffixes = ''.join(Path(nth_url_segment(url)).suffixes)
-                    mimetype = guess(f'../{archive_fname}')
-                    if mimetype is None:
-                        mimetype = guess_type(f'../{archive_fname}')[0]
-                    else:
-                        mimetype = mimetype.mime
-                    if mimetype is None:
-                        mimetype = EXT_TO_MIME.get(suffixes, 'application/octet-stream')
+                    mimetype = guess_media_type(f'../{archive_fname}', fallback='application/octet-stream')
                     log.info("Extracting %s archive to %s/out" % (mimetype, tempdir))
                     if mimetype == 'application/zip':
                         with ZipFile(f'../{archive_fname}', 'r') as zipf:

--- a/ocrd/requirements.txt
+++ b/ocrd/requirements.txt
@@ -10,5 +10,4 @@ pyyaml
 Deprecated == 1.2.0
 memory-profiler >= 0.58.0
 sparklines >= 0.4.2
-filetype
 gdown

--- a/ocrd_modelfactory/ocrd_modelfactory/__init__.py
+++ b/ocrd_modelfactory/ocrd_modelfactory/__init__.py
@@ -8,11 +8,9 @@ from pathlib import Path
 from yaml import safe_load, safe_dump
 
 from PIL import Image
-from mimetypes import guess_type
-from filetype import guess
 from lxml import etree as ET
 
-from ocrd_utils import VERSION, MIMETYPE_PAGE, EXT_TO_MIME
+from ocrd_utils import VERSION, MIMETYPE_PAGE, guess_media_type
 from ocrd_models import OcrdExif, OcrdFile
 from ocrd_models.ocrd_page import (
     PcGtsType, PageType, MetadataType,
@@ -94,17 +92,7 @@ def page_from_file(input_file, with_tree=False):
             and reverse mapping, too (cf. :py:func:`ocrd_models.ocrd_page.parseEtree`)
     """
     if not isinstance(input_file, OcrdFile):
-        mimetype = guess(input_file)
-        if mimetype is None:
-            mimetype = guess_type(input_file)[0]
-        else:
-            mimetype = mimetype.mime
-        if mimetype is None:
-            mimetype = EXT_TO_MIME.get(Path(input_file).suffix, None)
-        if mimetype is None:
-            raise ValueError("Could not determine MIME type of input_file must")
-        if mimetype == 'application/xml':
-            mimetype = MIMETYPE_PAGE
+        mimetype = guess_media_type(input_file, application_xml=MIMETYPE_PAGE)
         input_file = OcrdFile(ET.Element("dummy"),
                               local_filename=input_file,
                               mimetype=mimetype)

--- a/ocrd_modelfactory/ocrd_modelfactory/__init__.py
+++ b/ocrd_modelfactory/ocrd_modelfactory/__init__.py
@@ -8,9 +8,12 @@ from pathlib import Path
 from yaml import safe_load, safe_dump
 
 from PIL import Image
+from mimetypes import guess_type
+from filetype import guess
+from lxml import etree as ET
 
-from ocrd_utils import VERSION, MIMETYPE_PAGE
-from ocrd_models import OcrdExif
+from ocrd_utils import VERSION, MIMETYPE_PAGE, EXT_TO_MIME
+from ocrd_models import OcrdExif, OcrdFile
 from ocrd_models.ocrd_page import (
     PcGtsType, PageType, MetadataType,
     parse, parseEtree
@@ -79,15 +82,32 @@ def page_from_image(input_file, with_tree=False):
 
 def page_from_file(input_file, with_tree=False):
     """
-    Create a new PAGE-XML from a METS file representing a PAGE-XML or an image.
+    Create :py:class:`~ocrd_models.ocrd_page.OcrdPage`
+    from an :py:class:`~ocrd_models.ocrd_file.OcrdFile` or a file path
+    representing either a PAGE-XML or an image (to generate a PAGE-XML for).
 
     Arguments:
-        input_file (:py:class:`~ocrd_models.ocrd_file.OcrdFile`): file to open \
+        input_file (:py:class:`~ocrd_models.ocrd_file.OcrdFile` or `str`): file to open \
             and produce a PAGE DOM for
     Keyword arguments:
         with_tree (boolean): whether to return XML node tree, element-node mapping \
             and reverse mapping, too (cf. :py:func:`ocrd_models.ocrd_page.parseEtree`)
     """
+    if not isinstance(input_file, OcrdFile):
+        mimetype = guess(input_file)
+        if mimetype is None:
+            mimetype = guess_type(input_file)[0]
+        else:
+            mimetype = mimetype.mime
+        if mimetype is None:
+            mimetype = EXT_TO_MIME.get(Path(input_file).suffix, None)
+        if mimetype is None:
+            raise ValueError("Could not determine MIME type of input_file must")
+        if mimetype == 'application/xml':
+            mimetype = MIMETYPE_PAGE
+        input_file = OcrdFile(ET.Element("dummy"),
+                              local_filename=input_file,
+                              mimetype=mimetype)
     if not input_file.local_filename:
         raise ValueError("input_file must have 'local_filename' property")
     if not Path(input_file.local_filename).exists():

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -171,6 +171,7 @@ from .os import (
     get_processor_resource_types,
     get_ocrd_tool_json,
     get_moduledir,
+    guess_media_type,
     list_all_resources,
     is_file_in_directory,
     list_resource_candidates,

--- a/ocrd_utils/requirements.txt
+++ b/ocrd_utils/requirements.txt
@@ -6,3 +6,4 @@ atomicwrites >= 1.3.0
 importlib_metadata;python_version<'3.8'
 importlib_resources;python_version<'3.9'
 frozendict>=2.3.4
+filetype

--- a/tests/utils/test_os.py
+++ b/tests/utils/test_os.py
@@ -1,11 +1,13 @@
 from tempfile import mkdtemp
 from tests.base import TestCase, main, assets
 from shutil import rmtree
+from pathlib import Path
 from os import environ as ENV, getcwd
 from os.path import expanduser, join
 
 from ocrd_utils.os import (
     list_resource_candidates,
+    guess_media_type,
 )
 
 class TestOsUtils(TestCase):
@@ -33,6 +35,15 @@ class TestOsUtils(TestCase):
             '$HOME/.local/share/ocrd-resources/ocrd-dummy',
             '/usr/local/share/ocrd-resources/ocrd-dummy',
         ]])
+
+    def test_guess_media_type(self):
+        testdata = Path(__file__).parent / '../data'
+        assert guess_media_type(__file__) == 'text/x-python'
+        assert guess_media_type(testdata / 'filename.tar.gz') == 'application/gzip'
+        assert guess_media_type(testdata / 'filename.tar.xz') == 'application/x-xz'
+        assert guess_media_type(testdata / 'filename.zip') == 'application/zip'
+        assert guess_media_type(testdata / 'mets-with-metsDocumentID.xml') == 'application/xml'
+        assert guess_media_type(testdata / 'mets-with-metsDocumentID.xml', application_xml='text/x-mets') == 'text/x-mets'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I repeatedly find myself in need of this.

BTW, there still is a problem with our tests. I keep getting [`I/O operation on closed file`](https://github.com/pytest-dev/pytest/issues/14) in test_logging.py when running in local environments. More explanations [here](https://github.com/pytest-dev/pytest/issues/5743). Also explains our previous problems with [click.CliRunner](https://github.com/pytest-dev/pytest/issues/3344) I believe. I don't know how to actually fix this, but running with `-s` helps as a workaround.

Let's see how the CI reacts.