### PR TITLE
Improve packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,8 @@ env2/
 
 # vim swp
 *.swp
+# emacs bkup
+*~
 
 ocrd.egg-info
 .pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ SPHINX_APIDOC =
 
 BUILD_ORDER = ocrd_utils ocrd_models ocrd_modelfactory ocrd_validators ocrd_network ocrd
 
-FIND_VERSION = grep version= ocrd_utils/setup.py|grep -Po "([0-9ab]+\.?)+"
+PEP_440_PATTERN := '([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?'
+OCRD_VERSION != fgrep version= ocrd_utils/setup.py | grep -Po $(PEP_440_PATTERN)
 
 # BEGIN-EVAL makefile-parser --make-help Makefile
 
@@ -71,7 +72,8 @@ install:
 	$(PIP) install -U pip wheel setuptools fastentrypoints
 	@# speedup for end-of-life builds
 	if $(PYTHON) -V | fgrep -e 3.5 -e 3.6; then $(PIP) install --prefer-binary opencv-python-headless numpy; fi
-	for mod in $(BUILD_ORDER);do (cd $$mod ; $(PIP_INSTALL) .);done
+#	$(PIP_INSTALL) $(BUILD_ORDER:%=./%/dist/ocrd$*(OCRD_VERSION)*.whl)
+	$(foreach MODULE,$(BUILD_ORDER),$(PIP_INSTALL) ./$(MODULE) &&) echo done
 	@# workaround for shapely#1598
 	$(PIP) install --no-binary shapely --force-reinstall shapely
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ TESTDIR = tests
 SPHINX_APIDOC = 
 
 BUILD_ORDER = ocrd_utils ocrd_models ocrd_modelfactory ocrd_validators ocrd_network ocrd
+reverse = $(if $(wordlist 2,2,$(1)),$(call reverse,$(wordlist 2,$(words $(1)),$(1))) $(firstword $(1)),$(1))
 
 PEP_440_PATTERN := '([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?'
 OCRD_VERSION != fgrep version= ocrd_utils/setup.py | grep -Po $(PEP_440_PATTERN)
@@ -83,7 +84,7 @@ install-dev: uninstall
 
 # Uninstall the tool
 uninstall:
-	for mod in $(BUILD_ORDER);do $(PIP) uninstall -y $$mod;done
+	$(PIP) uninstall -y $(call reverse,$(BUILD_ORDER))
 
 # Regenerate python code from PAGE XSD
 generate-page: GDS_PAGE = ocrd_models/ocrd_models/ocrd_page_generateds.py

--- a/Makefile
+++ b/Makefile
@@ -254,5 +254,6 @@ cuda-ldconfig: /etc/ld.so.conf.d/cuda.conf
 
 # Build wheels and source dist and twine upload them
 pypi: uninstall install
-	for mod in $(BUILD_ORDER);do (cd $$mod; $(PYTHON) setup.py sdist bdist_wheel);done
-	version=`$(FIND_VERSION)`; twine upload ocrd*/dist/ocrd*$$version*{tar.gz,whl}
+	$(PIP) install build
+	$(foreach MODULE,$(BUILD_ORDER),$(PYTHON) -m build -n ./$(MODULE) &&) echo done
+	twine upload ocrd*/dist/ocrd*$(OCRD_VERSION)*{tar.gz,whl}

--- a/ocrd/MANIFEST.in
+++ b/ocrd/MANIFEST.in
@@ -1,1 +1,3 @@
 recursive-include ocrd *.json *.yml *.yaml *.bash *.xml
+include requirements.txt
+include README.md

--- a/ocrd_modelfactory/MANIFEST.in
+++ b/ocrd_modelfactory/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include README.md

--- a/ocrd_models/MANIFEST.in
+++ b/ocrd_models/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include README.md

--- a/ocrd_network/MANIFEST.in
+++ b/ocrd_network/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include README.md

--- a/ocrd_utils/MANIFEST.in
+++ b/ocrd_utils/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include ocrd_logging.conf
+include requirements.txt

--- a/ocrd_validators/MANIFEST.in
+++ b/ocrd_validators/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include README.md


### PR DESCRIPTION
Since [python setup.py sdist bdist_wheel is deprecated](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html), this uses `build` instead. Also, it turns out, we forgot to add our `requirements.txt` to the manifest (and `ocrd.processor.builtin.dummy` as a package) for correct packaging. Further improves the makefile.

Note: in the long run we should
- switch to pyproject.toml, with setuptools as build backend, and setup.cfg
- move requirements.txt to the latter's `install_requires` key, and either abandon `requirements.txt` or keep it for dev purposes (with a workable state of `pip freeze`)
- tie versioning to git tags (so there will be no need for manual synchronization anymore, and not interdependencies at build time) via [setuptools_scm recipe](https://www.moritzkoerber.com/posts/versioning-with-setuptools_scm/) – see [this example](https://github.com/slub/textract2page/blob/master/pyproject.toml)