### PR TITLE
Improve ocrd_network logging

### DIFF
--- a/ocrd/ocrd/cli/__init__.py
+++ b/ocrd/ocrd/cli/__init__.py
@@ -48,6 +48,10 @@ Variables:
 {config.describe('OCRD_PROFILE_FILE')}
 \b
 {config.describe('OCRD_PROFILE', wrap_text=False)}
+\b
+{config.describe('OCRD_NETWORK_SOCKETS_ROOT_DIR')}
+\b
+{config.describe('OCRD_NETWORK_LOGS_ROOT_DIR')}
 """
 
 def command_with_replaced_help(*replacements):

--- a/ocrd_network/ocrd_network/database.py
+++ b/ocrd_network/ocrd_network/database.py
@@ -166,6 +166,8 @@ async def db_update_processing_job(job_id: str, **kwargs) -> DBProcessorJob:
             job.path_to_mets = value
         elif key == 'exec_time':
             job.exec_time = value
+        elif key == 'log_file_path':
+            job.log_file_path = value
         else:
             raise ValueError(f'Field "{key}" is not updatable.')
     await job.save()

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -12,6 +12,7 @@ from re import search as re_search
 from pathlib import Path
 import subprocess
 from time import sleep
+from tempfile import gettempdir
 
 from ocrd_utils import getLogger, safe_filename
 
@@ -522,7 +523,7 @@ class Deployer:
     # TODO: No support for TCP version yet
     def start_unix_mets_server(self, mets_path: str) -> str:
         log_file = get_mets_server_logging_file_path(mets_path=mets_path)
-        mets_server_url = f'/tmp/{safe_filename(mets_path)}.sock'
+        mets_server_url = f'{gettempdir()}/{safe_filename(mets_path)}.sock'
 
         if is_mets_server_running(mets_server_url=mets_server_url):
             self.log.info(f"The mets server is already started: {mets_server_url}")

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -535,7 +535,7 @@ class Deployer:
                   '-d', f'{cwd}', 'server', 'start'],
             shell=False,
             stdout=open(file=log_file, mode='w'),
-            stderr=open(file=log_file, mode='w'),
+            stderr=open(file=log_file, mode='a'),
             cwd=cwd,
             universal_newlines=True
         )

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -12,9 +12,8 @@ from re import search as re_search
 from pathlib import Path
 import subprocess
 from time import sleep
-from tempfile import gettempdir
 
-from ocrd_utils import getLogger, safe_filename
+from ocrd_utils import config, getLogger, safe_filename
 
 from .deployment_utils import (
     create_docker_client,
@@ -521,11 +520,11 @@ class Deployer:
         return re_search(r'xyz([0-9]+)xyz', output).group(1)  # type: ignore
 
     # TODO: No support for TCP version yet
-    def start_unix_mets_server(self, mets_path: str) -> str:
+    def start_unix_mets_server(self, mets_path: str) -> Path:
         log_file = get_mets_server_logging_file_path(mets_path=mets_path)
-        mets_server_url = f'{gettempdir()}/{safe_filename(mets_path)}.sock'
+        mets_server_url = Path(config.OCRD_NETWORK_SOCKETS_ROOT_DIR, f"{safe_filename(mets_path)}.sock")
 
-        if is_mets_server_running(mets_server_url=mets_server_url):
+        if is_mets_server_running(mets_server_url=str(mets_server_url)):
             self.log.info(f"The mets server is already started: {mets_server_url}")
             return mets_server_url
 

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -546,9 +546,8 @@ class Deployer:
 
     def stop_unix_mets_server(self, mets_server_url: str) -> None:
         self.log.info(f'Stopping UDS mets server: {mets_server_url}')
-        mets_server_url = Path(mets_server_url)
-        if mets_server_url in self.mets_servers:
-            mets_server_pid = self.mets_servers[mets_server_url]
+        if Path(mets_server_url) in self.mets_servers:
+            mets_server_pid = self.mets_servers[Path(mets_server_url)]
         else:
             raise Exception(f"Mets server not found: {mets_server_url}")
 

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -546,6 +546,7 @@ class Deployer:
 
     def stop_unix_mets_server(self, mets_server_url: str) -> None:
         self.log.info(f'Stopping UDS mets server: {mets_server_url}')
+        mets_server_url = Path(mets_server_url)
         if mets_server_url in self.mets_servers:
             mets_server_pid = self.mets_servers[mets_server_url]
         else:

--- a/ocrd_network/ocrd_network/logging.py
+++ b/ocrd_network/ocrd_network/logging.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from ocrd_utils import safe_filename
+from ocrd_utils import safe_filename, config
 
 
 OCRD_NETWORK_MODULES = [
@@ -14,8 +14,7 @@ OCRD_NETWORK_MODULES = [
 def get_root_logging_dir(module_name: str) -> Path:
     if module_name not in OCRD_NETWORK_MODULES:
         raise ValueError(f"Invalid module name: {module_name}, should be one of: {OCRD_NETWORK_MODULES}")
-    # TODO: Utilize env variable to set the root
-    module_log_dir = Path("/tmp", "ocrd_network_logs", module_name)
+    module_log_dir = Path(config.OCRD_NETWORK_LOGS_ROOT_DIR, module_name)
     module_log_dir.mkdir(parents=True, exist_ok=True)
     return module_log_dir
 

--- a/ocrd_network/ocrd_network/logging.py
+++ b/ocrd_network/ocrd_network/logging.py
@@ -1,6 +1,6 @@
-from os import makedirs
-from os.path import join
+from pathlib import Path
 from ocrd_utils import safe_filename
+
 
 OCRD_NETWORK_MODULES = [
     "mets_servers",
@@ -11,38 +11,38 @@ OCRD_NETWORK_MODULES = [
 ]
 
 
-def get_root_logging_dir(module_name: str) -> str:
+def get_root_logging_dir(module_name: str) -> Path:
     if module_name not in OCRD_NETWORK_MODULES:
         raise ValueError(f"Invalid module name: {module_name}, should be one of: {OCRD_NETWORK_MODULES}")
     # TODO: Utilize env variable to set the root
-    module_log_dir = join("/tmp/ocrd_network_logs", module_name)
-    makedirs(name=module_log_dir, exist_ok=True)
+    module_log_dir = Path("/tmp", "ocrd_network_logs", module_name)
+    module_log_dir.mkdir(parents=True, exist_ok=True)
     return module_log_dir
 
 
-def get_cache_locked_pages_logging_file_path() -> str:
-    return join(get_root_logging_dir("processing_servers"), f"cache_locked_pages.log")
+def get_cache_locked_pages_logging_file_path() -> Path:
+    return get_root_logging_dir("processing_servers") / "cache_locked_pages.log"
 
 
-def get_cache_processing_requests_logging_file_path() -> str:
-    return join(get_root_logging_dir("processing_servers"), f"cache_processing_requests.log")
+def get_cache_processing_requests_logging_file_path() -> Path:
+    return get_root_logging_dir("processing_servers") / "cache_processing_requests.log"
 
 
-def get_processing_job_logging_file_path(job_id: str) -> str:
-    return join(get_root_logging_dir("processing_jobs"), f"{job_id}.log")
+def get_processing_job_logging_file_path(job_id: str) -> Path:
+    return get_root_logging_dir("processing_jobs") / f"{job_id}.log"
 
 
-def get_processing_server_logging_file_path(pid: int) -> str:
-    return join(get_root_logging_dir("processing_servers"), f"server.{pid}.log")
+def get_processing_server_logging_file_path(pid: int) -> Path:
+    return get_root_logging_dir("processing_servers") / f"server.{pid}.log"
 
 
-def get_processing_worker_logging_file_path(processor_name: str, pid: int) -> str:
-    return join(get_root_logging_dir("processing_workers"), f"worker.{pid}.{processor_name}.log")
+def get_processing_worker_logging_file_path(processor_name: str, pid: int) -> Path:
+    return get_root_logging_dir("processing_workers") / f"worker.{pid}.{processor_name}.log"
 
 
-def get_processor_server_logging_file_path(processor_name: str, pid: int) -> str:
-    return join(get_root_logging_dir("processor_servers"), f"server.{pid}.{processor_name}.log")
+def get_processor_server_logging_file_path(processor_name: str, pid: int) -> Path:
+    return get_root_logging_dir("processor_servers") / f"server.{pid}.{processor_name}.log"
 
 
-def get_mets_server_logging_file_path(mets_path: str) -> str:
-    return join(get_root_logging_dir("mets_servers"), f"{safe_filename(mets_path)}.log")
+def get_mets_server_logging_file_path(mets_path: str) -> Path:
+    return get_root_logging_dir("mets_servers") / f"{safe_filename(mets_path)}.log"

--- a/ocrd_network/ocrd_network/logging.py
+++ b/ocrd_network/ocrd_network/logging.py
@@ -1,0 +1,48 @@
+from os import makedirs
+from os.path import join
+from ocrd_utils import safe_filename
+
+OCRD_NETWORK_MODULES = [
+    "mets_servers",
+    "processing_jobs",
+    "processing_servers",
+    "processing_workers",
+    "processor_servers"
+]
+
+
+def get_root_logging_dir(module_name: str) -> str:
+    if module_name not in OCRD_NETWORK_MODULES:
+        raise ValueError(f"Invalid module name: {module_name}, should be one of: {OCRD_NETWORK_MODULES}")
+    # TODO: Utilize env variable to set the root
+    module_log_dir = join("/tmp/ocrd_network_logs", module_name)
+    makedirs(name=module_log_dir, exist_ok=True)
+    return module_log_dir
+
+
+def get_cache_locked_pages_logging_file_path() -> str:
+    return join(get_root_logging_dir("processing_servers"), f"cache_locked_pages.log")
+
+
+def get_cache_processing_requests_logging_file_path() -> str:
+    return join(get_root_logging_dir("processing_servers"), f"cache_processing_requests.log")
+
+
+def get_processing_job_logging_file_path(job_id: str) -> str:
+    return join(get_root_logging_dir("processing_jobs"), f"{job_id}.log")
+
+
+def get_processing_server_logging_file_path(pid: int) -> str:
+    return join(get_root_logging_dir("processing_servers"), f"server.{pid}.log")
+
+
+def get_processing_worker_logging_file_path(processor_name: str, pid: int) -> str:
+    return join(get_root_logging_dir("processing_workers"), f"worker.{pid}.{processor_name}.log")
+
+
+def get_processor_server_logging_file_path(processor_name: str, pid: int) -> str:
+    return join(get_root_logging_dir("processor_servers"), f"server.{pid}.{processor_name}.log")
+
+
+def get_mets_server_logging_file_path(mets_path: str) -> str:
+    return join(get_root_logging_dir("mets_servers"), f"{safe_filename(mets_path)}.log")

--- a/ocrd_network/ocrd_network/models/job.py
+++ b/ocrd_network/ocrd_network/models/job.py
@@ -66,6 +66,7 @@ class PYJobOutput(BaseModel):
     input_file_grps: List[str]
     output_file_grps: Optional[List[str]]
     page_id: Optional[str] = None
+    log_file_path: Optional[str]
 
 
 class DBProcessorJob(Document):
@@ -88,6 +89,7 @@ class DBProcessorJob(Document):
     start_time: Optional[datetime]
     end_time: Optional[datetime]
     exec_time: Optional[str]
+    log_file_path: Optional[str]
 
     class Settings:
         use_enum_values = True
@@ -101,7 +103,8 @@ class DBProcessorJob(Document):
             workspace_id=self.workspace_id,
             input_file_grps=self.input_file_grps,
             output_file_grps=self.output_file_grps,
-            page_id=self.page_id
+            page_id=self.page_id,
+            log_file_path=self.log_file_path
         )
 
 

--- a/ocrd_network/ocrd_network/processing_server.py
+++ b/ocrd_network/ocrd_network/processing_server.py
@@ -14,7 +14,7 @@ from fastapi import (
     UploadFile
 )
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 
 from pika.exceptions import ChannelClosedByBroker
 from ocrd.task_sequence import ProcessorTask
@@ -52,6 +52,7 @@ from .server_cache import (
 )
 from .server_utils import (
     _get_processor_job,
+    _get_processor_job_log,
     expand_page_ids,
     validate_and_return_mets_path,
     validate_job_input
@@ -155,6 +156,15 @@ class ProcessingServer(FastAPI):
             response_model=PYJobOutput,
             response_model_exclude_unset=True,
             response_model_exclude_none=True
+        )
+
+        self.router.add_api_route(
+            path='/processor/{processor_name}/{job_id}/log',
+            endpoint=self.get_processor_job_log,
+            methods=['GET'],
+            tags=['processing'],
+            status_code=status.HTTP_200_OK,
+            summary='Get the log file of a job id'
         )
 
         self.router.add_api_route(
@@ -523,6 +533,9 @@ class ProcessingServer(FastAPI):
 
     async def get_processor_job(self, processor_name: str, job_id: str) -> PYJobOutput:
         return await _get_processor_job(self.log, processor_name, job_id)
+
+    async def get_processor_job_log(self, processor_name: str, job_id: str) -> FileResponse:
+        return await _get_processor_job_log(self.log, processor_name, job_id)
 
     async def remove_from_request_cache(self, result_message: PYResultMessage):
         result_job_id = result_message.job_id

--- a/ocrd_network/ocrd_network/processing_server.py
+++ b/ocrd_network/ocrd_network/processing_server.py
@@ -1,6 +1,8 @@
 import json
+import logging
 import requests
 import httpx
+from os import getpid
 from typing import Dict, List
 import uvicorn
 
@@ -30,6 +32,7 @@ from .database import (
     db_update_workspace
 )
 from .deployer import Deployer
+from .logging import get_processing_server_logging_file_path
 from .models import (
     DBProcessorJob,
     DBWorkflowJob,
@@ -82,6 +85,11 @@ class ProcessingServer(FastAPI):
             description='OCR-D Processing Server'
         )
         self.log = getLogger('ocrd_network.processing_server')
+        log_file = get_processing_server_logging_file_path(pid=getpid())
+        file_handler = logging.FileHandler(filename=log_file, mode='a')
+        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        self.log.addHandler(file_handler)
+
         self.log.info(f"Downloading ocrd all tool json")
         self.ocrd_all_tool_json = download_ocrd_all_tool_json(
             ocrd_all_url="https://ocr-d.de/js/ocrd-all-tool.json"

--- a/ocrd_network/ocrd_network/processing_server.py
+++ b/ocrd_network/ocrd_network/processing_server.py
@@ -1,5 +1,5 @@
 import json
-import logging
+from logging import FileHandler, Formatter
 import requests
 import httpx
 from os import getpid
@@ -18,7 +18,7 @@ from fastapi.responses import JSONResponse
 
 from pika.exceptions import ChannelClosedByBroker
 from ocrd.task_sequence import ProcessorTask
-from ocrd_utils import initLogging, getLogger
+from ocrd_utils import initLogging, getLogger, LOG_FORMAT
 from ocrd import Resolver, Workspace
 from pathlib import Path
 from .database import (
@@ -86,8 +86,8 @@ class ProcessingServer(FastAPI):
         )
         self.log = getLogger('ocrd_network.processing_server')
         log_file = get_processing_server_logging_file_path(pid=getpid())
-        file_handler = logging.FileHandler(filename=log_file, mode='a')
-        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        file_handler = FileHandler(filename=log_file, mode='a')
+        file_handler.setFormatter(Formatter(LOG_FORMAT))
         self.log.addHandler(file_handler)
 
         self.log.info(f"Downloading ocrd all tool json")

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -9,14 +9,14 @@ is a single OCR-D Processor instance.
 """
 
 from datetime import datetime
