### PR TITLE
ocrd-tool version: print exact tool version

### DIFF
--- a/ocrd/ocrd/cli/ocrd_tool.py
+++ b/ocrd/ocrd/cli/ocrd_tool.py
@@ -48,7 +48,7 @@ def ocrd_tool_cli(ctx, json_file):
 @ocrd_tool_cli.command('version', help='Version of ocrd-tool.json')
 @pass_ocrd_tool
 def ocrd_tool_version(ctx):
-    print('Version "%s", ocrd/core "%s"' % (ctx.json['version'], OCRD_VERSION))
+    print(ctx.json['version'])
 
 # ----------------------------------------------------------------------
 # ocrd ocrd-tool validate


### PR DESCRIPTION
changes the implementation of `ocrd ocrd-tool PATH version` to print something like …
```
0.1.2
```
…instead of…
```
Version "0.1.2", ocrd/core "2.45.0"
```
…(which cannot easily be parsed futher, esp. in bashlib, and is therefore not in accordance with non-bashlib processors).