### PR TITLE
`run_cli` now also supports the METS server

### DIFF
--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -273,11 +273,9 @@ def generate_processor_help(ocrd_tool, processor_instance=None, subcommand=None)
                                   or JSON file path
   -P, --param-override KEY VAL    Override a single JSON object key-value pair,
                                   taking precedence over --parameter
-  -m, --mets URL-PATH             URL or file path of METS to process
-  -U, --mets-server-url URL           URL of a METS Server for parallel incremental access to METS
+  -U, --mets-server-url URL       URL of a METS Server for parallel incremental access to METS
                                   If URL starts with http:// start an HTTP server there,
                                   otherwise URL is a path to an on-demand-created unix socket
-  -w, --working-dir PATH          Working directory of local workspace
   -l, --log-level [OFF|ERROR|WARN|INFO|DEBUG|TRACE]
                                   Override log level globally [INFO]
 '''

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -171,6 +171,7 @@ def run_cli(
         output_file_grp=None,
         parameter=None,
         working_dir=None,
+        mets_server_url=None,
 ):
     """
     Open a workspace and run a processor on the command line.
@@ -206,6 +207,8 @@ def run_cli(
         args += ['--parameter', parameter]
     if overwrite:
         args += ['--overwrite']
+    if mets_server_url:
+        args += ['--mets-server-url', mets_server_url]
     log = getLogger('ocrd.processor.helpers.run_cli')
     log.debug("Running subprocess '%s'", ' '.join(args))
     result = run(args, check=False)


### PR DESCRIPTION
I missed adding the `mets_server_url` kwarg to `run_cli` when finishing #966, now added.

Also remove duplicate lines from the `--help` output.