### PR TITLE
Use grep with extended instead of Perl regexp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SPHINX_APIDOC =
 
 BUILD_ORDER = ocrd_utils ocrd_models ocrd_modelfactory ocrd_validators ocrd_network ocrd
 
-FIND_VERSION = grep version= ocrd_utils/setup.py|grep -Po "([0-9ab]+\.?)+"
+FIND_VERSION = grep version= ocrd_utils/setup.py|grep -Eo "([0-9ab]+\.?)+"
 
 # BEGIN-EVAL makefile-parser --make-help Makefile
 


### PR DESCRIPTION
The command works with both variants.
-E is also supported on macOS while -P is not.