### PR TITLE
cli.resmgr.download: fix basedir

### DIFF
--- a/ocrd/ocrd/cli/resmgr.py
+++ b/ocrd/ocrd/cli/resmgr.py
@@ -156,12 +156,12 @@ def download(any_url, no_dynamic, resource_type, path_in_archive, allow_uninstal
                     fpath = resmgr.download(
                         this_executable,
                         resdict['url'],
+                        basedir,
                         name=resdict['name'],
                         resource_type=resdict.get('type', resource_type),
                         path_in_archive=resdict.get('path_in_archive', path_in_archive),
                         overwrite=overwrite,
                         no_subdir=location in ['cwd', 'module'],
-                        basedir=basedir,
                         progress_cb=lambda delta: bar.update(delta)
                     )
                 if registered == 'unregistered':


### PR DESCRIPTION
This likely fixes a bug where (starting from Python 3.8) confusing the argument `basedir` with a (non-existing) keyword arg `basedir=` (and later in the argument list) caused a wrong CWD-based fpath result (IIUC).