### PR TITLE
Workflow endpoint logging 2023 09 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changed:
 
   * METS Server: Make sockets world-readable and -writable, #1098, #1099
   * METS Server: Implement find_files support for `local_filename` and `url`, #1100
+  * Logging: consistent logger names derived from `ocrd.`, #1101
+  * Logging: consistent logging across the packages, including `ocrd_network`, #1101
 
 ## [2.54.0] - 2023-09-12
 

--- a/ocrd/ocrd/cli/log.py
+++ b/ocrd/ocrd/cli/log.py
@@ -21,7 +21,7 @@ class LogCtx():
 pass_log = click.make_pass_decorator(LogCtx)
 
 @click.group("log")
-@click.option('-n', '--name', envvar='OCRD_TOOL_NAME', default='ocrd', metavar='LOGGER_NAME', help='Name of the logger', show_default=True)
+@click.option('-n', '--name', envvar='OCRD_TOOL_NAME', default='log_cli', metavar='LOGGER_NAME', help='Name of the logger', show_default=True)
 @click.pass_context
 def log_cli(ctx, name, *args, **kwargs):
     """

--- a/ocrd/ocrd/cli/network.py
+++ b/ocrd/ocrd/cli/network.py
@@ -23,9 +23,6 @@ def network_cli():
     Managing network components
     """
     initLogging()
-    # TODO: Remove after the logging fix in core
-    logging.getLogger('paramiko.transport').setLevel(logging.INFO)
-    logging.getLogger('ocrd_network').setLevel(logging.DEBUG)
 
 
 network_cli.add_command(client_cli)

--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -67,7 +67,7 @@ def ocrd_cli_wrap_processor(
 
     initLogging()
 
-    LOG = getLogger('ocrd_cli_wrap_processor')
+    LOG = getLogger('ocrd.cli_wrap_processor')
     # LOG.info('kwargs=%s' % kwargs)
     # Merge parameter overrides and parameters
     if 'parameter_override' in kwargs:
@@ -150,9 +150,6 @@ def check_and_run_network_agent(ProcessorClass, subcommand: str, address: str, d
             raise ValueError(f"Option '--address' invalid for subcommand {subcommand}")
         if not queue:
             raise ValueError(f"Option '--queue' required for subcommand {subcommand}")
-
-    import logging
-    logging.getLogger('ocrd.network').setLevel(logging.DEBUG)
 
     processor = ProcessorClass(workspace=None, dump_json=True)
     if subcommand == 'worker':

--- a/ocrd/ocrd/decorators/__init__.py
+++ b/ocrd/ocrd/decorators/__init__.py
@@ -39,6 +39,7 @@ def ocrd_cli_wrap_processor(
     subcommand=None,
     address=None,
     queue=None,
+    log_filename=None,
     database=None,
     # ocrd_network params end #
     **kwargs

--- a/ocrd/ocrd/decorators/ocrd_cli_options.py
+++ b/ocrd/ocrd/decorators/ocrd_cli_options.py
@@ -48,6 +48,7 @@ def ocrd_cli_options(f):
         option('-D', '--dump-module-dir', is_flag=True, default=False),
         option('-h', '--help', is_flag=True, default=False),
         option('-V', '--version', is_flag=True, default=False),
+        option('--log-filename', default=None),
         # Subcommand, only used for 'worker'/'server'. Cannot be handled in
         # click because processors use the @command decorator and even if they
         # were using `group`, you cannot combine have a command with

--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -145,6 +145,7 @@ ocrd__parse_argv () {
             -I|--input-file-grp) ocrd__argv[input_file_grp]=$2 ; shift ;;
             -w|--working-dir) ocrd__argv[working_dir]=$(realpath "$2") ; shift ;;
             -m|--mets) ocrd__argv[mets_file]=$(realpath "$2") ; shift ;;
+            --log-filename) ocrd__argv[log_filename]="$2" ; shift ;;
             --mets-server-url) ocrd_argv[mets_server_url]="$2" ; shift ;;
             --overwrite) ocrd__argv[overwrite]=true ;;
             --profile) ocrd__argv[profile]=true ;;
