### PR TITLE
ocrd network extension

### DIFF
--- a/ocrd_network/ocrd_network/cli/processing_worker.py
+++ b/ocrd_network/ocrd_network/cli/processing_worker.py
@@ -25,13 +25,14 @@ from .. import (
               help='Create the rabbitmq-queue for the worker. Usually the processing server starts'
               'the workers and creates the queues. This is to make external addition of workers for'
               'new processors possible')
-@click.option('--retry-attempts',
+@click.option('--queue-connect-attempts',
               type=int,
               default=1,
-              help='Retry creating the connection. There is two seconds wait between attempts. '
-              'Helpfull if the server needs time to be fully started')
+              help='Number of attempts to establish the connection to rabbitmq for creating the '
+              'queue. There is two seconds wait between attempts. Helpfull if the server needs '
+              'time to be fully started')
 def processing_worker_cli(processor_name: str, queue: str, database: str, create_queue: bool,
-                          retry_attempts=1):
+                          queue_connect_attempts: int):
     """
     Start Processing Worker
     (a specific ocr-d processor consuming tasks from RabbitMQ queue)
@@ -55,7 +56,10 @@ def processing_worker_cli(processor_name: str, queue: str, database: str, create
             processor_class=None,  # For readability purposes assigned here
         )
         if create_queue:
-            processing_worker.create_queue(connection_attempts=retry_attempts, retry_delay=2)
+            processing_worker.create_queue(
+                connection_attempts=queue_connect_attempts,
+                retry_delay=2
+            )
         # The RMQConsumer is initialized and a connection to the RabbitMQ is performed
         processing_worker.connect_consumer()
         # Start consuming from the queue with name `processor_name`

--- a/ocrd_network/ocrd_network/cli/processing_worker.py
+++ b/ocrd_network/ocrd_network/cli/processing_worker.py
@@ -25,7 +25,13 @@ from .. import (
               help='Create the rabbitmq-queue for the worker. Usually the processing server starts'
               'the workers and creates the queues. This is to make external addition of workers for'
               'new processors possible')
-def processing_worker_cli(processor_name: str, queue: str, database: str, create_queue: bool):
+@click.option('--retry-attempts',
+              type=int,
+              default=1,
+              help='Retry creating the connection. There is two seconds wait between attempts. '
+              'Helpfull if the server needs time to be fully started')
+def processing_worker_cli(processor_name: str, queue: str, database: str, create_queue: bool,
+                          retry_attempts=1):
     """
     Start Processing Worker
     (a specific ocr-d processor consuming tasks from RabbitMQ queue)
@@ -49,7 +55,7 @@ def processing_worker_cli(processor_name: str, queue: str, database: str, create
             processor_class=None,  # For readability purposes assigned here
         )
         if create_queue:
-            processing_worker.create_queue()
+            processing_worker.create_queue(connection_attempts=retry_attempts, retry_delay=2)
         # The RMQConsumer is initialized and a connection to the RabbitMQ is performed
         processing_worker.connect_consumer()
         # Start consuming from the queue with name `processor_name`

--- a/ocrd_network/ocrd_network/cli/processing_worker.py
+++ b/ocrd_network/ocrd_network/cli/processing_worker.py
@@ -20,7 +20,12 @@ from .. import (
               help='The URL of the MongoDB, format: mongodb://host:port',
               type=DatabaseParamType(),
               required=True)
