### PR TITLE
deps-conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV PIP=pip
 
+ENV MAMBA_EXE=/usr/local/bin/conda
+ENV MAMBA_ROOT_PREFIX=/conda
+ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
+ENV CONDA_EXE=$MAMBA_EXE
+ENV CONDA_PREFIX=$MAMBA_ROOT_PREFIX
+ENV CONDA_SHLVL='1'
+
 WORKDIR /build-ocrd
 COPY ocrd ./ocrd
 COPY ocrd_modelfactory ./ocrd_modelfactory/
@@ -20,11 +27,8 @@ COPY Makefile .
 COPY README.md .
 COPY LICENSE .
 RUN echo 'APT::Install-Recommends "0"; APT::Install-Suggests "0";' >/etc/apt/apt.conf.d/ocr-d.conf
-RUN apt-get update && apt-get -y install software-properties-common \
-    && apt-get update && apt-get -y install \
+RUN apt-get update && apt-get -y install \
         ca-certificates \
-        python3-dev \
-        python3-venv \
         gcc \
         make \
         wget \
@@ -32,7 +36,8 @@ RUN apt-get update && apt-get -y install software-properties-common \
         curl \
         sudo \
         git \
-    && make deps-ubuntu \
+    && make get-conda \
+    && make deps-conda \
     && python3 -m venv /usr/local \
     && hash -r \
     && pip install --upgrade pip setuptools wheel \
@@ -42,4 +47,4 @@ RUN apt-get update && apt-get -y install software-properties-common \
 
 WORKDIR /data
 
-CMD ["/usr/local/bin/ocrd", "--help"]
+CMD ["/conda/bin/ocrd", "--help"]

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,13 +1,6 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-ENV MAMBA_EXE=/usr/local/bin/conda
-ENV MAMBA_ROOT_PREFIX=/conda
-ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
-ENV CONDA_EXE=$MAMBA_EXE
-ENV CONDA_PREFIX=$MAMBA_ROOT_PREFIX
-ENV CONDA_SHLVL='1'
-
 WORKDIR /build
 
 COPY Makefile .
@@ -18,5 +11,5 @@ WORKDIR /data
 
 RUN rm -fr /build
 
-CMD ["/usr/local/bin/ocrd", "--help"]
+CMD ["/conda/bin/ocrd", "--help"]
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ help:
 	@echo ""
 	@echo "  Targets"
 	@echo ""
+	@echo "    get-conda      Install Conda distribution"
+	@echo "    deps-conda     Dependencies for deployment via Conda"
 	@echo "    deps-cuda      Dependencies for deployment with GPU support via Conda"
 	@echo "    deps-ubuntu    Dependencies for deployment in an Ubuntu/Debian Linux"
 	@echo "    deps-test      Install test python deps via pip"
@@ -52,16 +54,32 @@ help:
 # pip install command. Default: $(PIP_INSTALL)
 PIP_INSTALL ?= $(PIP) install
 
-deps-cuda: CONDA_EXE ?= /usr/local/bin/conda
-deps-cuda: export CONDA_PREFIX ?= /conda
-deps-cuda: PYTHON_PREFIX != $(PYTHON) -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'
-deps-cuda:
-	curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+.PHONY: get-conda deps-cuda deps-conda deps-ubuntu
+
+ifeq ($(shell command -v conda),)
+# no prior Conda distribution, so install Mamba now
+# (see https://mamba.readthedocs.io/en/latest/installation.html)
+get-conda: CONDA_EXE ?= /usr/local/bin/conda
+get-conda: export CONDA_PREFIX ?= /conda
+# first part of recipe: see micro.mamba.pm/install.sh
+get-conda: OS != uname
+get-conda: PLATFORM = $(subst Darwin,osx,$(subst Linux,linux,$(OS)))
+get-conda: ARCH != uname -m
+get-conda: MACHINE = $(or $(filter aarch64 arm64 ppc64le, $(ARCH)), 64)
+get-conda: URL = https://micro.mamba.pm/api/micromamba/$(PLATFORM)-$(MACHINE)/latest
+get-conda:
+	curl -Ls $(URL) | tar -xvj bin/micromamba
 	mv bin/micromamba $(CONDA_EXE)
 # Install Conda system-wide (for interactive / login shells)
 	echo 'export MAMBA_EXE=$(CONDA_EXE) MAMBA_ROOT_PREFIX=$(CONDA_PREFIX) CONDA_PREFIX=$(CONDA_PREFIX) PATH=$(CONDA_PREFIX)/bin:$$PATH' >> /etc/profile.d/98-conda.sh
 	mkdir -p $(CONDA_PREFIX)/lib $(CONDA_PREFIX)/include
 	echo $(CONDA_PREFIX)/lib >> /etc/ld.so.conf.d/conda.conf