@@ -168,7 +169,7 @@ ocrd__parse_argv () {
             if ! [ -v ocrd__worker_queue ]; then
                 ocrd__raise "For the Processing Worker --queue is required"
             fi
-            ocrd network processing-worker $OCRD_TOOL_NAME --queue "${ocrd__worker_queue}" --database "${ocrd__worker_database}"
+            ocrd network processing-worker $OCRD_TOOL_NAME --queue "${ocrd__worker_queue}" --database "${ocrd__worker_database}" --log-filename "${ocrd__argv[log_filename]}"
         elif [ ${ocrd__subcommand} = "server" ]; then
             if ! [ -v ocrd__worker_address ]; then
                 ocrd__raise "For the Processor Server --address is required"

--- a/ocrd/ocrd/mets_server.py
+++ b/ocrd/ocrd/mets_server.py
@@ -198,7 +198,7 @@ class OcrdMetsServer():
         _exit(0)
 
     def startup(self):
-        self.log.info("Starting down METS server")
+        self.log.info("Starting up METS server")
 
         workspace = self.workspace
 

--- a/ocrd/ocrd/mets_server.py
+++ b/ocrd/ocrd/mets_server.py
@@ -100,7 +100,7 @@ class ClientSideOcrdMets():
 
     def __init__(self, url):
         protocol = 'tcp' if url.startswith('http://') else 'uds'
-        self.log = getLogger(f'ocrd.mets_client.{protocol}')
+        self.log = getLogger(f'ocrd.mets_client[{url}]')
         self.url = url if protocol == 'tcp' else f'http+unix://{url.replace("/", "%2F")}'
         self.session = requests_session() if protocol == 'tcp' else requests_unixsocket_session()
 
@@ -118,6 +118,7 @@ class ClientSideOcrdMets():
     @deprecated_alias(pageId="page_id")
     @deprecated_alias(fileGrp="file_grp")
     def find_files(self, **kwargs):
+        self.log.debug('find_files(%s)', kwargs)
         if 'pageId' in kwargs:
             kwargs['page_id'] = kwargs.pop('pageId')
         if 'ID' in kwargs:
@@ -187,15 +188,17 @@ class OcrdMetsServer():
         self.workspace = workspace
         self.url = url
         self.is_uds = not (url.startswith('http://') or url.startswith('https://'))
-        self.log = getLogger('ocrd.workspace_client')
+        self.log = getLogger(f'ocrd.mets_server[{self.url}]')
 
     def shutdown(self):
+        self.log.info("Shutting down METS server")
         if self.is_uds:
             Path(self.url).unlink()
         # os._exit because uvicorn catches SystemExit raised by sys.exit
         _exit(0)
 
     def startup(self):
+        self.log.info("Starting down METS server")
 
         workspace = self.workspace
 
@@ -281,7 +284,7 @@ class OcrdMetsServer():
             """
             Stop the server
             """
-            getLogger('ocrd_models.ocrd_mets').info('Shutting down')
+            getLogger('ocrd.models.ocrd_mets').info('Shutting down')
             workspace.save_mets()
             self.shutdown()
 
@@ -290,6 +293,7 @@ class OcrdMetsServer():
         if self.is_uds:
             # Create socket and change to world-readable and -writable to avoid
             # permsission errors
+            self.log.debug(f"chmod 0o677 {self.url}")
             server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             server.bind(self.url)  # creates the socket file
             server.close()
@@ -299,4 +303,5 @@ class OcrdMetsServer():
             parsed = urlparse(self.url)
             uvicorn_kwargs = {'host': parsed.hostname, 'port': parsed.port}
 
+        self.log.debug("Starting uvicorn")
         uvicorn.run(app, **uvicorn_kwargs)

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -11,7 +11,7 @@ from typing import List, Type
 
 from click import wrap_text
 from ocrd.workspace import Workspace
-from ocrd_utils import freeze_args, getLogger, pushd_popd, config
+from ocrd_utils import freeze_args, getLogger, pushd_popd, config, setOverrideLogLevel
 
 
 __all__ = [
@@ -36,7 +36,7 @@ def run_processor(
         resolver=None,
         workspace=None,
         page_id=None,
-        log_level=None,         # TODO actually use this!
+        log_level=None,
         input_file_grp=None,
         output_file_grp=None,
         show_resource=None,
@@ -71,6 +71,8 @@ def run_processor(
     Args:
         processorClass (object): Python class of the module processor.
     """
+    if log_level:
+        setOverrideLogLevel(log_level)
     workspace = _get_workspace(
         workspace,
         resolver,

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -251,6 +251,8 @@ def generate_processor_help(ocrd_tool, processor_instance=None, subcommand=None)
   --database                      The MongoDB server address in format
                                   "mongodb://{host}:{port}"
                                   [mongodb://localhost:27018]
+  --log-filename                  Filename to redirect STDOUT/STDERR to,
+                                  if specified.
 '''
 
     processing_server_options = '''\

--- a/ocrd/ocrd/workspace.py
+++ b/ocrd/ocrd/workspace.py
@@ -123,7 +123,6 @@ class Workspace():
         """
         def after_add_cb(f):
             """callback to run on merged OcrdFile instances in the destination"""
-            print(f)
             if not f.local_filename:
                 # OcrdFile has no local_filename, so nothing to be copied
                 return
@@ -177,7 +176,6 @@ class Workspace():
         """
         log = getLogger('ocrd.workspace.download_file')
         with pushd_popd(self.directory):
-            print(f)
             if f.local_filename:
                 file_path = Path(f.local_filename).absolute()
                 if file_path.exists():

--- a/ocrd_models/ocrd_models/ocrd_exif.py
+++ b/ocrd_models/ocrd_models/ocrd_exif.py
@@ -41,7 +41,7 @@ class OcrdExif():
         if which('identify'):
             self.run_identify(img)
         else:
-            getLogger('ocrd_exif').warning("ImageMagick 'identify' not available, Consider installing ImageMagick for more robust pixel density estimation")
+            getLogger('ocrd.exif').warning("ImageMagick 'identify' not available, Consider installing ImageMagick for more robust pixel density estimation")
             self.run_pil(img)
 
     def run_identify(self, img):
@@ -56,9 +56,9 @@ class OcrdExif():
         if ret.returncode:
             stderr = ret.stderr.decode('utf-8')
             if 'no decode delegate for this image format' in stderr:
-                getLogger('ocrd_exif').warning("ImageMagick does not support the '%s' image format. ", img.format)
+                getLogger('ocrd.exif').warning("ImageMagick does not support the '%s' image format. ", img.format)
             else:
-                getLogger('ocrd_exif').error("identify exited with non-zero %s: %s", ret.returncode, stderr)
+                getLogger('ocrd.exif').error("identify exited with non-zero %s: %s", ret.returncode, stderr)
             self.xResolution = self.yResolution = 1
             self.resolutionUnit = 'inches'
         else:

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -65,7 +65,7 @@ class OcrdMets(OcrdXmlDocument):
         # then enable caching, if "false", disable caching, overriding the
         # kwarg to the constructor
         if config.is_set('OCRD_METS_CACHING'):
-            getLogger('ocrd_models.ocrd_mets').debug('METS Caching %s because OCRD_METS_CACHING is %s',
+            getLogger('ocrd.models.ocrd_mets').debug('METS Caching %s because OCRD_METS_CACHING is %s',
                     'enabled' if config.OCRD_METS_CACHING else 'disabled', config.raw_value('OCRD_METS_CACHING'))
             self._cache_flag = config.OCRD_METS_CACHING
 
@@ -98,7 +98,7 @@ class OcrdMets(OcrdXmlDocument):
         if el_fileSec is None:
             return
 
-        log = getLogger('ocrd_models.ocrd_mets._fill_caches-files')
+        log = getLogger('ocrd.models.ocrd_mets._fill_caches-files')
 
         for el_fileGrp in el_fileSec.findall('mets:fileGrp', NS):
             fileGrp_use = el_fileGrp.get('USE')
@@ -115,7 +115,7 @@ class OcrdMets(OcrdXmlDocument):
         el_div_list = tree_root.findall(".//mets:div[@TYPE='page']", NS)
         if len(el_div_list) == 0:
             return
-        log = getLogger('ocrd_models.ocrd_mets._fill_caches-pages')
+        log = getLogger('ocrd.models.ocrd_mets._fill_caches-pages')
 
         for el_div in el_div_list:
             div_id = el_div.get('ID')
@@ -401,7 +401,7 @@ class OcrdMets(OcrdXmlDocument):
             recursive (boolean): Whether to recursively delete each ``mets:file`` in the group
             force (boolean): Do not raise an exception if ``mets:fileGrp`` does not exist
         """
-        log = getLogger('ocrd_models.ocrd_mets.remove_file_group')
+        log = getLogger('ocrd.models.ocrd_mets.remove_file_group')
         el_fileSec = self._tree.getroot().find('mets:fileSec', NS)
         if el_fileSec is None:
             raise Exception("No fileSec!")
@@ -466,7 +466,7 @@ class OcrdMets(OcrdXmlDocument):
             raise ValueError("Invalid syntax for mets:file/@ID %s (not an xs:ID)" % ID)
         if not REGEX_FILE_ID.fullmatch(fileGrp):
             raise ValueError("Invalid syntax for mets:fileGrp/@USE %s (not an xs:ID)" % fileGrp)
-        log = getLogger('ocrd_models.ocrd_mets.add_file')
+        log = getLogger('ocrd.models.ocrd_mets.add_file')
 
         el_fileGrp = self.add_file_group(fileGrp)
         if not ignore:
@@ -521,7 +521,7 @@ class OcrdMets(OcrdXmlDocument):
         Returns:
             The old :py:class:`ocrd_models.ocrd_file.OcrdFile` reference.
         """
-        log = getLogger('ocrd_models.ocrd_mets.remove_one_file')
+        log = getLogger('ocrd.models.ocrd_mets.remove_one_file')
         log.debug("remove_one_file(%s %s)" % (ID, fileGrp))
         if isinstance(ID, OcrdFile):
             ocrd_file = ID

--- a/ocrd_models/ocrd_models/utils.py
+++ b/ocrd_models/ocrd_models/utils.py
@@ -20,7 +20,7 @@ def xmllint_format(xml):
     Arguments:
         xml (string): Serialized XML
     """
-    log = getLogger('ocrd_models.utils.xmllint_format')
+    log = getLogger('ocrd.models.utils.xmllint_format')
     parser = ET.XMLParser(resolve_entities=False, strip_cdata=False, remove_blank_text=True)
     document = ET.fromstring(xml, parser)
     return ('%s\n%s' % ('<?xml version="1.0" encoding="UTF-8"?>',
@@ -30,7 +30,7 @@ def handle_oai_response(response):
     """
     In case of a valid OAI-Response, extract first METS-Entry-Data
     """
-    log = getLogger('ocrd_models.utils.handle_oai_response')
+    log = getLogger('ocrd.models.utils.handle_oai_response')
     content_type = response.headers['Content-Type']
     if 'xml' in content_type or 'text' in content_type:
         content = response.content
@@ -46,7 +46,7 @@ def is_oai_content(data):
     """
     Return True if data is an OAI-PMH request/response
     """
-    log = getLogger('ocrd_models.utils.is_oai_content')
+    log = getLogger('ocrd.models.utils.is_oai_content')
     xml_root = ET.fromstring(data)
     root_tag = xml_root.tag
     log.info("response data root.tag: '%s'" % root_tag)

--- a/ocrd_network/ocrd_network/__init__.py
+++ b/ocrd_network/ocrd_network/__init__.py
@@ -1,27 +1,3 @@
-# This network package is supposed to contain all the packages and modules to realize the network architecture:
-# https://github.com/OCR-D/spec/pull/222/files#diff-8d0dae8c9277ff1003df93c5359c82a12d3f5c8452281f87781921921204d283
-
-# For reference, currently:
-# 1. The WebAPI is available here: https://github.com/OCR-D/ocrd-webapi-implementation
-# The ocrd-webapi-implementation repo implements the Discovery / Workflow / Workspace endpoints of the WebAPI currently.
-# This Processing Server PR implements just the Processor endpoint of the WebAPI. 
-# Once we have this merged to core under ocrd-network, the other endpoints will be adapted to ocrd-network 
-# and then the ocrd-webapi-implementation repo can be archived for reference.
-
-# 2. The RabbitMQ Library (i.e., utils) is used as an API to abstract and 
-# simplify (from the view point of processing server and workers) interactions with the RabbitMQ Server.
-# The library was adopted from: https://github.com/OCR-D/ocrd-webapi-implementation/tree/main/ocrd_webapi/rabbitmq
-
-# 3. Some potentially more useful code to be adopted for the Processing Server/Worker is available here:
-# https://github.com/OCR-D/core/pull/884
-# Update: Should be revisited again for adopting any relevant parts (if necessary). 
-# Nothing relevant is under the radar for now.
-
-# 4. The Mets Server discussion/implementation is available here:
-# https://github.com/OCR-D/core/pull/966
-
-# Note: The Mets Server is still not placed on the architecture diagram and probably won't be a part of
-# the network package. The reason, Mets Server is tightly coupled with the `OcrdWorkspace`.
 from .client import Client
 from .processing_server import ProcessingServer
 from .processing_worker import ProcessingWorker

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -513,6 +513,7 @@ class Deployer:
         stdin, stdout = channel.makefile('wb'), channel.makefile('rb')
         cmd = f'{processor_name} server --address {agent_address} --database {database_url}'
         stdin.write(f"echo starting processor server with '{cmd}'\n")
+        stdin.write(f'{cmd} &\n')
         stdin.write('echo xyz$!xyz \n exit \n')
         output = stdout.read().decode('utf-8')
         stdout.close()

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -512,11 +512,7 @@ class Deployer:
         channel = ssh_client.invoke_shell()
         stdin, stdout = channel.makefile('wb'), channel.makefile('rb')
         cmd = f'{processor_name} server --address {agent_address} --database {database_url}'
-        port = agent_address.split(':')[1]
-        log_path = f'/tmp/server_{processor_name}_{port}_{getpid()}.log'
-        # TODO: This entire stdin/stdout thing is broken with servers!
-        stdin.write(f"echo starting processor server with '{cmd}' >> '{log_path}'\n")
-        stdin.write(f'{cmd} >> {log_path} 2>&1 &\n')
+        stdin.write(f"echo starting processor server with '{cmd}'\n")
         stdin.write('echo xyz$!xyz \n exit \n')
         output = stdout.read().decode('utf-8')
         stdout.close()

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -39,7 +39,7 @@ from .utils import (
 
 class Deployer:
     def __init__(self, config_path: str) -> None:
-        self.log = getLogger(__name__)
+        self.log = getLogger('ocrd_network.deployer')
         config = validate_and_load_config(config_path)
 
         self.data_mongo: DataMongoDB = DataMongoDB(config['database'])

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -474,9 +474,12 @@ class Deployer:
         # printed with `echo $!` but it is printed inbetween other output. Because of that I added
         # `xyz` before and after the code to easily be able to filter out the pid via regex when
         # returning from the function
-        log_path = f'/tmp/deployed_{processor_name}.log'
-        stdin.write(f"echo starting processing worker with '{cmd}' >> '{log_path}'\n")
-        stdin.write(f'{cmd} >> {log_path} 2>&1 &\n')
+
+        # TODO: Check here again
+        # log_path = f'/tmp/deployed_{processor_name}.log'
+        # stdin.write(f"echo starting processing worker with '{cmd}' >> '{log_path}'\n")
+        # stdin.write(f'{cmd} >> {log_path} 2>&1 &\n')
+        stdin.write(f'{cmd} &\n')
         stdin.write('echo xyz$!xyz \n exit \n')
         output = stdout.read().decode('utf-8')
         stdout.close()

--- a/ocrd_network/ocrd_network/process_helpers.py
+++ b/ocrd_network/ocrd_network/process_helpers.py
@@ -27,7 +27,7 @@ def invoke_processor(
 
     ctx_mgr = redirect_stderr_and_stdout_to_file(log_filename) if log_filename else nullcontext()
     with ctx_mgr:
-        initLogging()
+        initLogging(force_reinit=True)
         workspace = get_ocrd_workspace_instance(
             mets_path=abs_path_to_mets,
             mets_server_url=mets_server_url

--- a/ocrd_network/ocrd_network/process_helpers.py
+++ b/ocrd_network/ocrd_network/process_helpers.py
@@ -1,9 +1,11 @@
 import json
 from typing import List, Optional
 import logging
+from contextlib import nullcontext
 
 from ocrd.processor.helpers import run_cli, run_processor
 from .utils import get_ocrd_workspace_instance
+from ocrd_utils import redirect_stderr_and_stdout_to_file
 
 
 # A wrapper for run_processor() and run_cli()
@@ -15,44 +17,47 @@ def invoke_processor(
         output_file_grps: List[str],
         page_id: str,
         parameters: dict,
-        mets_server_url: Optional[str] = None
+        mets_server_url: Optional[str] = None,
+        log_filename : str = None,
 ) -> None:
     if not (processor_class or executable):
-        raise ValueError(f'Missing processor class and executable')
+        raise ValueError('Missing processor class and executable')
     input_file_grps_str = ','.join(input_file_grps)
     output_file_grps_str = ','.join(output_file_grps)
 
-    workspace = get_ocrd_workspace_instance(
-        mets_path=abs_path_to_mets,
-        mets_server_url=mets_server_url
-    )
+    ctx_mgr = redirect_stderr_and_stdout_to_file(log_filename) if log_filename else nullcontext()
+    with ctx_mgr:
+        workspace = get_ocrd_workspace_instance(
+            mets_path=abs_path_to_mets,
+            mets_server_url=mets_server_url
+        )
 
-    if processor_class:
-        try:
-            run_processor(
-                processorClass=processor_class,
+        if processor_class:
+            try:
+                run_processor(
+                    processorClass=processor_class,
+                    workspace=workspace,
+                    input_file_grp=input_file_grps_str,
+                    output_file_grp=output_file_grps_str,
+                    page_id=page_id,
+                    parameter=parameters,
+                    instance_caching=True,
+                    mets_server_url=mets_server_url,
+                    log_level=logging.DEBUG
+                )
+            except Exception as e:
+                raise RuntimeError(f"Python executable '{processor_class.__dict__}' exited with: {e}")
+        else:
+            return_code = run_cli(
+                executable=executable,
                 workspace=workspace,
+                mets_url=abs_path_to_mets,
                 input_file_grp=input_file_grps_str,
                 output_file_grp=output_file_grps_str,
                 page_id=page_id,
-                parameter=parameters,
-                instance_caching=True,
+                parameter=json.dumps(parameters),
                 mets_server_url=mets_server_url,
                 log_level=logging.DEBUG
             )
-        except Exception as e:
-            raise RuntimeError(f"Python executable '{processor_class.__dict__}' exited with: {e}")
-    else:
-        return_code = run_cli(
-            executable=executable,
-            workspace=workspace,
-            mets_url=abs_path_to_mets,
-            input_file_grp=input_file_grps_str,
-            output_file_grp=output_file_grps_str,
-            page_id=page_id,
-            parameter=json.dumps(parameters),
-            mets_server_url=mets_server_url,
-            log_level=logging.DEBUG
-        )
-        if return_code != 0:
-            raise RuntimeError(f"CLI executable '{executable}' exited with: {return_code}")
+            if return_code != 0:
+                raise RuntimeError(f"CLI executable '{executable}' exited with: {return_code}")

--- a/ocrd_network/ocrd_network/process_helpers.py
+++ b/ocrd_network/ocrd_network/process_helpers.py
@@ -5,7 +5,7 @@ from contextlib import nullcontext
 
 from ocrd.processor.helpers import run_cli, run_processor
 from .utils import get_ocrd_workspace_instance
-from ocrd_utils import redirect_stderr_and_stdout_to_file
+from ocrd_utils import redirect_stderr_and_stdout_to_file, initLogging
 
 
 # A wrapper for run_processor() and run_cli()
@@ -27,6 +27,7 @@ def invoke_processor(
 
     ctx_mgr = redirect_stderr_and_stdout_to_file(log_filename) if log_filename else nullcontext()
     with ctx_mgr:
+        initLogging()
         workspace = get_ocrd_workspace_instance(
             mets_path=abs_path_to_mets,
             mets_server_url=mets_server_url

--- a/ocrd_network/ocrd_network/process_helpers.py
+++ b/ocrd_network/ocrd_network/process_helpers.py
@@ -1,5 +1,6 @@
 import json
 from typing import List, Optional
+import logging
 
 from ocrd.processor.helpers import run_cli, run_processor
 from .utils import get_ocrd_workspace_instance
@@ -36,7 +37,8 @@ def invoke_processor(
                 page_id=page_id,
                 parameter=parameters,
                 instance_caching=True,
-                mets_server_url=mets_server_url
+                mets_server_url=mets_server_url,
+                log_level=logging.DEBUG
             )
         except Exception as e:
             raise RuntimeError(f"Python executable '{processor_class.__dict__}' exited with: {e}")
@@ -49,7 +51,8 @@ def invoke_processor(
             output_file_grp=output_file_grps_str,
             page_id=page_id,
             parameter=json.dumps(parameters),
-            mets_server_url=mets_server_url
+            mets_server_url=mets_server_url,
+            log_level=logging.DEBUG
         )
         if return_code != 0:
             raise RuntimeError(f"CLI executable '{executable}' exited with: {return_code}")

--- a/ocrd_network/ocrd_network/processing_server.py
+++ b/ocrd_network/ocrd_network/processing_server.py
@@ -70,9 +70,12 @@ class ProcessingServer(FastAPI):
 
     def __init__(self, config_path: str, host: str, port: int) -> None:
         initLogging()
-        super().__init__(on_startup=[self.on_startup], on_shutdown=[self.on_shutdown],
-                         title='OCR-D Processing Server',
-                         description='OCR-D processing and processors')
+        super().__init__(
+            on_startup=[self.on_startup],
+            on_shutdown=[self.on_shutdown],
+            title='OCR-D Processing Server',
+            description='OCR-D Processing Server'
+        )
         self.log = getLogger('ocrd_network.processing_server')
         self.log.info(f"Downloading ocrd all tool json")
         self.ocrd_all_tool_json = download_ocrd_all_tool_json(

--- a/ocrd_network/ocrd_network/processing_server.py
+++ b/ocrd_network/ocrd_network/processing_server.py
@@ -74,13 +74,7 @@ class ProcessingServer(FastAPI):
         super().__init__(on_startup=[self.on_startup], on_shutdown=[self.on_shutdown],
                          title='OCR-D Processing Server',
                          description='OCR-D processing and processors')
-        self.log = getLogger(__name__)
-        # TODO: remove this when refactoring the logging
-        self.log.setLevel(logging.DEBUG)
-        log_fh = logging.FileHandler(f'/tmp/ocrd_processing_server.log')
-        log_fh.setLevel(logging.DEBUG)
-        self.log.addHandler(log_fh)
-
+        self.log = getLogger('ocrd_network.processing_server')
         self.log.info(f"Downloading ocrd all tool json")
         self.ocrd_all_tool_json = download_ocrd_all_tool_json(
             ocrd_all_url="https://ocr-d.de/js/ocrd-all-tool.json"

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -44,14 +44,13 @@ from ocrd_utils import config
 
 class ProcessingWorker:
     def __init__(self, rabbitmq_addr, mongodb_addr, processor_name, ocrd_tool: dict, processor_class=None) -> None:
-        self.log = getLogger('ocrd_network.processing_worker')
-        # TODO: Provide more flexibility for configuring file logging (i.e. via ENV variables)
-        file_handler = logging.FileHandler(f'/tmp/worker_{processor_name}_{getpid()}.log', mode='a')
-        logging_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-        file_handler.setFormatter(logging.Formatter(logging_format))
+        logging_suffix = f'{processor_name}.{getpid()}'
+        self.log = getLogger(f'ocrd_network.processing_worker')
+        file_handler = logging.FileHandler(f'/tmp/worker_{logging_suffix}.log', mode='a')
+        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
         file_handler.setLevel(logging.DEBUG)
         self.log.addHandler(file_handler)
-        # TODO: remove this when refactoring the logging
+        # TODO: removing this line still leads to empty output
         self.log.setLevel(logging.DEBUG)
 
         try:

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -44,7 +44,7 @@ from ocrd_utils import config
 
 class ProcessingWorker:
     def __init__(self, rabbitmq_addr, mongodb_addr, processor_name, ocrd_tool: dict, processor_class=None) -> None:
-        self.log = getLogger(__name__)
+        self.log = getLogger('ocrd_network.processing_worker')
         # TODO: Provide more flexibility for configuring file logging (i.e. via ENV variables)
         file_handler = logging.FileHandler(f'/tmp/worker_{processor_name}_{getpid()}.log', mode='a')
         logging_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -43,11 +43,13 @@ from ocrd_utils import config
 
 
 class ProcessingWorker:
-    def __init__(self, rabbitmq_addr, mongodb_addr, processor_name, ocrd_tool: dict, processor_class=None) -> None:
+    def __init__(self, rabbitmq_addr, mongodb_addr, processor_name, ocrd_tool: dict, processor_class=None, log_filename:str=None) -> None:
         initLogging()
-        logging_suffix = f'{processor_name}.{getpid()}'
         self.log = getLogger(f'ocrd_network.processing_worker')
-        file_handler = logging.FileHandler(f'/tmp/ocrd_worker_{logging_suffix}.log', mode='a')
+        if not log_filename:
+            log_filename = f'/tmp/ocrd_worker_{processor_name}.{getpid()}.log'
+        self.log_filename = log_filename
+        file_handler = logging.FileHandler(log_filename, mode='a')
         file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
         self.log.addHandler(file_handler)
 
@@ -219,6 +221,7 @@ class ProcessingWorker:
                 input_file_grps=input_file_grps,
                 output_file_grps=output_file_grps,
                 page_id=page_id,
+                log_filename=self.log_filename,
                 parameters=processing_message.parameters,
                 mets_server_url=mets_server_url
             )

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -45,7 +45,6 @@ from ocrd_utils import config
 class ProcessingWorker:
     def __init__(self, rabbitmq_addr, mongodb_addr, processor_name, ocrd_tool: dict, processor_class=None) -> None:
         initLogging()
-        self.test_logging()
         logging_suffix = f'{processor_name}.{getpid()}'
         self.log = getLogger(f'ocrd_network.processing_worker')
         file_handler = logging.FileHandler(f'/tmp/ocrd_worker_{logging_suffix}.log', mode='a')
@@ -294,17 +293,3 @@ class ProcessingWorker:
 
         # the following function is idempotent
         self.rmq_publisher.create_queue(queue_name=self.processor_name)
-
-    @staticmethod
-    def test_logging():
-        log_path = "/home/mm/Desktop/my_test.log"
-        log_test = logging.getLogger(f'my_test_to_file')
-        log_test.setLevel(logging.DEBUG)
-        test_file_hdlr = logging.FileHandler(log_path, mode="w")
-        test_file_hdlr.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
-        test_file_hdlr.setLevel(logging.DEBUG)
-        log_test.addHandler(test_file_hdlr)
-
-        for name in logging.root.manager.loggerDict.keys():
-            log_test.debug(f"Name: {name}")
-            log_test.debug(f"{logging.getLogger(name).__dict__}")

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -16,7 +16,7 @@ import pika.spec
 import pika.adapters.blocking_connection
 from pika.exceptions import AMQPConnectionError
 
-from ocrd_utils import getLogger
+from ocrd_utils import initLogging, getLogger
 
 from time import sleep
 
@@ -44,14 +44,13 @@ from ocrd_utils import config
 
 class ProcessingWorker:
     def __init__(self, rabbitmq_addr, mongodb_addr, processor_name, ocrd_tool: dict, processor_class=None) -> None:
+        initLogging()
+        self.test_logging()
         logging_suffix = f'{processor_name}.{getpid()}'
         self.log = getLogger(f'ocrd_network.processing_worker')
-        file_handler = logging.FileHandler(f'/tmp/worker_{logging_suffix}.log', mode='a')
+        file_handler = logging.FileHandler(f'/tmp/ocrd_worker_{logging_suffix}.log', mode='a')
         file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
-        file_handler.setLevel(logging.DEBUG)
         self.log.addHandler(file_handler)
-        # TODO: removing this line still leads to empty output
-        self.log.setLevel(logging.DEBUG)
 
         try:
             verify_database_uri(mongodb_addr)
@@ -295,3 +294,17 @@ class ProcessingWorker:
 
         # the following function is idempotent
         self.rmq_publisher.create_queue(queue_name=self.processor_name)
+
+    @staticmethod
+    def test_logging():
+        log_path = "/home/mm/Desktop/my_test.log"
+        log_test = logging.getLogger(f'my_test_to_file')
+        log_test.setLevel(logging.DEBUG)
+        test_file_hdlr = logging.FileHandler(log_path, mode="w")
+        test_file_hdlr.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        test_file_hdlr.setLevel(logging.DEBUG)
+        log_test.addHandler(test_file_hdlr)
+
+        for name in logging.root.manager.loggerDict.keys():
+            log_test.debug(f"Name: {name}")
+            log_test.debug(f"{logging.getLogger(name).__dict__}")

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -16,7 +16,7 @@ import pika.spec
 import pika.adapters.blocking_connection
 from pika.exceptions import AMQPConnectionError
 
-from ocrd_utils import initLogging, getLogger
+from ocrd_utils import getLogger
 
 from time import sleep
 
@@ -44,7 +44,6 @@ from ocrd_utils import config
 
 class ProcessingWorker:
     def __init__(self, rabbitmq_addr, mongodb_addr, processor_name, ocrd_tool: dict, processor_class=None, log_filename:str=None) -> None:
-        initLogging()
         self.log = getLogger(f'ocrd_network.processing_worker')
         if not log_filename:
             log_filename = f'/tmp/ocrd_worker_{processor_name}.{getpid()}.log'

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -10,7 +10,7 @@ is a single OCR-D Processor instance.
 
 from datetime import datetime
 import logging
-from os import getpid
+from os import getpid, makedirs
 
 import pika.spec
 import pika.adapters.blocking_connection
@@ -49,9 +49,10 @@ class ProcessingWorker:
         if not log_filename:
             log_filename = f'/tmp/ocrd_worker_{processor_name}.{getpid()}.log'
         self.log_filename = log_filename
-        file_handler = logging.FileHandler(log_filename, mode='a')
-        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
-        self.log.addHandler(file_handler)
+        # TODO: Use that handler once the separate job logs is resolved
+        # file_handler = logging.FileHandler(log_filename, mode='a')
+        # file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        # self.log.addHandler(file_handler)
 
         try:
             verify_database_uri(mongodb_addr)
@@ -214,6 +215,9 @@ class ProcessingWorker:
             start_time=start_time
         )
         try:
+            # TODO: Refactor the root logging dir for jobs
+            # makedirs(name='/tmp/ocrd_processing_jobs_logs', exist_ok=True)
+            # log_filename = f'/tmp/ocrd_processing_jobs_logs/{job_id}.log'
             invoke_processor(
                 processor_class=self.processor_class,
                 executable=self.processor_name,

--- a/ocrd_network/ocrd_network/processor_server.py
+++ b/ocrd_network/ocrd_network/processor_server.py
@@ -41,7 +41,7 @@ class ProcessorServer(FastAPI):
     def __init__(self, mongodb_addr: str, processor_name: str = "", processor_class=None):
         if not (processor_name or processor_class):
             raise ValueError('Either "processor_name" or "processor_class" must be provided')
-        self.log = getLogger(__name__)
+        self.log = getLogger('ocrd_network.processor_server')
 
         self.db_url = mongodb_addr
         self.processor_name = processor_name

--- a/ocrd_network/ocrd_network/processor_server.py
+++ b/ocrd_network/ocrd_network/processor_server.py
@@ -7,6 +7,7 @@ import uvicorn
 from fastapi import FastAPI, HTTPException, status
 
 from ocrd_utils import (
+    initLogging,
     get_ocrd_tool_json,
     getLogger,
     parse_json_string_with_comments,
@@ -41,7 +42,12 @@ class ProcessorServer(FastAPI):
     def __init__(self, mongodb_addr: str, processor_name: str = "", processor_class=None):
         if not (processor_name or processor_class):
             raise ValueError('Either "processor_name" or "processor_class" must be provided')
+        initLogging()
+        logging_suffix = f'{processor_name}.{getpid()}'
         self.log = getLogger('ocrd_network.processor_server')
+        file_handler = logging.FileHandler(f'/tmp/ocrd_server_{logging_suffix}.log', mode='a')
+        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        self.log.addHandler(file_handler)
 
         self.db_url = mongodb_addr
         self.processor_name = processor_name

--- a/ocrd_network/ocrd_network/processor_server.py
+++ b/ocrd_network/ocrd_network/processor_server.py
@@ -239,12 +239,6 @@ class ProcessorServer(FastAPI):
         return version_str
 
     def run_server(self, host, port, access_log=False):
-        # TODO: Provide more flexibility for configuring file logging (i.e. via ENV variables)
-        file_handler = logging.FileHandler(f'/tmp/server_{self.processor_name}_{port}_{getpid()}.log', mode='a')
-        logging_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-        file_handler.setFormatter(logging.Formatter(logging_format))
-        file_handler.setLevel(logging.DEBUG)
-        self.log.addHandler(file_handler)
         uvicorn.run(self, host=host, port=port, access_log=access_log)
 
     async def get_processor_job(self, processor_name: str, job_id: str) -> PYJobOutput:

--- a/ocrd_network/ocrd_network/rabbitmq_utils/connector.py
+++ b/ocrd_network/ocrd_network/rabbitmq_utils/connector.py
@@ -4,15 +4,8 @@ some part of the source code from the official
 RabbitMQ documentation.
 """
 from typing import Any, Optional, Union
-
-from pika import (
-    BasicProperties,
-    BlockingConnection,
-    ConnectionParameters,
-    PlainCredentials
-)
+from pika import BasicProperties, BlockingConnection, ConnectionParameters, PlainCredentials
 from pika.adapters.blocking_connection import BlockingChannel
-
 from .constants import (
     DEFAULT_EXCHANGER_NAME,
     DEFAULT_EXCHANGER_TYPE,
@@ -26,8 +19,7 @@ from .constants import (
 
 
 class RMQConnector:
-    def __init__(self, logger, host: str = HOST, port: int = PORT, vhost: str = VHOST) -> None:
-        self._logger = logger
+    def __init__(self, host: str = HOST, port: int = PORT, vhost: str = VHOST) -> None:
         self._host = host
         self._port = port
         self._vhost = vhost
@@ -54,10 +46,7 @@ class RMQConnector:
                     exchange_type=DEFAULT_EXCHANGER_TYPE,
                 )
                 # Declare the default queue
-                RMQConnector.queue_declare(
-                    channel,
-                    queue_name=DEFAULT_QUEUE
-                )
+                RMQConnector.queue_declare(channel, queue_name=DEFAULT_QUEUE)
                 # Bind the default queue to the default exchange
                 RMQConnector.queue_bind(
                     channel,
@@ -142,8 +131,11 @@ class RMQConnector:
             return exchange
 
     @staticmethod
-    def exchange_delete(channel: BlockingChannel, exchange_name: str,
-                        if_unused: bool = False) -> None:
+    def exchange_delete(
+            channel: BlockingChannel,
+            exchange_name: str,
+            if_unused: bool = False
+    ) -> None:
         # Deletes queue only if unused
         if channel and channel.is_open:
             channel.exchange_delete(exchange=exchange_name, if_unused=if_unused)
@@ -167,8 +159,13 @@ class RMQConnector:
             )
 
     @staticmethod
-    def queue_bind(channel: BlockingChannel, queue_name: str, exchange_name: str, routing_key: str,
-                   arguments: Optional[Any] = None) -> None:
+    def queue_bind(
+            channel: BlockingChannel,
+            queue_name: str,
+            exchange_name: str,
+            routing_key: str,
+            arguments: Optional[Any] = None
+    ) -> None:
         if arguments is None:
             arguments = {}
         if channel and channel.is_open:
@@ -204,8 +201,12 @@ class RMQConnector:
             return queue
 
     @staticmethod
-    def queue_delete(channel: BlockingChannel, queue_name: str, if_unused: bool = False,
-                     if_empty: bool = False) -> None:
+    def queue_delete(
+            channel: BlockingChannel,
+            queue_name: str,
+            if_unused: bool = False,
+            if_empty: bool = False
+    ) -> None:
         if channel and channel.is_open:
             channel.queue_delete(
                 queue=queue_name,
@@ -221,8 +222,13 @@ class RMQConnector:
             channel.queue_purge(queue=queue_name)
 
     @staticmethod
-    def queue_unbind(channel: BlockingChannel, queue_name: str, exchange_name: str,
-                     routing_key: str, arguments: Optional[Any] = None) -> None:
+    def queue_unbind(
+            channel: BlockingChannel,
+            queue_name: str,
+            exchange_name: str,
+            routing_key: str,
+            arguments: Optional[Any] = None
+    ) -> None:
         if arguments is None:
             arguments = {}
         if channel and channel.is_open:
@@ -234,8 +240,12 @@ class RMQConnector:
             )
 
     @staticmethod
-    def set_qos(channel: BlockingChannel, prefetch_size: int = 0,
-                prefetch_count: int = PREFETCH_COUNT, global_qos: bool = False) -> None:
+    def set_qos(
+            channel: BlockingChannel,
+            prefetch_size: int = 0,
+            prefetch_count: int = PREFETCH_COUNT,
+            global_qos: bool = False
+    ) -> None:
         if channel and channel.is_open:
             channel.basic_qos(
                 # No specific limit if set to 0
@@ -251,8 +261,13 @@ class RMQConnector:
             channel.confirm_delivery()
 
     @staticmethod
-    def basic_publish(channel: BlockingChannel, exchange_name: str, routing_key: str,
-                      message_body: bytes, properties: BasicProperties) -> None:
+    def basic_publish(
+            channel: BlockingChannel,
+            exchange_name: str,
+            routing_key: str,
+            message_body: bytes,
+            properties: BasicProperties
+    ) -> None:
         if channel and channel.is_open:
             channel.basic_publish(
                 exchange=exchange_name,

--- a/ocrd_network/ocrd_network/rabbitmq_utils/constants.py
+++ b/ocrd_network/ocrd_network/rabbitmq_utils/constants.py
@@ -11,8 +11,6 @@ __all__ = [
     'RECONNECT_WAIT',
     'RECONNECT_TRIES',
     'PREFETCH_COUNT',
-    'LOG_FORMAT',
-    'LOG_LEVEL'
 ]
 
 DEFAULT_EXCHANGER_NAME: str = 'ocrd-network-default'
@@ -32,7 +30,3 @@ RECONNECT_TRIES: int = 3
 # QOS, i.e., how many messages to consume in a single go
 # Check here: https://www.rabbitmq.com/consumer-prefetch.html
 PREFETCH_COUNT: int = 1
-
-# TODO: Integrate the OCR-D Logger once the logging in OCR-D is improved/optimized
-LOG_FORMAT: str = '%(levelname) -10s %(asctime)s %(name) -30s %(funcName) -35s %(lineno) -5d: %(message)s'
-LOG_LEVEL: int = logging.WARNING

--- a/ocrd_network/ocrd_network/rabbitmq_utils/consumer.py
+++ b/ocrd_network/ocrd_network/rabbitmq_utils/consumer.py
@@ -11,7 +11,6 @@ from pika import PlainCredentials
 
 from .constants import (
     DEFAULT_QUEUE,
-    LOG_LEVEL,
     RABBIT_MQ_HOST as HOST,
     RABBIT_MQ_PORT as PORT,
     RABBIT_MQ_VHOST as VHOST
@@ -25,9 +24,6 @@ class RMQConsumer(RMQConnector):
         if not logger_name:
             logger_name = __name__
         logger = logging.getLogger(logger_name)
-        logging.getLogger(logger_name).setLevel(LOG_LEVEL)
-        # This may mess up the global logger
-        logging.basicConfig(level=logging.WARNING)
         super().__init__(logger=logger, host=host, port=port, vhost=vhost)
 
         self.consumer_tag = None

--- a/ocrd_network/ocrd_network/rabbitmq_utils/publisher.py
+++ b/ocrd_network/ocrd_network/rabbitmq_utils/publisher.py
@@ -15,8 +15,6 @@ from pika import (
 from .constants import (
     DEFAULT_EXCHANGER_NAME,
     DEFAULT_ROUTER,
-    LOG_FORMAT,
-    LOG_LEVEL,
     RABBIT_MQ_HOST as HOST,
     RABBIT_MQ_PORT as PORT,
     RABBIT_MQ_VHOST as VHOST
@@ -30,9 +28,6 @@ class RMQPublisher(RMQConnector):
         if logger_name is None:
             logger_name = __name__
         logger = logging.getLogger(logger_name)
-        logging.getLogger(logger_name).setLevel(LOG_LEVEL)
-        # This may mess up the global logger
-        logging.basicConfig(level=logging.WARNING)
         super().__init__(logger=logger, host=host, port=port, vhost=vhost)
 
         self.message_counter = 0

--- a/ocrd_network/ocrd_network/rabbitmq_utils/publisher.py
+++ b/ocrd_network/ocrd_network/rabbitmq_utils/publisher.py
@@ -3,15 +3,9 @@ The source code in this file is adapted by reusing
 some part of the source code from the official
 RabbitMQ documentation.
 """
-
-import logging
 from typing import Optional
-
-from pika import (
-    BasicProperties,
-    PlainCredentials
-)
-
+from pika import BasicProperties, PlainCredentials
+from ocrd_utils import getLogger
 from .constants import (
     DEFAULT_EXCHANGER_NAME,
     DEFAULT_ROUTER,
@@ -23,13 +17,9 @@ from .connector import RMQConnector
 
 
 class RMQPublisher(RMQConnector):
-    def __init__(self, host: str = HOST, port: int = PORT, vhost: str = VHOST,
-                 logger_name: str = None) -> None:
-        if logger_name is None:
-            logger_name = __name__
-        logger = logging.getLogger(logger_name)
-        super().__init__(logger=logger, host=host, port=port, vhost=vhost)
-
+    def __init__(self, host: str = HOST, port: int = PORT, vhost: str = VHOST) -> None:
+        self.log = getLogger('ocrd_network.rabbitmq_utils.publisher')
+        super().__init__(host=host, port=port, vhost=vhost)
         self.message_counter = 0
         self.deliveries = {}
         self.acked_counter = 0
@@ -93,9 +83,9 @@ class RMQPublisher(RMQConnector):
         if exchange_name is None:
             exchange_name = DEFAULT_EXCHANGER_NAME
         if properties is None:
-            headers = {'OCR-D WebApi Header': 'OCR-D WebApi Value'}
+            headers = {'ocrd_network default header': 'ocrd_network default header value'}
             properties = BasicProperties(
-                app_id='webapi-processing-server',
+                app_id='ocrd_network default app id',
                 content_type='application/json',
                 headers=headers
             )
@@ -114,8 +104,8 @@ class RMQPublisher(RMQConnector):
 
         self.message_counter += 1
         self.deliveries[self.message_counter] = True
-        self._logger.info(f'Published message #{self.message_counter}')
+        self.log.debug(f'Published message #{self.message_counter}')
 
     def enable_delivery_confirmations(self) -> None:
-        self._logger.debug('Enabling delivery confirmations (Confirm.Select RPC)')
+        self.log.debug('Enabling delivery confirmations (Confirm.Select RPC)')
         RMQConnector.confirm_delivery(channel=self._channel)

--- a/ocrd_utils/ocrd_logging.conf
+++ b/ocrd_utils/ocrd_logging.conf
@@ -11,7 +11,7 @@
 # each logger requires a corresponding configuration section below
 #
 [loggers]
-keys=root,ocrd_tensorflow,ocrd_shapely_geos,ocrd_PIL
+keys=root,ocrd,ocrd_network,ocrd_models,ocrd_tensorflow,ocrd_shapely_geos,ocrd_PIL
 
 #
 # mandatory handlers section
@@ -20,7 +20,7 @@ keys=root,ocrd_tensorflow,ocrd_shapely_geos,ocrd_PIL
 # each handler requires a corresponding configuration section below
 #
 [handlers]
-keys=consoleHandler,fileHandler
+keys=consoleHandler,fileHandler,processingServerHandler
 
 #
 # optional custom formatters section
@@ -54,19 +54,23 @@ handlers=consoleHandler
 #qualname=ocrd.workspace
 
 # ocrd loggers
-[logger_ocrd_ocrd]
+[logger_ocrd]
 level=ERROR
 handlers=consoleHandler
 qualname=ocrd
+propagate=0
 
-[logger_ocrd_ocrd_models]
+[logger_ocrd_models]
 level=INFO
 handlers=consoleHandler
 qualname=ocrd_models
-[logger_ocrd_ocrd_network]
+propagate=0
+
+[logger_ocrd_network]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler,processingServerHandler
 qualname=ocrd_network
+propagate=0
 
 #
 # logger tensorflow
@@ -110,6 +114,11 @@ args=(sys.stderr,)
 class=FileHandler
 formatter=detailedFormatter
 args=('ocrd.log','a+')
+
+[handler_processingServerHandler]
+class=FileHandler
+formatter=defaultFormatter
+args=('/tmp/ocrd_processing_server.log','a+')
 
 #
 # default log format conforming to OCR-D (https://ocr-d.de/en/spec/cli#logging)

--- a/ocrd_utils/ocrd_logging.conf
+++ b/ocrd_utils/ocrd_logging.conf
@@ -63,19 +63,10 @@ qualname=ocrd
 level=INFO
 handlers=consoleHandler
 qualname=ocrd_models
-[logger_ocrd_ocrd_utils]
-level=INFO
-handlers=consoleHandler
-qualname=ocrd_utils
 [logger_ocrd_ocrd_network]
-level=INFO
+level=DEBUG
 handlers=consoleHandler
 qualname=ocrd_network
-[logger_ocrd_ocrd_exif]
-level=INFO
-handlers=consoleHandler
-qualname=ocrd_exif
-
 
 #
 # logger tensorflow

--- a/ocrd_utils/ocrd_logging.conf
+++ b/ocrd_utils/ocrd_logging.conf
@@ -11,7 +11,7 @@
 # each logger requires a corresponding configuration section below
 #
 [loggers]
-keys=root,ocrd,ocrd_network,ocrd_models,ocrd_tensorflow,ocrd_shapely_geos,ocrd_PIL
+keys=root,ocrd,ocrd_network,ocrd_models,ocrd_tensorflow,ocrd_shapely_geos,ocrd_PIL,uvicorn,uvicorn_access,uvicorn_error
 
 #
 # mandatory handlers section
@@ -96,6 +96,23 @@ qualname=shapely.geos
 level=INFO
 handlers=consoleHandler
 qualname=PIL
+
+#
+# uvicorn loggers
+#
+[logger_uvicorn]
+level=INFO
+handlers=consoleHandler
+qualname=uvicorn
+[logger_uvicorn_access]
+level=DEBUG
+handlers=consoleHandler
+qualname=uvicorn.access
+[logger_uvicorn_error]
+level=DEBUG
+handlers=consoleHandler
+qualname=uvicorn.error
+
 
 
 #

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -182,6 +182,7 @@ from .os import (
     atomic_write,
     pushd_popd,
     unzip_file_to_dir,
+    redirect_stderr_and_stdout_to_file,
     )
 
 from .str import (

--- a/ocrd_utils/ocrd_utils/image.py
+++ b/ocrd_utils/ocrd_utils/image.py
@@ -212,7 +212,7 @@ def rotate_coordinates(transform, angle, orig=np.array([0, 0])):
     
     Return a numpy array of the resulting affine transformation matrix.
     """
-    LOG = getLogger('ocrd_utils.coords.rotate_coordinates')
+    LOG = getLogger('ocrd.utils.coords.rotate_coordinates')
     rad = np.deg2rad(angle)
     cos = np.cos(rad)
     sin = np.sin(rad)
@@ -254,7 +254,7 @@ def rotate_image(image, angle, fill='background', transparency=False):
 
     Return a new PIL.Image.
     """
-    LOG = getLogger('ocrd_utils.rotate_image')
+    LOG = getLogger('ocrd.utils.rotate_image')
     LOG.debug('rotating image by %.2f°', angle)
     if transparency and image.mode in ['RGB', 'L']:
         # ensure no information is lost by adding transparency channel
@@ -298,7 +298,7 @@ def shift_coordinates(transform, offset):
     
     Return a numpy array of the resulting affine transformation matrix.
     """
-    LOG = getLogger('ocrd_utils.coords.shift_coordinates')
+    LOG = getLogger('ocrd.utils.coords.shift_coordinates')
     LOG.debug('shifting coordinates by %s', str(offset))
     shift = np.eye(3)
     shift[0, 2] = offset[0]
@@ -315,7 +315,7 @@ def scale_coordinates(transform, factors):
     
     Return a numpy array of the resulting affine transformation matrix.
     """
-    LOG = getLogger('ocrd_utils.coords.scale_coordinates')
+    LOG = getLogger('ocrd.utils.coords.scale_coordinates')
     LOG.debug('scaling coordinates by %s', str(factors))
     scale = np.eye(3)
     scale[0, 0] = factors[0]
@@ -374,7 +374,7 @@ def transpose_coordinates(transform, method, orig=np.array([0, 0])):
 
     Return a numpy array of the resulting affine transformation matrix.
     """
-    LOG = getLogger('ocrd_utils.coords.transpose_coordinates')
+    LOG = getLogger('ocrd.utils.coords.transpose_coordinates')
     LOG.debug('transposing coordinates with %s around %s', membername(Image, method), str(orig))
     # get rotation matrix for passive rotation/reflection:
     rot90 = np.array([[0, 1, 0],
@@ -441,7 +441,7 @@ def transpose_image(image, method):
     
     Return a new PIL.Image.
     """
-    LOG = getLogger('ocrd_utils.transpose_image')
+    LOG = getLogger('ocrd.utils.transpose_image')
     LOG.debug('transposing image with %s', membername(Image, method))
     return image.transpose(method)
 
@@ -459,7 +459,7 @@ def crop_image(image, box=None):
 
     Return a new PIL.Image.
     """
-    LOG = getLogger('ocrd_utils.crop_image')
+    LOG = getLogger('ocrd.utils.crop_image')
     if not box:
         box = (0, 0, image.width, image.height)
     elif box[0] < 0 or box[1] < 0 or box[2] > image.width or box[3] > image.height:

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -48,10 +48,7 @@ __all__ = [
 
 LOGGING_DEFAULTS = {
     'ocrd': logging.INFO,
-    'ocrd_models': logging.INFO,
-    'ocrd_utils': logging.INFO,
-    'ocrd_network': logging.INFO,
-    'ocrd_exif': logging.INFO,
+    'ocrd_network': logging.DEBUG,
     # 'ocrd.resolver': logging.INFO,
     # 'ocrd.resolver.download_to_directory': logging.INFO,
     # 'ocrd.resolver.add_files_to_mets': logging.INFO,
@@ -59,6 +56,7 @@ LOGGING_DEFAULTS = {
     'shapely.geos': logging.ERROR,
     'tensorflow': logging.ERROR,
     'PIL': logging.INFO,
+    'paramiko.transport': logging.INFO
 }
 
 _initialized_flag = False
@@ -94,8 +92,6 @@ def getLogger(*args, **kwargs):
     Wrapper around ``logging.getLogger`` that alls :py:func:`initLogging` if
     that wasn't explicitly called before.
     """
-    if not _initialized_flag:
-        initLogging()
     logger = logging.getLogger(*args, **kwargs)
     return logger
 

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -62,7 +62,10 @@ LOGGING_DEFAULTS = {
     'shapely.geos': logging.ERROR,
     'tensorflow': logging.ERROR,
     'PIL': logging.INFO,
-    'paramiko.transport': logging.INFO
+    'paramiko.transport': logging.INFO,
+    'uvicorn.access': logging.DEBUG,
+    'uvicorn.error': logging.DEBUG,
+    'uvicorn': logging.INFO
 }
 
 _initialized_flag = False

--- a/ocrd_utils/ocrd_utils/logging.py
+++ b/ocrd_utils/ocrd_utils/logging.py
@@ -46,6 +46,12 @@ __all__ = [
     'setOverrideLogLevel',
 ]
 
+# These are the loggers we add handlers to
+ROOT_OCRD_LOGGERS = [
+    'ocrd',
+    'ocrd_network'
+]
+
 LOGGING_DEFAULTS = {
     'ocrd': logging.INFO,
     'ocrd_network': logging.DEBUG,
@@ -144,9 +150,10 @@ def initLogging(builtin_only=False, force_reinit=False):
     # levels of individual loggers.
     logging.disable(logging.NOTSET)
 
-    # remove all handlers for the ocrd logger
-    for handler in logging.getLogger('ocrd').handlers[:]:
-        logging.getLogger('ocrd').removeHandler(handler)
+    # remove all handlers for the ocrd root loggers
+    for logger_name in ROOT_OCRD_LOGGERS:
+        for handler in logging.getLogger(logger_name).handlers[:]:
+            logging.getLogger(logger_name).removeHandler(handler)
 
     config_file = None
     if not builtin_only:
@@ -167,7 +174,8 @@ def initLogging(builtin_only=False, force_reinit=False):
         ocrd_handler = logging.StreamHandler(stream=sys.stderr)
         ocrd_handler.setFormatter(logging.Formatter(fmt=LOG_FORMAT, datefmt=LOG_TIMEFMT))
         ocrd_handler.setLevel(logging.DEBUG)
-        logging.getLogger('ocrd').addHandler(ocrd_handler)
+        for logger_name in ROOT_OCRD_LOGGERS:
+            logging.getLogger(logger_name).addHandler(ocrd_handler)
         for logger_name, logger_level in LOGGING_DEFAULTS.items():
             logging.getLogger(logger_name).setLevel(logger_level)
 
@@ -187,8 +195,9 @@ def disableLogging(silent=True):
     # logging.basicConfig(level=logging.CRITICAL)
     # logging.disable(logging.ERROR)
     # remove all handlers for the ocrd logger
-    for handler in logging.getLogger('ocrd').handlers[:]:
-        logging.getLogger('ocrd').removeHandler(handler)
+    for logger_name in ROOT_OCRD_LOGGERS:
+        for handler in logging.getLogger(logger_name).handlers[:]:
+            logging.getLogger(logger_name).removeHandler(handler)
     for logger_name in LOGGING_DEFAULTS:
         logging.getLogger(logger_name).setLevel(logging.NOTSET)
 

--- a/ocrd_utils/ocrd_utils/os.py
+++ b/ocrd_utils/ocrd_utils/os.py
@@ -82,7 +82,7 @@ def get_ocrd_tool_json(executable):
     try:
         ocrd_tool = loads(run([executable, '--dump-json'], stdout=PIPE).stdout)
     except (JSONDecodeError, OSError) as e:
-        getLogger('ocrd_utils.get_ocrd_tool_json').error(f'{executable} --dump-json produced invalid JSON: {e}')
+        getLogger('ocrd.utils.get_ocrd_tool_json').error(f'{executable} --dump-json produced invalid JSON: {e}')
         ocrd_tool = {}
     if 'resource_locations' not in ocrd_tool:
         ocrd_tool['resource_locations'] = ['data', 'cwd', 'system', 'module']
@@ -94,7 +94,7 @@ def get_moduledir(executable):
     try:
         moduledir = run([executable, '--dump-module-dir'], encoding='utf-8', stdout=PIPE).stdout.rstrip('\n')
     except (JSONDecodeError, OSError) as e:
-        getLogger('ocrd_utils.get_moduledir').error(f'{executable} --dump-module-dir failed: {e}')
+        getLogger('ocrd.utils.get_moduledir').error(f'{executable} --dump-module-dir failed: {e}')
     return moduledir
 
 def list_resource_candidates(executable, fname, cwd=getcwd(), moduled=None, xdg_data_home=None):

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -28,21 +28,21 @@ class TestLogCli(TestCase):
             del(ENV['OCRD_TOOL_NAME'])
 
     def test_loglevel(self):
-        assert 'DEBUG ocrd - foo' not in self._get_log_output('log', 'debug', 'foo')
-        assert 'DEBUG ocrd - foo' in self._get_log_output('-l', 'DEBUG', 'log', 'debug', 'foo')
+        assert 'DEBUG ocrd.log_cli - foo' not in self._get_log_output('log', 'debug', 'foo')
+        assert 'DEBUG ocrd.log_cli - foo' in self._get_log_output('-l', 'DEBUG', 'log', 'debug', 'foo')
 
     def test_log_basic(self):
-        assert 'INFO ocrd - foo bar' in self._get_log_output('log', 'info', 'foo bar')
+        assert 'INFO ocrd.log_cli - foo bar' in self._get_log_output('log', 'info', 'foo bar')
 
     def test_log_name_param(self):
-        assert 'INFO ocrd.boo.far - foo bar' in self._get_log_output('log', '--name', 'ocrd.boo.far', 'info', 'foo bar')
+        assert 'INFO ocrd.boo.far - foo bar' in self._get_log_output('log', '--name', 'boo.far', 'info', 'foo bar')
 
     def test_log_name_envvar(self):
-        ENV['OCRD_TOOL_NAME'] = 'ocrd.boo.far'
+        ENV['OCRD_TOOL_NAME'] = 'boo.far'
         assert 'INFO ocrd.boo.far - foo bar' in self._get_log_output('log', 'info', 'foo bar')
 
     def test_log_name_levels(self):
-        ENV['OCRD_TOOL_NAME'] = 'ocrd.foo'
+        ENV['OCRD_TOOL_NAME'] = 'foo'
         assert 'DEBUG ocrd.foo - foo' in self._get_log_output('-l', 'DEBUG', 'log', 'debug', 'foo')
         assert 'DEBUG ocrd.foo - foo' in self._get_log_output('-l', 'DEBUG', 'log', 'trace', 'foo')
         assert 'INFO ocrd.foo - foo' in  self._get_log_output('log', 'info', 'foo')

--- a/tests/test_resolver_oai.py
+++ b/tests/test_resolver_oai.py
@@ -91,7 +91,7 @@ def test_handle_response_for_invalid_content(mock_get, response_dir):
     initLogging()
 
     # capture log
-    log = getLogger('ocrd_models.utils.handle_oai_response')
+    log = getLogger('ocrd.models.utils.handle_oai_response')
     capt = FIFOIO(256)
     sh = StreamHandler(capt)
     sh.setFormatter(Formatter(LOG_FORMAT))
@@ -103,7 +103,7 @@ def test_handle_response_for_invalid_content(mock_get, response_dir):
     # assert
     mock_get.assert_called_once_with(url, timeout=None)
     log_output = capt.getvalue()
-    assert 'WARNING ocrd_models.utils.handle_oai_response' in log_output
+    assert 'WARNING ocrd.models.utils.handle_oai_response' in log_output
 
 
 if __name__ == '__main__':

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -568,7 +568,7 @@ def test_deskewing(plain_workspace):
     logger_capture = FIFOIO(256)
     logger_handler = logging.StreamHandler(logger_capture)
     #logger_handler.setFormatter(logging.Formatter(fmt=LOG_FORMAT, datefmt=LOG_TIMEFMT))
-    logger = logging.getLogger('ocrd_utils.crop_image')
+    logger = logging.getLogger('ocrd.utils.crop_image')
     logger.addHandler(logger_handler)
     reg_image2, reg_coords2 = plain_workspace.image_from_segment(region, page_image, page_coords, fill=0)
     #reg_image2.show(title='reg_image2')

--- a/tests/utils/test_os.py
+++ b/tests/utils/test_os.py
@@ -4,9 +4,11 @@ from shutil import rmtree
 from pathlib import Path
 from os import environ as ENV, getcwd
 from os.path import expanduser, join
+import sys
 
 from ocrd_utils.os import (
     list_resource_candidates,
+    redirect_stderr_and_stdout_to_file,
     guess_media_type,
 )
 
@@ -45,6 +47,17 @@ class TestOsUtils(TestCase):
         assert guess_media_type(testdata / 'mets-with-metsDocumentID.xml') == 'application/xml'
         assert guess_media_type(testdata / 'mets-with-metsDocumentID.xml', application_xml='text/x-mets') == 'text/x-mets'
 
+    def test_redirect_stderr_and_stdout_to_file(self):
+        # TODO test logging is redirected properly without running into
+        # pytest's capturing intricacies
+        fname = '/tmp/test-redirect.txt'
+        Path(fname).write_bytes(b'')
+        with redirect_stderr_and_stdout_to_file(fname):
+            print('one')
+            sys.stdout.write('two\n')
+            sys.stderr.write('three\n')
+            print('four', file=sys.stderr)
+        assert Path(fname).read_text(encoding='utf-8') == 'one\ntwo\nthree\nfour\n'
 
 if __name__ == '__main__':
     main(__file__)


### PR DESCRIPTION
This includes #1101 and updates the default config, builtin and config file, to offer the same behavior as the hard-coded logging `ocrd_network`.

I did add a file handler for the processing serverlog, as it was before, so you get the idea on how to adapt the server cache logging as well.

I did not remove the hard-coded logging configuration in ocrd_network though, since @MehmedGIT & @joschrew know best what the exact behavior should be.

The easies way to fine-tune the logging setup is to copy `ocrd_utils/ocrd_logging.conf` to `$PWD` (or `$HOME`), then remove the coded logging setup and translate it into the config file syntax and add your changes to this PR, then we can merge it to #1083 (as this PR proposes) or into master if we decide to merge #1089 into master before finishing the logging stuff.

Ideally, we should change the root logger from `ocrd_network` to `ocrd.network`. That way, we only need one logger definition but it's not urgent.