### PR TITLE
:bug: pydantic fields must not start with underscore

### DIFF
--- a/tests/test_mets_server.py
+++ b/tests/test_mets_server.py
@@ -141,7 +141,7 @@ def test_mets_server_str(start_mets_server):
     f = next(workspace_server.find_files())
     assert str(f) == '<ClientSideOcrdFile fileGrp=OCR-D-IMG, ID=FILE_0001_IMAGE, mimetype=image/tiff, url=---, local_filename=OCR-D-IMG/FILE_0001_IMAGE.tif]/>'
     a = workspace_server.mets.agents[0]
-    assert str(a) == '<ClientSideOcrdAgent [type=---, othertype=SOFTWARE, role=CREATOR, otherrole=---, name=DFG-Koordinierungsprojekt zur Weiterentwicklung von Verfahren der Optical Character Recognition (OCR-D)]/>'
+    assert str(a) == '<ClientSideOcrdAgent [type=OTHER, othertype=SOFTWARE, role=CREATOR, otherrole=---, name=DFG-Koordinierungsprojekt zur Weiterentwicklung von Verfahren der Optical Character Recognition (OCR-D)]/>'
     assert str(workspace_server.mets) == '<ClientSideOcrdMets[url=%s]>' % ('http+unix://%2Ftmp%2Focrd-mets-server.sock' if mets_server_url == TRANSPORTS[0] else TRANSPORTS[1])
 
 def test_mets_test_unimplemented(start_mets_server):


### PR DESCRIPTION
Since https://github.com/pydantic/pydantic/pull/6797 a field name starting with underscore (e.g. `_type` in OcrdAgentModel) raise `NameError`. Noticed in https://app.circleci.com/pipelines/github/OCR-D/ocrd_olena/178/workflows/669e922c-b637-4edc-9db7-d3ae5c7a7b1d/jobs/180 . This PR fixes that with as few changes as possible.