### PR TITLE
Harmonize loggers

### DIFF
--- a/ocrd/ocrd/cli/log.py
+++ b/ocrd/ocrd/cli/log.py
@@ -21,7 +21,7 @@ class LogCtx():
 pass_log = click.make_pass_decorator(LogCtx)
 
 @click.group("log")
-@click.option('-n', '--name', envvar='OCRD_TOOL_NAME', default='ocrd', metavar='LOGGER_NAME', help='Name of the logger', show_default=True)
+@click.option('-n', '--name', envvar='OCRD_TOOL_NAME', default='log_cli', metavar='LOGGER_NAME', help='Name of the logger', show_default=True)
 @click.pass_context
 def log_cli(ctx, name, *args, **kwargs):
     """

--- a/ocrd/ocrd/cli/network.py
+++ b/ocrd/ocrd/cli/network.py
@@ -25,7 +25,7 @@ def network_cli():
     initLogging()
     # TODO: Remove after the logging fix in core
     logging.getLogger('paramiko.transport').setLevel(logging.INFO)
-    logging.getLogger('ocrd_network').setLevel(logging.DEBUG)
+    logging.getLogger('ocrd.network').setLevel(logging.DEBUG)
 
 
 network_cli.add_command(client_cli)

--- a/ocrd/ocrd/cli/network.py
+++ b/ocrd/ocrd/cli/network.py
@@ -23,9 +23,6 @@ def network_cli():
     Managing network components
     """
     initLogging()
-    # TODO: Remove after the logging fix in core
-    logging.getLogger('paramiko.transport').setLevel(logging.INFO)
-    logging.getLogger('ocrd.network').setLevel(logging.DEBUG)
 
 
 network_cli.add_command(client_cli)