-import logging
+from logging import FileHandler, Formatter
 from os import getpid
 from time import sleep
 import pika.spec
 import pika.adapters.blocking_connection
 from pika.exceptions import AMQPConnectionError
 
-from ocrd_utils import config, getLogger
+from ocrd_utils import config, getLogger, LOG_FORMAT
 from .database import (
     sync_initiate_database,
     sync_db_get_workspace,
@@ -46,8 +46,8 @@ class ProcessingWorker:
     def __init__(self, rabbitmq_addr, mongodb_addr, processor_name, ocrd_tool: dict, processor_class=None) -> None:
         self.log = getLogger(f'ocrd_network.processing_worker')
         log_file = get_processing_worker_logging_file_path(processor_name=processor_name, pid=getpid())
-        file_handler = logging.FileHandler(filename=log_file, mode='a')
-        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        file_handler = FileHandler(filename=log_file, mode='a')
+        file_handler.setFormatter(Formatter(LOG_FORMAT))
         self.log.addHandler(file_handler)
 
         try:

--- a/ocrd_network/ocrd_network/processing_worker.py
+++ b/ocrd_network/ocrd_network/processing_worker.py
@@ -204,14 +204,15 @@ class ProcessingWorker:
         execution_failed = False
         self.log.debug(f'Invoking processor: {self.processor_name}')
         start_time = datetime.now()
+        job_log_file = get_processing_job_logging_file_path(job_id=job_id)
         sync_db_update_processing_job(
             job_id=job_id,
             state=StateEnum.running,
             path_to_mets=path_to_mets,
-            start_time=start_time
+            start_time=start_time,
+            log_file_path=job_log_file
         )
         try:
-            job_log_file = get_processing_job_logging_file_path(job_id=job_id)
             invoke_processor(
                 processor_class=self.processor_class,
                 executable=self.processor_name,

--- a/ocrd_network/ocrd_network/processor_server.py
+++ b/ocrd_network/ocrd_network/processor_server.py
@@ -18,6 +18,7 @@ from .database import (
     db_update_processing_job,
     initiate_database
 )
+from .logging import get_processor_server_logging_file_path
 from .models import (
     PYJobInput,
     PYJobOutput,
@@ -49,9 +50,9 @@ class ProcessorServer(FastAPI):
             title=f'OCR-D Processor Server',
             description='OCR-D Processor Server'
         )
-        logging_suffix = f'{processor_name}.{getpid()}'
         self.log = getLogger('ocrd_network.processor_server')
-        file_handler = logging.FileHandler(f'/tmp/ocrd_server_{logging_suffix}.log', mode='a')
+        log_file = get_processor_server_logging_file_path(processor_name=processor_name, pid=getpid())
+        file_handler = logging.FileHandler(filename=log_file, mode='a')
         file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
         self.log.addHandler(file_handler)
 

--- a/ocrd_network/ocrd_network/processor_server.py
+++ b/ocrd_network/ocrd_network/processor_server.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-import logging
+from logging import FileHandler, Formatter
 from os import getpid
 from subprocess import run, PIPE
 import uvicorn
@@ -10,7 +10,8 @@ from ocrd_utils import (
     initLogging,
     get_ocrd_tool_json,
     getLogger,
-    parse_json_string_with_comments,
+    LOG_FORMAT,
+    parse_json_string_with_comments
 )
 from .database import (
     DBProcessorJob,
@@ -52,8 +53,8 @@ class ProcessorServer(FastAPI):
         )
         self.log = getLogger('ocrd_network.processor_server')
         log_file = get_processor_server_logging_file_path(processor_name=processor_name, pid=getpid())
-        file_handler = logging.FileHandler(filename=log_file, mode='a')
-        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        file_handler = FileHandler(filename=log_file, mode='a')
+        file_handler.setFormatter(Formatter(LOG_FORMAT))
         self.log.addHandler(file_handler)
 
         self.db_url = mongodb_addr

--- a/ocrd_network/ocrd_network/server_cache.py
+++ b/ocrd_network/ocrd_network/server_cache.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 from typing import Dict, List
 from logging import DEBUG, getLogger, FileHandler
+from os import makedirs
 
 from .database import db_get_processing_job, db_update_processing_job
+from .logging import (
+    get_cache_locked_pages_logging_file_path,
+    get_cache_processing_requests_logging_file_path
+)
 from .models import PYJobInput, StateEnum
 
 __all__ = [
@@ -16,7 +21,8 @@ class CacheLockedPages:
         self.log = getLogger("ocrd_network.server_cache.locked_pages")
         # TODO: remove this when refactoring the logging
         self.log.setLevel(DEBUG)
-        log_fh = FileHandler(f'/tmp/ocrd_processing_server_cache_locked_pages.log')
+        log_file = get_cache_locked_pages_logging_file_path()
+        log_fh = FileHandler(filename=log_file, mode='a')
         log_fh.setLevel(DEBUG)
         self.log.addHandler(log_fh)
 
@@ -111,7 +117,8 @@ class CacheProcessingRequests:
         self.log = getLogger("ocrd_network.server_cache.processing_requests")
         # TODO: remove this when refactoring the logging
         self.log.setLevel(DEBUG)
-        log_fh = FileHandler(f'/tmp/ocrd_processing_server_cache_processing_requests.log')
+        log_file = get_cache_processing_requests_logging_file_path()
+        log_fh = FileHandler(filename=log_file, mode='a')
         log_fh.setLevel(DEBUG)
         self.log.addHandler(log_fh)
 

--- a/ocrd_network/ocrd_network/server_cache.py
+++ b/ocrd_network/ocrd_network/server_cache.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from typing import Dict, List
-from logging import DEBUG, getLogger, FileHandler
-from os import makedirs
+from logging import FileHandler, Formatter
 
+from ocrd_utils import getLogger, LOG_FORMAT
 from .database import db_get_processing_job, db_update_processing_job
 from .logging import (
     get_cache_locked_pages_logging_file_path,
@@ -19,11 +19,9 @@ __all__ = [
 class CacheLockedPages:
     def __init__(self) -> None:
         self.log = getLogger("ocrd_network.server_cache.locked_pages")
-        # TODO: remove this when refactoring the logging
-        self.log.setLevel(DEBUG)
         log_file = get_cache_locked_pages_logging_file_path()
         log_fh = FileHandler(filename=log_file, mode='a')
-        log_fh.setLevel(DEBUG)
+        log_fh.setFormatter(Formatter(LOG_FORMAT))
         self.log.addHandler(log_fh)
 
         # Used for keeping track of locked pages for a workspace
@@ -115,11 +113,9 @@ class CacheLockedPages:
 class CacheProcessingRequests:
     def __init__(self) -> None:
         self.log = getLogger("ocrd_network.server_cache.processing_requests")
-        # TODO: remove this when refactoring the logging
-        self.log.setLevel(DEBUG)
         log_file = get_cache_processing_requests_logging_file_path()
         log_fh = FileHandler(filename=log_file, mode='a')
-        log_fh.setLevel(DEBUG)
+        log_fh.setFormatter(Formatter(LOG_FORMAT))
         self.log.addHandler(log_fh)
 
         # Used for buffering/caching processing requests in the Processing Server

--- a/ocrd_network/ocrd_network/server_utils.py
+++ b/ocrd_network/ocrd_network/server_utils.py
@@ -1,5 +1,7 @@
 import re
 from fastapi import HTTPException, status
+from fastapi.responses import FileResponse
+from pathlib import Path
 from typing import List
 from ocrd_validators import ParameterValidator
 from ocrd_utils import (
@@ -26,6 +28,12 @@ async def _get_processor_job(logger, processor_name: str, job_id: str) -> PYJobO
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Processing job with id '{job_id}' of processor type '{processor_name}' not existing"
         )
+
+
+async def _get_processor_job_log(logger, processor_name: str, job_id: str) -> FileResponse:
+    db_job = await _get_processor_job(logger, processor_name, job_id)
+    log_file_path = Path(db_job.log_file_path)
+    return FileResponse(path=log_file_path, filename=log_file_path.name)
 
 
 async def validate_and_return_mets_path(logger, job_input: PYJobInput) -> str:

--- a/ocrd_utils/ocrd_utils/config.py
+++ b/ocrd_utils/ocrd_utils/config.py
@@ -9,7 +9,9 @@ in the `ocrd` package for the actual values
 
 from os import environ
 from pathlib import Path
+from tempfile import gettempdir
 from textwrap import fill, indent
+
 
 class OcrdEnvVariable():
 
@@ -155,6 +157,18 @@ config.add("OCRD_NETWORK_WORKER_QUEUE_CONNECT_ATTEMPTS",
     description="Number of attempts for a worker to create its queue. Helpfull if the rabbitmq-server needs time to be fully started",
     parser=int,
     default=(True, 3))
+
+config.add(name="OCRD_NETWORK_SOCKETS_ROOT_DIR",
+           description="The root directory where all mets server related socket files are created",
+           parser=lambda val: Path(val),
+           default=(True, Path(gettempdir(), "ocrd_network_sockets")))
+config.OCRD_NETWORK_SOCKETS_ROOT_DIR.mkdir(parents=True, exist_ok=True)
+
+config.add(name="OCRD_NETWORK_LOGS_ROOT_DIR",
+           description="The root directory where all ocrd_network related file logs are stored",
+           parser=lambda val: Path(val),
+           default=(True, Path(gettempdir(), "ocrd_network_logs")))
+config.OCRD_NETWORK_LOGS_ROOT_DIR.mkdir(parents=True, exist_ok=True)
 
 config.add("HOME",
     description="Directory to look for `ocrd_logging.conf`, fallback for unset XDG variables.",


### PR DESCRIPTION
This PR improves the logging mechanism of the `ocrd_network` module.

Additions:
- A separate logging dir tree structure for the modules (processing servers, processing workers, processor servers, mets servers, processing jobs). Configurable with an env variable.
- Processing job-level logging - each job is logged into a separate file with format `{job_id}.log`
- Processing job-level logging file paths are added to the Job models and preserved in the database.
- The `ocrd_network` logging is based on the format provided in `ocrd_utils`
- Support env variables for setting the root directory for logging/sockets
- An endpoint for getting the log file of a processing job of a processor

Feel free to recommend suggestions.