### PR TITLE
Mets server fixes 2023 09 15

### DIFF
--- a/ocrd/ocrd/mets_server.py
+++ b/ocrd/ocrd/mets_server.py
@@ -190,6 +190,9 @@ class OcrdMetsServer():
         self.log = getLogger('ocrd.workspace_client')
 
     def shutdown(self):
+        if self.is_uds:
+            Path(self.url).unlink()
+        # os._exit because uvicorn catches SystemExit raised by sys.exit
         _exit(0)
 
     def startup(self):
@@ -278,8 +281,7 @@ class OcrdMetsServer():
             """
             getLogger('ocrd_models.ocrd_mets').info('Shutting down')
             workspace.save_mets()
-            # os._exit because uvicorn catches SystemExit raised by sys.exit
-            _exit(0)
+            self.shutdown()
 
         # ------------- #
 
@@ -294,6 +296,5 @@ class OcrdMetsServer():
         else:
             parsed = urlparse(self.url)
             uvicorn_kwargs = {'host': parsed.hostname, 'port': parsed.port}
-        else:
-            uvicorn_kwargs = {'uds': self.url}
+
         uvicorn.run(app, **uvicorn_kwargs)


### PR DESCRIPTION
PR rectifies the wrong fix in #1098, which changed permissions and started/stopped the socket in the client not the server.

Also ensures that the socket file is removed on shutdown.