### PR TITLE
download: add retry and timeout kwargs, controlled via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ Some parts of the software are configured via environement variables:
   * `PSS`: Enable proportionate memory profiling
 * `OCRD_PROFILE_FILE`: If set, then the CPU profile is written to this file for later peruse with a analysis tools like [snakeviz](https://jiffyclub.github.io/snakeviz/)
 
+* `PATH`: Search path for processor executables (affects `ocrd process` and `ocrd resmgr`).
+* `HOME`: Directory to look for `ocrd_logging.conf`, fallback for unset XDG variables (see below).
+
+* `XDG_CONFIG_HOME`: Directory to look for `./ocrd/resources.yml` (i.e. `ocrd resmgr` user database) – defaults to `$HOME/.config`.
+* `XDG_DATA_HOME`: Directory to look for `./ocrd-resources/*` (i.e. `ocrd resmgr` data location) – defaults to `$HOME/.local/share`.
+
+* `OCRD_DOWNLOAD_RETRIES`: Number of times to retry failed attempts for downloads of workspace files.
+* `OCRD_DOWNLOAD_TIMEOUT`: Timeout in seconds for connecting or reading (comma-separated) when downloading.
+
+* `OCRD_METS_CACHING`: Whether to enable in-memory storage of OcrdMets data structures for speedup during processing or workspace operations.
+
+* `OCRD_MAX_PROCESSOR_CACHE`: Maximum number of processor instances (for each set of parameters) to be kept in memory (including loaded models) for processing workers or processor servers.
+
+* `OCRD_NETWORK_SERVER_ADDR_PROCESSING`: Default address of Processing Server to connect to (for `ocrd network client processing`).
+* `OCRD_NETWORK_SERVER_ADDR_WORKFLOW`: Default address of Workflow Server to connect to (for `ocrd network client workflow`).
+* `OCRD_NETWORK_SERVER_ADDR_WORKSPACE`: Default address of Workspace Server to connect to (for `ocrd network client workspace`).
+
+
 ## Packages
 
 ### ocrd_utils

--- a/ocrd/ocrd/cli/__init__.py
+++ b/ocrd/ocrd/cli/__init__.py
@@ -64,13 +64,13 @@ Variables:
 \b
   OCRD_PROFILE
     Whether to enable gathering runtime statistics
-    on the `ocrd.profile` logger:
-    - non-empty: yields CPU and wall-time,
+    on the `ocrd.profile` logger (comma-separated):
+    - `CPU`: yields CPU and wall-time,
     - `RSS`: also yields peak memory (resident set size)
     - `PSS`: also yields peak memory (proportional set size)
   OCRD_PROFILE_FILE
-    When profiling is enabled, file to write to
-    (instead of standard log handler).
+    When profiling is enabled, data file to write to
+    (for external analysis tools like snakeviz).
 """
 
 def command_with_replaced_help(*replacements):

--- a/ocrd/ocrd/cli/__init__.py
+++ b/ocrd/ocrd/cli/__init__.py
@@ -10,6 +10,69 @@ import click
 
 __all__ = ['cli']
 
+_epilog = """
+
+\b            
+Variables:
+  PATH    Search path for processor executables
+          (affects `ocrd process` and `ocrd resmgr`)
+  HOME    Directory to look for `ocrd_logging.conf`,
+          fallback for unset XDG variables.
+
+\b
+  XDG_CONFIG_HOME
+    Directory to look for `./ocrd/resources.yml`
+    (i.e. `ocrd resmgr` user database) - defaults to
+    `$HOME/.config`.
+  XDG_DATA_HOME
+    Directory to look for `./ocrd-resources/*`
+    (i.e. `ocrd resmgr` data location) - defaults to
+    `$HOME/.local/share`.
+
+\b
+  OCRD_DOWNLOAD_RETRIES
+    Number of times to retry failed attempts
+    for downloads of workspace files.
+  OCRD_DOWNLOAD_TIMEOUT
+    Timeout in seconds for connecting or reading
+    (comma-separated) when downloading.
+
+\b
+  OCRD_METS_CACHING
+    Whether to enable in-memory storage of OcrdMets
+    data structures for speedup during processing or
+    workspace operations.
+
+\b
+  OCRD_MAX_PROCESSOR_CACHE
+    Maximum number of processor instances
+    (for each set of parameters) to be kept
+    in memory (including loaded models) for
+    processing workers or processor servers.
+
+\b
+  OCRD_NETWORK_SERVER_ADDR_PROCESSING
+    Default address of Processing Server to connect to
+    (for `ocrd network client processing`).
+  OCRD_NETWORK_SERVER_ADDR_WORKFLOW
+    Default address of Workflow Server to connect to
+    (for `ocrd network client workflow`).
+  OCRD_NETWORK_SERVER_ADDR_WORKSPACE
+    Default address of Workspace Server to connect to
+    (for `ocrd network client workspace`).
+
+\b
+  OCRD_PROFILE
+    Whether to enable gathering runtime statistics
+    on the `ocrd.profile` logger:
+    - non-empty: yields CPU and wall-time,
+    - `RSS`: also yields peak memory (resident set size)
+    - `PSS`: also yields peak memory (proportional set size)
+  OCRD_PROFILE_FILE
+    When profiling is enabled, file to write to
+    (instead of standard log handler).
+"""
+
 def command_with_replaced_help(*replacements):
 
     class CommandWithReplacedHelp(click.Command):
@@ -34,7 +97,7 @@ from .log import log_cli
 from .network import network_cli
 
 
-@click.group()
+@click.group(epilog=_epilog)
 @click.version_option()
 @ocrd_loglevel
 def cli(**kwargs): # pylint: disable=unused-argument

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -48,7 +48,7 @@ def _get_kant_data(key):
             return (_file.read(), mime)
 
 
-def request_behavior(*args):
+def request_behavior(*args, **kwargs):
     resp = mock.Mock()
     resp.status_code = 200
     resp.headers = {}

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import (
     Path
 )
+from requests import Session
 from unittest import (
     mock
 )
@@ -68,7 +69,7 @@ def test_workspace_from_url_bad():
     assert "Must pass 'mets_url'" in str(exc)
 
 
-@mock.patch("requests.get")
+@mock.object(Session, "get")
 def test_workspace_from_url_kant(mock_request, tmp_path):
 
     # arrange
@@ -88,7 +89,7 @@ def test_workspace_from_url_kant(mock_request, tmp_path):
     assert mock_request.call_count == 1
 
 
-@mock.patch("requests.get")
+@mock.object(Session, "get")
 def test_workspace_from_url_kant_with_resources(mock_request, tmp_path):
 
     # arrange
@@ -113,7 +114,7 @@ def test_workspace_from_url_kant_with_resources(mock_request, tmp_path):
     assert mock_request.call_count == 7
 
 
-@mock.patch("requests.get")
+@mock.object(Session, "get")
 def test_workspace_from_url_kant_with_resources_existing_local(mock_request, tmp_path):
 
     # arrange
@@ -133,7 +134,7 @@ def test_workspace_from_url_kant_with_resources_existing_local(mock_request, tmp
     assert mock_request.call_count == 0
 
 
-@mock.patch("requests.get")
+@mock.object(Session, "get")
 def test_workspace_from_url_404(mock_request):
     """Expected behavior when try create workspace from invalid online target
     """

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -7,8 +7,9 @@ from pathlib import (
     Path
 )
 from requests import Session
-from unittest import (
-    mock
+from unittest.mock import (
+    patch,
+    Mock
 )
 from PIL import (
     Image
@@ -50,7 +51,7 @@ def _get_kant_data(key):
 
 
 def request_behavior(*args, **kwargs):
-    resp = mock.Mock()
+    resp = Mock()
     resp.status_code = 200
     resp.headers = {}
     the_key = args[0].split('/')[-1]
@@ -69,7 +70,7 @@ def test_workspace_from_url_bad():
     assert "Must pass 'mets_url'" in str(exc)
 
 
-@mock.object(Session, "get")
+@patch.object(Session, "get")
 def test_workspace_from_url_kant(mock_request, tmp_path):
 
     # arrange
@@ -89,7 +90,7 @@ def test_workspace_from_url_kant(mock_request, tmp_path):
     assert mock_request.call_count == 1
 
 
-@mock.object(Session, "get")
+@patch.object(Session, "get")
 def test_workspace_from_url_kant_with_resources(mock_request, tmp_path):
 
     # arrange
@@ -114,7 +115,7 @@ def test_workspace_from_url_kant_with_resources(mock_request, tmp_path):
     assert mock_request.call_count == 7
 
 
-@mock.object(Session, "get")
+@patch.object(Session, "get")
 def test_workspace_from_url_kant_with_resources_existing_local(mock_request, tmp_path):
 
     # arrange
@@ -134,7 +135,7 @@ def test_workspace_from_url_kant_with_resources_existing_local(mock_request, tmp
     assert mock_request.call_count == 0
 
 
-@mock.object(Session, "get")
+@patch.object(Session, "get")
 def test_workspace_from_url_404(mock_request):
     """Expected behavior when try create workspace from invalid online target
     """

--- a/tests/test_resolver_oai.py
+++ b/tests/test_resolver_oai.py
@@ -100,7 +100,7 @@ def test_handle_response_for_invalid_content(mock_get, response_dir):
     resolver.download_to_directory(response_dir, url)
 
     # assert
-    mock_get.assert_called_once_with(url)
+    mock_get.assert_called_once_with(url, timeout=None)
     log_output = capt.getvalue()
     assert 'WARNING ocrd_models.utils.handle_oai_response' in log_output
 

--- a/tests/test_resolver_oai.py
+++ b/tests/test_resolver_oai.py
@@ -72,7 +72,7 @@ def test_handle_common_oai_response(mock_get, response_dir, oai_response_content
     result = resolver.download_to_directory(response_dir, url)
 
     # assert
-    mock_get.assert_called_once_with(url)
+    mock_get.assert_called_once_with(url, timeout=None)
     assert result == 'oai'
 
 

--- a/tests/test_resolver_oai.py
+++ b/tests/test_resolver_oai.py
@@ -4,6 +4,7 @@ from shutil import copy
 from logging import StreamHandler, Formatter
 from os.path import join, dirname
 
+from requests import Session
 from tests.base import main, FIFOIO
 
 from ocrd.resolver import Resolver
@@ -55,7 +56,7 @@ def test_handle_response_mets(plain_xml_response_content):
     assert result.startswith(expected_start)
 
 
-@mock.patch("requests.get")
+@mock.object(Session, "get")
 def test_handle_common_oai_response(mock_get, response_dir, oai_response_content):
     """Base use case with valid OAI Response data"""
     initLogging()
@@ -76,7 +77,7 @@ def test_handle_common_oai_response(mock_get, response_dir, oai_response_content
     assert result == 'oai'
 
 
-@mock.patch("requests.get")
+@mock.object(Session, "get")
 def test_handle_response_for_invalid_content(mock_get, response_dir):
     """If invalid content is returned, store warning log entry"""
 

--- a/tests/test_resolver_oai.py
+++ b/tests/test_resolver_oai.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest.mock import patch
 from pytest import fixture
 from shutil import copy
 from logging import StreamHandler, Formatter
@@ -56,7 +56,7 @@ def test_handle_response_mets(plain_xml_response_content):
     assert result.startswith(expected_start)
 
 
-@mock.object(Session, "get")
+@patch.object(Session, "get")
 def test_handle_common_oai_response(mock_get, response_dir, oai_response_content):
     """Base use case with valid OAI Response data"""
     initLogging()
@@ -77,7 +77,7 @@ def test_handle_common_oai_response(mock_get, response_dir, oai_response_content
     assert result == 'oai'
 
 
-@mock.object(Session, "get")
+@patch.object(Session, "get")
 def test_handle_response_for_invalid_content(mock_get, response_dir):
     """If invalid content is returned, store warning log entry"""
 


### PR DESCRIPTION
Fixes #973 (retry facility) and also implements a timeout facility, and provides those to any download use-case besides CLI `ocrd workspace find --download` (e.g. processor's typical `Workspace.download_file(input_file)`, or `WorkspaceValidator(... download=True ...)`.

Since there are so many places which could ultimately trigger `Resolver.download_to_directory`, and we don't want to drag along the new kwargs `retries` and `timeout` everywhere, I chose to control them via **environment variables**:
- `OCRD_DOWNLOAD_RETRIES` → number of attempts
- `OCRD_DOWNLOAD_TIMEOUT` → a single float or a comma-separated tuple of floats (connection timeout, read timeout)

The retry facility itself only triggers on certain HTTP statuses (i.e. opt-in), which is debatable (e.g. I have seen proposals opting out of everything but 200 and 404).