### PR TITLE
resmgr download: raise if http >= 400

### DIFF
--- a/ocrd/ocrd/resource_manager.py
+++ b/ocrd/ocrd/resource_manager.py
@@ -250,6 +250,7 @@ class OcrdResourceManager():
                 except RuntimeError as e:
                     log.warning("Cannot unwrap Google Drive URL: ", e)
             with requests.get(url, stream=True) as r:
+                r.raise_for_status()
                 for data in r.iter_content(chunk_size=4096):
                     if progress_cb:
                         progress_cb(len(data))


### PR DESCRIPTION
This improves on errors caused by wrong URLs or misbehaving servers.

(In my case, a URL which previously worked [now yields HTTP 409](https://github.com/bertsky/ocrd_detectron2/actions/runs/5377364734/jobs/9755736373), but resmgr still attempted to unzip the error page.)