### PR TITLE
Fix loglevel type error when starting bashlib worker

### DIFF
--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -6,12 +6,13 @@ from time import perf_counter, process_time
 from functools import lru_cache
 import json
 import inspect
-from subprocess import run, PIPE
-from typing import List, Type
+from subprocess import run
+from typing import List
 
 from click import wrap_text
 from ocrd.workspace import Workspace
-from ocrd_utils import freeze_args, getLogger, pushd_popd, config, setOverrideLogLevel
+from ocrd_utils import freeze_args, getLogger, config, setOverrideLogLevel
+from logging import getLevelName
 
 
 __all__ = [
@@ -198,7 +199,7 @@ def run_cli(
     args = [executable, '--working-dir', workspace.directory]
     args += ['--mets', mets_url]
     if log_level:
-        args += ['--log-level', log_level]
+        args += ['--log-level', getLevelName(log_level)]
     if page_id:
         args += ['--page-id', page_id]
     if input_file_grp:

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -11,8 +11,7 @@ from typing import List
 
 from click import wrap_text
 from ocrd.workspace import Workspace
-from ocrd_utils import freeze_args, getLogger, config, setOverrideLogLevel
-from logging import getLevelName
+from ocrd_utils import freeze_args, getLogger, config, setOverrideLogLevel, getLevelName
 
 
 __all__ = [

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -199,7 +199,10 @@ def run_cli(
     args = [executable, '--working-dir', workspace.directory]
     args += ['--mets', mets_url]
     if log_level:
-        args += ['--log-level', getLevelName(log_level)]
+        if isinstance(log_level, str):
+            args += ['--log-level', log_level]
+        else:
+            args += ['--log-level', getLevelName(log_level)]
     if page_id:
         args += ['--page-id', page_id]
     if input_file_grp:
@@ -213,6 +216,9 @@ def run_cli(
     if mets_server_url:
         args += ['--mets-server-url', mets_server_url]
     log = getLogger('ocrd.processor.helpers.run_cli')
+    print("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+    print(args)
+    print("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     log.debug("Running subprocess '%s'", ' '.join(args))
     result = run(args, check=False)
     return result.returncode

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -216,9 +216,6 @@ def run_cli(
     if mets_server_url:
         args += ['--mets-server-url', mets_server_url]
     log = getLogger('ocrd.processor.helpers.run_cli')
-    print("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
-    print(args)
-    print("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     log.debug("Running subprocess '%s'", ' '.join(args))
     result = run(args, check=False)
     return result.returncode

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -199,10 +199,7 @@ def run_cli(
     args = [executable, '--working-dir', workspace.directory]
     args += ['--mets', mets_url]
     if log_level:
-        if isinstance(log_level, str):
-            args += ['--log-level', log_level]
-        else:
-            args += ['--log-level', getLevelName(log_level)]
+        args += ['--log-level', log_level if isinstance(log_level, str) else getLevelName(log_level)]
     if page_id:
         args += ['--page-id', page_id]
     if input_file_grp:


### PR DESCRIPTION
The log-level is provided as an Integer but a String, `'DEBUG' ` for example, is needed.