--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -151,9 +151,6 @@ def check_and_run_network_agent(ProcessorClass, subcommand: str, address: str, d
         if not queue:
             raise ValueError(f"Option '--queue' required for subcommand {subcommand}")
 
-    import logging
-    logging.getLogger('ocrd.network').setLevel(logging.DEBUG)
-
     processor = ProcessorClass(workspace=None, dump_json=True)
     if subcommand == 'worker':
         # TODO: Passing processor_name and ocrd_tool is reduntant

--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -67,7 +67,7 @@ def ocrd_cli_wrap_processor(
 
     initLogging()
 
-    LOG = getLogger('ocrd_cli_wrap_processor')
+    LOG = getLogger('ocrd.cli_wrap_processor')
     # LOG.info('kwargs=%s' % kwargs)
     # Merge parameter overrides and parameters
     if 'parameter_override' in kwargs:

--- a/ocrd/ocrd/mets_server.py
+++ b/ocrd/ocrd/mets_server.py
@@ -281,7 +281,7 @@ class OcrdMetsServer():
             """
             Stop the server
             """
-            getLogger('ocrd_models.ocrd_mets').info('Shutting down')
+            getLogger('ocrd.models.ocrd_mets').info('Shutting down')
             workspace.save_mets()
             self.shutdown()
 

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -11,7 +11,7 @@ from typing import List, Type
 
 from click import wrap_text
 from ocrd.workspace import Workspace
-from ocrd_utils import freeze_args, getLogger, pushd_popd, config
+from ocrd_utils import freeze_args, getLogger, pushd_popd, config, setOverrideLogLevel
 
 
 __all__ = [
@@ -36,7 +36,7 @@ def run_processor(
         resolver=None,
         workspace=None,
         page_id=None,
-        log_level=None,         # TODO actually use this!
+        log_level=None,
         input_file_grp=None,
         output_file_grp=None,
         show_resource=None,
@@ -71,6 +71,8 @@ def run_processor(
     Args:
         processorClass (object): Python class of the module processor.
     """
+    if log_level:
+        setOverrideLogLevel(log_level)
     workspace = _get_workspace(
         workspace,
         resolver,

--- a/ocrd_models/ocrd_models/ocrd_exif.py
+++ b/ocrd_models/ocrd_models/ocrd_exif.py
@@ -41,7 +41,7 @@ class OcrdExif():
         if which('identify'):
             self.run_identify(img)
         else:
-            getLogger('ocrd_exif').warning("ImageMagick 'identify' not available, Consider installing ImageMagick for more robust pixel density estimation")
+            getLogger('ocrd.exif').warning("ImageMagick 'identify' not available, Consider installing ImageMagick for more robust pixel density estimation")
             self.run_pil(img)
 
     def run_identify(self, img):
@@ -56,9 +56,9 @@ class OcrdExif():
         if ret.returncode:
             stderr = ret.stderr.decode('utf-8')
             if 'no decode delegate for this image format' in stderr:
-                getLogger('ocrd_exif').warning("ImageMagick does not support the '%s' image format. ", img.format)
+                getLogger('ocrd.exif').warning("ImageMagick does not support the '%s' image format. ", img.format)
             else:
-                getLogger('ocrd_exif').error("identify exited with non-zero %s: %s", ret.returncode, stderr)
+                getLogger('ocrd.exif').error("identify exited with non-zero %s: %s", ret.returncode, stderr)
             self.xResolution = self.yResolution = 1
             self.resolutionUnit = 'inches'
         else:

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -65,7 +65,7 @@ class OcrdMets(OcrdXmlDocument):
         # then enable caching, if "false", disable caching, overriding the
         # kwarg to the constructor
         if config.is_set('OCRD_METS_CACHING'):
-            getLogger('ocrd_models.ocrd_mets').debug('METS Caching %s because OCRD_METS_CACHING is %s',
+            getLogger('ocrd.models.ocrd_mets').debug('METS Caching %s because OCRD_METS_CACHING is %s',
                     'enabled' if config.OCRD_METS_CACHING else 'disabled', config.raw_value('OCRD_METS_CACHING'))
             self._cache_flag = config.OCRD_METS_CACHING
 
@@ -98,7 +98,7 @@ class OcrdMets(OcrdXmlDocument):
         if el_fileSec is None:
             return
 
-        log = getLogger('ocrd_models.ocrd_mets._fill_caches-files')
+        log = getLogger('ocrd.models.ocrd_mets._fill_caches-files')
 
         for el_fileGrp in el_fileSec.findall('mets:fileGrp', NS):
             fileGrp_use = el_fileGrp.get('USE')
@@ -115,7 +115,7 @@ class OcrdMets(OcrdXmlDocument):
         el_div_list = tree_root.findall(".//mets:div[@TYPE='page']", NS)
         if len(el_div_list) == 0:
             return
-        log = getLogger('ocrd_models.ocrd_mets._fill_caches-pages')
+        log = getLogger('ocrd.models.ocrd_mets._fill_caches-pages')
 
         for el_div in el_div_list:
             div_id = el_div.get('ID')
@@ -401,7 +401,7 @@ class OcrdMets(OcrdXmlDocument):
             recursive (boolean): Whether to recursively delete each ``mets:file`` in the group
             force (boolean): Do not raise an exception if ``mets:fileGrp`` does not exist
         """
-        log = getLogger('ocrd_models.ocrd_mets.remove_file_group')
+        log = getLogger('ocrd.models.ocrd_mets.remove_file_group')
         el_fileSec = self._tree.getroot().find('mets:fileSec', NS)
         if el_fileSec is None:
             raise Exception("No fileSec!")
@@ -466,7 +466,7 @@ class OcrdMets(OcrdXmlDocument):
             raise ValueError("Invalid syntax for mets:file/@ID %s (not an xs:ID)" % ID)
         if not REGEX_FILE_ID.fullmatch(fileGrp):
             raise ValueError("Invalid syntax for mets:fileGrp/@USE %s (not an xs:ID)" % fileGrp)
-        log = getLogger('ocrd_models.ocrd_mets.add_file')
+        log = getLogger('ocrd.models.ocrd_mets.add_file')
 
         el_fileGrp = self.add_file_group(fileGrp)
         if not ignore:
@@ -521,7 +521,7 @@ class OcrdMets(OcrdXmlDocument):
         Returns:
             The old :py:class:`ocrd_models.ocrd_file.OcrdFile` reference.
         """
-        log = getLogger('ocrd_models.ocrd_mets.remove_one_file')
+        log = getLogger('ocrd.models.ocrd_mets.remove_one_file')
         log.debug("remove_one_file(%s %s)" % (ID, fileGrp))
         if isinstance(ID, OcrdFile):
             ocrd_file = ID

--- a/ocrd_models/ocrd_models/utils.py
+++ b/ocrd_models/ocrd_models/utils.py
@@ -20,7 +20,7 @@ def xmllint_format(xml):
     Arguments:
         xml (string): Serialized XML
     """
-    log = getLogger('ocrd_models.utils.xmllint_format')
+    log = getLogger('ocrd.models.utils.xmllint_format')
     parser = ET.XMLParser(resolve_entities=False, strip_cdata=False, remove_blank_text=True)
     document = ET.fromstring(xml, parser)
     return ('%s\n%s' % ('<?xml version="1.0" encoding="UTF-8"?>',
@@ -30,7 +30,7 @@ def handle_oai_response(response):
     """
     In case of a valid OAI-Response, extract first METS-Entry-Data
     """
-    log = getLogger('ocrd_models.utils.handle_oai_response')
+    log = getLogger('ocrd.models.utils.handle_oai_response')
     content_type = response.headers['Content-Type']
     if 'xml' in content_type or 'text' in content_type:
         content = response.content
@@ -46,7 +46,7 @@ def is_oai_content(data):
     """
     Return True if data is an OAI-PMH request/response
     """
-    log = getLogger('ocrd_models.utils.is_oai_content')
+    log = getLogger('ocrd.models.utils.is_oai_content')
     xml_root = ET.fromstring(data)
     root_tag = xml_root.tag
     log.info("response data root.tag: '%s'" % root_tag)

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -33,7 +33,7 @@ from .utils import validate_and_load_config
 
 class Deployer:
     def __init__(self, config_path: str) -> None:
-        self.log = getLogger(__name__)
+        self.log = getLogger('ocrd_network.deployer')
         config = validate_and_load_config(config_path)
 
         self.data_mongo: DataMongoDB = DataMongoDB(config['database'])

--- a/ocrd_network/ocrd_network/processing_server.py
+++ b/ocrd_network/ocrd_network/processing_server.py
@@ -56,7 +56,7 @@ class ProcessingServer(FastAPI):
         super().__init__(on_startup=[self.on_startup], on_shutdown=[self.on_shutdown],
                          title='OCR-D Processing Server',
                          description='OCR-D processing and processors')
-        self.log = getLogger(__name__)
+        self.log = getLogger('ocrd_network.processing_server')
         self.log.info(f"Downloading ocrd all tool json")
         self.ocrd_all_tool_json = download_ocrd_all_tool_json(
             ocrd_all_url="https://ocr-d.de/js/ocrd-all-tool.json"

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -44,7 +44,7 @@ from ocrd_utils import config
 
 class ProcessingWorker:
     def __init__(self, rabbitmq_addr, mongodb_addr, processor_name, ocrd_tool: dict, processor_class=None) -> None:
-        self.log = getLogger(__name__)
+        self.log = getLogger('ocrd_network.processing_worker')
         # TODO: Provide more flexibility for configuring file logging (i.e. via ENV variables)
         file_handler = logging.FileHandler(f'/tmp/worker_{processor_name}_{getpid()}.log', mode='a')
         logging_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'

--- a/ocrd_network/ocrd_network/processor_server.py
+++ b/ocrd_network/ocrd_network/processor_server.py
@@ -39,7 +39,7 @@ class ProcessorServer(FastAPI):
     def __init__(self, mongodb_addr: str, processor_name: str = "", processor_class=None):
         if not (processor_name or processor_class):
             raise ValueError('Either "processor_name" or "processor_class" must be provided')
-        self.log = getLogger(__name__)
+        self.log = getLogger('ocrd_network.processor_server')
 
         self.db_url = mongodb_addr
         self.processor_name = processor_name

--- a/ocrd_network/ocrd_network/rabbitmq_utils/constants.py
+++ b/ocrd_network/ocrd_network/rabbitmq_utils/constants.py
@@ -11,8 +11,6 @@ __all__ = [
     'RECONNECT_WAIT',
     'RECONNECT_TRIES',
     'PREFETCH_COUNT',
-    'LOG_FORMAT',
-    'LOG_LEVEL'
 ]
 
 DEFAULT_EXCHANGER_NAME: str = 'ocrd-network-default'
@@ -32,7 +30,3 @@ RECONNECT_TRIES: int = 3
 # QOS, i.e., how many messages to consume in a single go
 # Check here: https://www.rabbitmq.com/consumer-prefetch.html
 PREFETCH_COUNT: int = 1
-
-# TODO: Integrate the OCR-D Logger once the logging in OCR-D is improved/optimized
-LOG_FORMAT: str = '%(levelname) -10s %(asctime)s %(name) -30s %(funcName) -35s %(lineno) -5d: %(message)s'
-LOG_LEVEL: int = logging.WARNING

--- a/ocrd_network/ocrd_network/rabbitmq_utils/consumer.py
+++ b/ocrd_network/ocrd_network/rabbitmq_utils/consumer.py
@@ -11,7 +11,6 @@ from pika import PlainCredentials
 
 from .constants import (
     DEFAULT_QUEUE,
-    LOG_LEVEL,
     RABBIT_MQ_HOST as HOST,
     RABBIT_MQ_PORT as PORT,
     RABBIT_MQ_VHOST as VHOST
@@ -25,9 +24,6 @@ class RMQConsumer(RMQConnector):
         if not logger_name:
             logger_name = __name__
         logger = logging.getLogger(logger_name)
-        logging.getLogger(logger_name).setLevel(LOG_LEVEL)
-        # This may mess up the global logger
-        logging.basicConfig(level=logging.WARNING)
         super().__init__(logger=logger, host=host, port=port, vhost=vhost)
 
         self.consumer_tag = None

--- a/ocrd_network/ocrd_network/rabbitmq_utils/publisher.py
+++ b/ocrd_network/ocrd_network/rabbitmq_utils/publisher.py
@@ -15,8 +15,6 @@ from pika import (
 from .constants import (
     DEFAULT_EXCHANGER_NAME,
     DEFAULT_ROUTER,
-    LOG_FORMAT,
-    LOG_LEVEL,
     RABBIT_MQ_HOST as HOST,
     RABBIT_MQ_PORT as PORT,
     RABBIT_MQ_VHOST as VHOST
@@ -30,9 +28,6 @@ class RMQPublisher(RMQConnector):
         if logger_name is None:
             logger_name = __name__
         logger = logging.getLogger(logger_name)
-        logging.getLogger(logger_name).setLevel(LOG_LEVEL)
-        # This may mess up the global logger
-        logging.basicConfig(level=logging.WARNING)
         super().__init__(logger=logger, host=host, port=port, vhost=vhost)
 
         self.message_counter = 0

--- a/ocrd_utils/ocrd_logging.conf
+++ b/ocrd_utils/ocrd_logging.conf
@@ -64,7 +64,7 @@ level=INFO
 handlers=consoleHandler
 qualname=ocrd_models
 [logger_ocrd_ocrd_network]
-level=INFO
+level=DEBUG
 handlers=consoleHandler
 qualname=ocrd_network
 

--- a/ocrd_utils/ocrd_logging.conf
+++ b/ocrd_utils/ocrd_logging.conf
@@ -63,19 +63,10 @@ qualname=ocrd
 level=INFO
 handlers=consoleHandler
 qualname=ocrd_models
-[logger_ocrd_ocrd_utils]
-level=INFO
-handlers=consoleHandler
-qualname=ocrd_utils
 [logger_ocrd_ocrd_network]
 level=INFO
 handlers=consoleHandler
 qualname=ocrd_network
-[logger_ocrd_ocrd_exif]
-level=INFO
-handlers=consoleHandler
-qualname=ocrd_exif
-
 
 #
 # logger tensorflow

--- a/ocrd_utils/ocrd_utils/image.py
+++ b/ocrd_utils/ocrd_utils/image.py
@@ -212,7 +212,7 @@ def rotate_coordinates(transform, angle, orig=np.array([0, 0])):
     
     Return a numpy array of the resulting affine transformation matrix.
     """
-    LOG = getLogger('ocrd_utils.coords.rotate_coordinates')
+    LOG = getLogger('ocrd.utils.coords.rotate_coordinates')
     rad = np.deg2rad(angle)
     cos = np.cos(rad)
     sin = np.sin(rad)
@@ -254,7 +254,7 @@ def rotate_image(image, angle, fill='background', transparency=False):
 
     Return a new PIL.Image.
     """
-    LOG = getLogger('ocrd_utils.rotate_image')
+    LOG = getLogger('ocrd.utils.rotate_image')
     LOG.debug('rotating image by %.2f°', angle)
     if transparency and image.mode in ['RGB', 'L']:
         # ensure no information is lost by adding transparency channel
@@ -298,7 +298,7 @@ def shift_coordinates(transform, offset):
     
     Return a numpy array of the resulting affine transformation matrix.
     """
-    LOG = getLogger('ocrd_utils.coords.shift_coordinates')
+    LOG = getLogger('ocrd.utils.coords.shift_coordinates')
     LOG.debug('shifting coordinates by %s', str(offset))
     shift = np.eye(3)
     shift[0, 2] = offset[0]
@@ -315,7 +315,7 @@ def scale_coordinates(transform, factors):
     
     Return a numpy array of the resulting affine transformation matrix.
     """
-    LOG = getLogger('ocrd_utils.coords.scale_coordinates')
+    LOG = getLogger('ocrd.utils.coords.scale_coordinates')
     LOG.debug('scaling coordinates by %s', str(factors))
     scale = np.eye(3)
     scale[0, 0] = factors[0]
@@ -374,7 +374,7 @@ def transpose_coordinates(transform, method, orig=np.array([0, 0])):
 
     Return a numpy array of the resulting affine transformation matrix.
     """
-    LOG = getLogger('ocrd_utils.coords.transpose_coordinates')
+    LOG = getLogger('ocrd.utils.coords.transpose_coordinates')
     LOG.debug('transposing coordinates with %s around %s', membername(Image, method), str(orig))
     # get rotation matrix for passive rotation/reflection:
     rot90 = np.array([[0, 1, 0],
@@ -441,7 +441,7 @@ def transpose_image(image, method):
     
     Return a new PIL.Image.
     """
-    LOG = getLogger('ocrd_utils.transpose_image')
+    LOG = getLogger('ocrd.utils.transpose_image')
     LOG.debug('transposing image with %s', membername(Image, method))
     return image.transpose(method)
 
@@ -459,7 +459,7 @@ def crop_image(image, box=None):
 
     Return a new PIL.Image.
     """
-    LOG = getLogger('ocrd_utils.crop_image')
+    LOG = getLogger('ocrd.utils.crop_image')
     if not box:
         box = (0, 0, image.width, image.height)
     elif box[0] < 0 or box[1] < 0 or box[2] > image.width or box[3] > image.height:

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -48,10 +48,7 @@ __all__ = [
 
 LOGGING_DEFAULTS = {
     'ocrd': logging.INFO,
-    'ocrd_models': logging.INFO,
-    'ocrd_utils': logging.INFO,
     'ocrd_network': logging.INFO,
-    'ocrd_exif': logging.INFO,
     # 'ocrd.resolver': logging.INFO,
     # 'ocrd.resolver.download_to_directory': logging.INFO,
     # 'ocrd.resolver.add_files_to_mets': logging.INFO,

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -94,8 +94,6 @@ def getLogger(*args, **kwargs):
     Wrapper around ``logging.getLogger`` that alls :py:func:`initLogging` if
     that wasn't explicitly called before.
     """
-    if not _initialized_flag:
-        initLogging()
     logger = logging.getLogger(*args, **kwargs)
     return logger
 

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -48,7 +48,7 @@ __all__ = [
 
 LOGGING_DEFAULTS = {
     'ocrd': logging.INFO,
-    'ocrd_network': logging.INFO,
+    'ocrd_network': logging.DEBUG,
     # 'ocrd.resolver': logging.INFO,
     # 'ocrd.resolver.download_to_directory': logging.INFO,
     # 'ocrd.resolver.add_files_to_mets': logging.INFO,
@@ -56,6 +56,7 @@ LOGGING_DEFAULTS = {
     'shapely.geos': logging.ERROR,
     'tensorflow': logging.ERROR,
     'PIL': logging.INFO,
+    'paramiko.transport': logging.INFO
 }
 
 _initialized_flag = False

--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -82,7 +82,7 @@ def get_ocrd_tool_json(executable):
     try:
         ocrd_tool = loads(run([executable, '--dump-json'], stdout=PIPE).stdout)
     except (JSONDecodeError, OSError) as e:
-        getLogger('ocrd_utils.get_ocrd_tool_json').error(f'{executable} --dump-json produced invalid JSON: {e}')
+        getLogger('ocrd.utils.get_ocrd_tool_json').error(f'{executable} --dump-json produced invalid JSON: {e}')
         ocrd_tool = {}
     if 'resource_locations' not in ocrd_tool:
         ocrd_tool['resource_locations'] = ['data', 'cwd', 'system', 'module']
@@ -94,7 +94,7 @@ def get_moduledir(executable):
     try:
         moduledir = run([executable, '--dump-module-dir'], encoding='utf-8', stdout=PIPE).stdout.rstrip('\n')
     except (JSONDecodeError, OSError) as e:
-        getLogger('ocrd_utils.get_moduledir').error(f'{executable} --dump-module-dir failed: {e}')
+        getLogger('ocrd.utils.get_moduledir').error(f'{executable} --dump-module-dir failed: {e}')
     return moduledir
 
 def list_resource_candidates(executable, fname, cwd=getcwd(), moduled=None, xdg_data_home=None):

--- a/tests/test_resolver_oai.py
+++ b/tests/test_resolver_oai.py
@@ -91,7 +91,7 @@ def test_handle_response_for_invalid_content(mock_get, response_dir):
     initLogging()
 
     # capture log
-    log = getLogger('ocrd_models.utils.handle_oai_response')
+    log = getLogger('ocrd.models.utils.handle_oai_response')
     capt = FIFOIO(256)
     sh = StreamHandler(capt)
     sh.setFormatter(Formatter(LOG_FORMAT))
@@ -103,7 +103,7 @@ def test_handle_response_for_invalid_content(mock_get, response_dir):
     # assert
     mock_get.assert_called_once_with(url, timeout=None)
     log_output = capt.getvalue()
-    assert 'WARNING ocrd_models.utils.handle_oai_response' in log_output
+    assert 'WARNING ocrd.models.utils.handle_oai_response' in log_output
 
 
 if __name__ == '__main__':

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -568,7 +568,7 @@ def test_deskewing(plain_workspace):
     logger_capture = FIFOIO(256)
     logger_handler = logging.StreamHandler(logger_capture)
     #logger_handler.setFormatter(logging.Formatter(fmt=LOG_FORMAT, datefmt=LOG_TIMEFMT))
-    logger = logging.getLogger('ocrd_utils.crop_image')
+    logger = logging.getLogger('ocrd.utils.crop_image')
     logger.addHandler(logger_handler)
     reg_image2, reg_coords2 = plain_workspace.image_from_segment(region, page_image, page_coords, fill=0)
     #reg_image2.show(title='reg_image2')


### PR DESCRIPTION
This is a colophon to #1080

- changing the logger names - all OCR-D/core logging except for `ocrd_network` now are derived from the `ocrd` logger
-  making the logger names in `ocrd_network` explicit
- removing the custom logging code in `ocrd_network` and porting the defaults to the config file and `ocrd_utils.logging` resp.
- simplifying the naming in the logging configuration file and removing now unrequired logger configs 

Unfortunately, there is a heisenbug for (ironically) `test_log_error` in `tests/cli/test_log.py`. Error goes away when replacing the `StreamHandler` of `consoleHandler` with a `FileHandler` in the logging configuration - which isn't even used in that test. I tried `git bisecting` through the changes, but it only appears in the commit 660b46806. If anybody (@m3ssman perhaps?) has an idea, pls let me know.