+else
+get-conda: ;
+endif
+
+deps-cuda: PYTHON_PREFIX != $(PYTHON) -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'
+deps-cuda: get-conda
 # Get CUDA toolkit, including compiler and libraries with dev,
 # however, the Nvidia channels do not provide (recent) cudnn (needed for Torch, TF etc):
 #MAMBA_ROOT_PREFIX=$(CONDA_PREFIX) \
@@ -70,7 +88,6 @@ deps-cuda:
 # The conda-forge channel has cudnn and cudatoolkit but no cudatoolkit-dev anymore (and we need both!),
 # so let's combine nvidia and conda-forge (will be same lib versions, no waste of space),
 # but omitting cuda-cudart-dev and cuda-libraries-dev (as these will be pulled by pip for torch anyway):
-	MAMBA_ROOT_PREFIX=$(CONDA_PREFIX) \
 	conda install -c nvidia/label/cuda-11.8.0 \
 	                 cuda-nvcc \
 	                 cuda-cccl \
@@ -106,9 +123,15 @@ deps-cuda:
 	 && ldconfig
 # gputil/nvidia-smi would be nice, too – but that drags in Python as a conda dependency...
 
-# Dependencies for deployment in an ubuntu/debian linux
+# Dependencies for deployment via Conda
+deps-conda: get-conda
+	conda install -c conda-forge python==3.8.* imagemagick geos pkgconfig
+
+# Dependencies for deployment in an Ubuntu/Debian Linux
 deps-ubuntu:
 	apt-get install -y python3 imagemagick libgeos-dev
+
+.PHONY: deps-test install install-dev uninstall
 
 # Install test python deps via pip
 deps-test:


### PR DESCRIPTION
This starts Conda with `deps-conda` as a replacement for Apt with `deps-ubuntu` to install system dependencies.

System dependencies should be encapsulated better than via fixed Linux distributions in OCR-D. [Long ago](https://github.com/OCR-D/ocrd_all/issues/56) I expressed my conviction that we can find some existing universal mechanism for porting. IMHO Conda fits that description quite well.

So the idea is to allow OCR-D modules to express their system requirements in a `deps-conda` rule, which will run `conda install ...`. Of course, modules could do even more and [provide a full conda build](https://docs.conda.io/projects/conda-build/en/stable/concepts/recipe.html) (i.e. `build.sh` and `meta.yaml`) and have the Makefile simply delegate to that.

For example, the `ocrd/tesserocr` Dockerfile could be as simple as
```Dockerfile
FROM ocrd/core
COPY Makefile .
RUN make deps-conda
RUN pip install .
```
where that would simply be defined as
```Makefile
deps-conda:
	conda install -c conda-forge tesseract leptonica
```
(which would give us an up to date libtesseract against which `pip install tesserocr` will compile).

To make that work, this PR lays the foundation in `ocrd/core`:
- install Conda, if not already present
- install system dependencies for ocrd, ocrd_utils etc. via its own `deps-conda` rule

Techically, we could separate the second commit (i.e. switching from `apt` to `conda` in the Dockerfiles) and save it for another day (when we have the courage).