### PR TITLE
Fix logging to a file with bashlib based processors

### DIFF
--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -145,7 +145,7 @@ ocrd__parse_argv () {
             -I|--input-file-grp) ocrd__argv[input_file_grp]=$2 ; shift ;;
             -w|--working-dir) ocrd__argv[working_dir]=$(realpath "$2") ; shift ;;
             -m|--mets) ocrd__argv[mets_file]=$(realpath "$2") ; shift ;;
-            --mets-server-url) ocrd_argv[mets_server_url]="$2" ; shift ;;
+            --mets-server-url) ocrd__argv[mets_server_url]="$2" ; shift ;;
             --overwrite) ocrd__argv[overwrite]=true ;;
             --profile) ocrd__argv[profile]=true ;;
             --profile-file) ocrd__argv[profile_file]=$(realpath "$2") ; shift ;;

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -169,7 +169,6 @@ def run_cli(
         page_id=None,
         overwrite=None,
         log_level=None,
-        log_filename=None,
         input_file_grp=None,
         output_file_grp=None,
         parameter=None,
@@ -214,11 +213,7 @@ def run_cli(
         args += ['--mets-server-url', mets_server_url]
     log = getLogger('ocrd.processor.helpers.run_cli')
     log.debug("Running subprocess '%s'", ' '.join(args))
-    if not log_filename:
-        result = run(args, check=False)
-    else:
-        with open(log_filename, 'a') as file_desc:
-            result = run(args, check=False, stdout=file_desc, stderr=file_desc)
+    result = run(args, check=False)
     return result.returncode
 
 

--- a/ocrd/ocrd/processor/helpers.py
+++ b/ocrd/ocrd/processor/helpers.py
@@ -170,6 +170,7 @@ def run_cli(
         page_id=None,
         overwrite=None,
         log_level=None,
+        log_filename=None,
         input_file_grp=None,
         output_file_grp=None,
         parameter=None,
@@ -214,8 +215,13 @@ def run_cli(
         args += ['--mets-server-url', mets_server_url]
     log = getLogger('ocrd.processor.helpers.run_cli')
     log.debug("Running subprocess '%s'", ' '.join(args))
-    result = run(args, check=False)
+    if not log_filename:
+        result = run(args, check=False)
+    else:
+        with open(log_filename, 'a') as file_desc:
+            result = run(args, check=False, stdout=file_desc, stderr=file_desc)
     return result.returncode
+
 
 def generate_processor_help(ocrd_tool, processor_instance=None, subcommand=None):
     """Generate a string describing the full CLI of this processor including params.

--- a/ocrd_network/ocrd_network/process_helpers.py
+++ b/ocrd_network/ocrd_network/process_helpers.py
@@ -25,15 +25,15 @@ def invoke_processor(
     input_file_grps_str = ','.join(input_file_grps)
     output_file_grps_str = ','.join(output_file_grps)
 
-    ctx_mgr = redirect_stderr_and_stdout_to_file(log_filename) if log_filename else nullcontext()
-    with ctx_mgr:
-        initLogging(force_reinit=True)
-        workspace = get_ocrd_workspace_instance(
-            mets_path=abs_path_to_mets,
-            mets_server_url=mets_server_url
-        )
+    workspace = get_ocrd_workspace_instance(
+        mets_path=abs_path_to_mets,
+        mets_server_url=mets_server_url
+    )
 
-        if processor_class:
+    if processor_class:
+        ctx_mgr = redirect_stderr_and_stdout_to_file(log_filename) if log_filename else nullcontext()
+        with ctx_mgr:
+            initLogging(force_reinit=True)
             try:
                 run_processor(
                     processorClass=processor_class,
@@ -48,17 +48,18 @@ def invoke_processor(
                 )
             except Exception as e:
                 raise RuntimeError(f"Python executable '{processor_class.__dict__}' exited with: {e}")
-        else:
-            return_code = run_cli(
-                executable=executable,
-                workspace=workspace,
-                mets_url=abs_path_to_mets,
-                input_file_grp=input_file_grps_str,
-                output_file_grp=output_file_grps_str,
-                page_id=page_id,
-                parameter=json.dumps(parameters),
-                mets_server_url=mets_server_url,
-                log_level=logging.DEBUG
-            )
-            if return_code != 0:
-                raise RuntimeError(f"CLI executable '{executable}' exited with: {return_code}")
+    else:
+        return_code = run_cli(
+            executable=executable,
+            workspace=workspace,
+            mets_url=abs_path_to_mets,
+            input_file_grp=input_file_grps_str,
+            output_file_grp=output_file_grps_str,
+            page_id=page_id,
+            parameter=json.dumps(parameters),
+            mets_server_url=mets_server_url,
+            log_level=logging.DEBUG,
+            log_filename=log_filename
+        )
+        if return_code != 0:
+            raise RuntimeError(f"CLI executable '{executable}' exited with: {return_code}")

--- a/ocrd_network/ocrd_network/process_helpers.py
+++ b/ocrd_network/ocrd_network/process_helpers.py
@@ -1,6 +1,5 @@
 import json
 from typing import List, Optional
-import logging
 from contextlib import nullcontext
 
 from ocrd.processor.helpers import run_cli, run_processor
@@ -44,7 +43,7 @@ def invoke_processor(
                     parameter=parameters,
                     instance_caching=True,
                     mets_server_url=mets_server_url,
-                    log_level=logging.DEBUG
+                    log_level='DEBUG'
                 )
             except Exception as e:
                 raise RuntimeError(f"Python executable '{processor_class.__dict__}' exited with: {e}")
@@ -58,7 +57,7 @@ def invoke_processor(
             page_id=page_id,
             parameter=json.dumps(parameters),
             mets_server_url=mets_server_url,
-            log_level=logging.DEBUG,
+            log_level='DEBUG',
             log_filename=log_filename
         )
         if return_code != 0:

--- a/ocrd_network/ocrd_network/process_helpers.py
+++ b/ocrd_network/ocrd_network/process_helpers.py
@@ -24,14 +24,13 @@ def invoke_processor(
     input_file_grps_str = ','.join(input_file_grps)
     output_file_grps_str = ','.join(output_file_grps)
 
-    workspace = get_ocrd_workspace_instance(
-        mets_path=abs_path_to_mets,
-        mets_server_url=mets_server_url
-    )
-
-    if processor_class:
-        ctx_mgr = redirect_stderr_and_stdout_to_file(log_filename) if log_filename else nullcontext()
-        with ctx_mgr:
+    ctx_mgr = redirect_stderr_and_stdout_to_file(log_filename) if log_filename else nullcontext()
+    with ctx_mgr:
+        workspace = get_ocrd_workspace_instance(
+            mets_path=abs_path_to_mets,
+            mets_server_url=mets_server_url
+        )
+        if processor_class:
             initLogging(force_reinit=True)
             try:
                 run_processor(
@@ -47,18 +46,17 @@ def invoke_processor(
                 )
             except Exception as e:
                 raise RuntimeError(f"Python executable '{processor_class.__dict__}' exited with: {e}")
-    else:
-        return_code = run_cli(
-            executable=executable,
-            workspace=workspace,
-            mets_url=abs_path_to_mets,
-            input_file_grp=input_file_grps_str,
-            output_file_grp=output_file_grps_str,
-            page_id=page_id,
-            parameter=json.dumps(parameters),
-            mets_server_url=mets_server_url,
-            log_level='DEBUG',
-            log_filename=log_filename
-        )
-        if return_code != 0:
-            raise RuntimeError(f"CLI executable '{executable}' exited with: {return_code}")
+        else:
+            return_code = run_cli(
+                executable=executable,
+                workspace=workspace,
+                mets_url=abs_path_to_mets,
+                input_file_grp=input_file_grps_str,
+                output_file_grp=output_file_grps_str,
+                page_id=page_id,
+                parameter=json.dumps(parameters),
+                mets_server_url=mets_server_url,
+                log_level='DEBUG'
+            )
+            if return_code != 0:
+                raise RuntimeError(f"CLI executable '{executable}' exited with: {return_code}")


### PR DESCRIPTION
This PR fixes the logging errors of type:
```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.7/logging/__init__.py", line 1028, in emit
    stream.write(msg + self.terminator)
ValueError: I/O operation on closed file.
```

EDIT: Forcing InitLogging() just for Python processors but not for bashlib processors was the simple fix.