### PR TITLE
OcrdMets.physical_pages should return "proper" str

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -577,9 +577,9 @@ class OcrdMets(OcrdXmlDocument):
         if self._cache_flag:
             return list(self._page_cache.keys())
             
-        return self._tree.getroot().xpath(
+        return [str(x) for x in self._tree.getroot().xpath(
             'mets:structMap[@TYPE="PHYSICAL"]/mets:div[@TYPE="physSequence"]/mets:div[@TYPE="page"]/@ID',
-            namespaces=NS)
+            namespaces=NS)]
 
     def get_physical_pages(self, for_fileIds=None):
         """

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -7,6 +7,7 @@ from os import environ
 from contextlib import contextmanager
 import shutil
 from logging import StreamHandler
+import lxml
 
 from tests.base import (
     main,
@@ -101,6 +102,7 @@ def test_physical_pages(sbb_sample_01):
     assert len(sbb_sample_01.physical_pages) == 3, '3 physical pages'
     assert isinstance(sbb_sample_01.physical_pages, list)
     assert isinstance(sbb_sample_01.physical_pages[0], str)
+    assert not isinstance(sbb_sample_01.physical_pages[0], lxml.etree._ElementUnicodeResult)
 
 def test_physical_pages_from_empty_mets():
     mets = OcrdMets(content="<mets></mets>")


### PR DESCRIPTION
`lxml.xpath` returns `lxml.etree._ElementUnicodeResult` which are also `str`, but not quite which led to problems in #1083.