-def processing_worker_cli(processor_name: str, queue: str, database: str):
+@click.option('--create-queue',
+              is_flag=True,
+              help='Create the rabbitmq-queue for the worker. Usually the processing server starts'
+              'the workers and creates the queues. This is to make external addition of workers for'
+              'new processors possible')
+def processing_worker_cli(processor_name: str, queue: str, database: str, create_queue: bool):
     """
     Start Processing Worker
     (a specific ocr-d processor consuming tasks from RabbitMQ queue)
@@ -33,7 +38,7 @@ def processing_worker_cli(processor_name: str, queue: str, database: str):
 
     ocrd_tool = get_ocrd_tool_json(processor_name)
     if not ocrd_tool:
-        raise Exception(f"The ocrd_tool is empty or missing")
+        raise Exception("The ocrd_tool is empty or missing")
 
     try:
         processing_worker = ProcessingWorker(
@@ -43,6 +48,8 @@ def processing_worker_cli(processor_name: str, queue: str, database: str):
             ocrd_tool=ocrd_tool,
             processor_class=None,  # For readability purposes assigned here
         )
+        if create_queue:
+            processing_worker.create_queue()
         # The RMQConsumer is initialized and a connection to the RabbitMQ is performed
         processing_worker.connect_consumer()
         # Start consuming from the queue with name `processor_name`

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -18,6 +18,8 @@ import pika.adapters.blocking_connection
 
 from ocrd_utils import getLogger
 
+from time import sleep
+
 from .database import (
     sync_initiate_database,
     sync_db_get_workspace,
@@ -270,13 +272,23 @@ class ProcessingWorker:
         response = requests.post(url=callback_url, headers=headers, json=json_data)
         self.log.info(f'Response from callback_url "{response}"')
 
-    def create_queue(self):
+    def create_queue(self, connection_attempts=1, retry_delay=1):
         """Create the queue for this worker
 
         Originally only the processing-server created the queues for the workers according to the
         configuration file. This is intended to make external deployment of workers possible.
         """
         if self.rmq_publisher is None:
-            self.connect_publisher()
+            attempts = connection_attempts
+            while attempts > 0:
+                try:
+                    self.connect_publisher()
+                    break
+                except BaseException as e:
+                    if attempts <= 1:
+                        raise e
+                    attempts -= 1
+                    sleep(retry_delay)
+
         # the following function is idempotent
         self.rmq_publisher.create_queue(queue_name=self.processor_name)

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -269,3 +269,14 @@ class ProcessingWorker:
         }
         response = requests.post(url=callback_url, headers=headers, json=json_data)
         self.log.info(f'Response from callback_url "{response}"')
+
+    def create_queue(self):
+        """Create the queue for this worker
+
+        Originally only the processing-server created the queues for the workers according to the
+        configuration file. This is intended to make external deployment of workers possible.
+        """
+        if self.rmq_publisher is None:
+            self.connect_publisher()
+        # the following function is idempotent
+        self.rmq_publisher.create_queue(queue_name=self.processor_name)

--- a/ocrd_network/ocrd_network/server_utils.py
+++ b/ocrd_network/ocrd_network/server_utils.py
@@ -41,10 +41,10 @@ async def validate_and_resolve_mets_path(logger, job_input: PYJobInput, resolve:
 
 def validate_job_input(logger, processor_name: str, ocrd_tool: dict, job_input: PYJobInput) -> None:
     if bool(job_input.path_to_mets) == bool(job_input.workspace_id):
-        logger.exception("Either 'path' or 'workspace_id' must be provided, but not both")
+        logger.exception("Either 'path_to_mets' or 'workspace_id' must be provided, but not both")
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Either 'path' or 'workspace_id' must be provided, but not both"
+            detail="Either 'path_to_mets' or 'workspace_id' must be provided, but not both"
         )
     if not ocrd_tool:
         logger.exception(f"Processor '{processor_name}' not available. Empty or missing ocrd_tool")

--- a/ocrd_network/requirements.txt
+++ b/ocrd_network/requirements.txt
@@ -1,5 +1,6 @@
 uvicorn>=0.17.6
 fastapi>=0.78.0
+pydantic==1.*
 docker
 paramiko
 pika>=1.2.0

--- a/ocrd_validators/ocrd_validators/processing_server_config.schema.yml
+++ b/ocrd_validators/ocrd_validators/processing_server_config.schema.yml
@@ -55,7 +55,6 @@ properties:
   hosts:
     description: A list of hosts where Processing Servers will be deployed
     type: array
-    minItems: 1
     items:
       description: A host where one or many Processing Servers will be deployed
       type: object


### PR DESCRIPTION
This are mainly only small additions to ocrd_network which I need for the slim containers.
Summary:
    - Possibility to create a queue for a worker when the worker is externally managed. Previously only the processing-server was able to create a queue for a worker. 
    - Retry for queue creation: When a worker is started at the same time as the rabbit-mq, the rabbitmq needs up to 2 seconds to be fully available so that a queue can be created.
    - allow starting a processing-server without any workers or processor-servers
    - limit pydantic to version 1. Version 2 was released in June 2023 and conflicts with current models which were created for pydantic v1