### PR TITLE
METS server: POST /reload to reload METS from disk, #1123

### DIFF
--- a/ocrd/ocrd/mets_server.py
+++ b/ocrd/ocrd/mets_server.py
@@ -114,6 +114,9 @@ class ClientSideOcrdMets():
     def workspace_path(self):
         return self.session.request('GET', f'{self.url}/workspace_path').text
 
+    def reload(self):
+        return self.session.request('POST', f'{self.url}/reload').text
+
     @deprecated_alias(ID="file_id")
     @deprecated_alias(pageId="page_id")
     @deprecated_alias(fileGrp="file_grp")
@@ -282,6 +285,11 @@ class OcrdMetsServer():
         @app.get('/workspace_path', response_model=str)
         async def workspace_path():
             return Response(content=workspace.directory, media_type="text/plain")
+
+        @app.post('/reload')
+        async def workspace_reload_mets():
+            workspace.reload_mets()
+            return Response(content=f'Reloaded from {workspace.directory}', media_type="text/plain")
 
         @app.delete('/')
         async def stop():

--- a/tests/test_mets_server.py
+++ b/tests/test_mets_server.py
@@ -202,3 +202,18 @@ def test_find_all_files(start_mets_server):
     assert len(workspace_server.mets.find_all_files(pageId='//PHYS_000(1|2)')) == 34, '34 files in PHYS_001 and PHYS_0002'
     assert len(workspace_server.mets.find_all_files(pageId='//PHYS_0001,//PHYS_0005')) == 18, '18 files in PHYS_001 and PHYS_0005 (two regexes)'
     assert len(workspace_server.mets.find_all_files(pageId='//PHYS_0005,PHYS_0001..PHYS_0002')) == 35, '35 files in //PHYS_0005,PHYS_0001..PHYS_0002'
+
+def test_reload(start_mets_server):
+    _, workspace_server = start_mets_server
+    workspace_server_copy = Workspace(Resolver(), workspace_server.directory)
+    assert len(workspace_server.mets.find_all_files()) == 35, '35 files total'
+    assert len(workspace_server_copy.mets.find_all_files()) == 35, '35 files total'
+
+    workspace_server_copy.add_file('FOO', ID='foo', mimetype='foo/bar', local_filename='mets.xml', pageId='foo')
+    assert len(workspace_server.mets.find_all_files()) == 35, '35 files total'
+    assert len(workspace_server_copy.mets.find_all_files()) == 36, '36 files total'
+
+    workspace_server_copy.save_mets()
+    print(workspace_server.mets.reload())
+    assert len(workspace_server.mets.find_all_files()) == 36, '36 files total'
+


### PR DESCRIPTION
Implements an endpoint `POST/reload` and method `ClientSideOcrdMets.reload()` to reload the METS from disk.

This is in support of use cases where not all the processors in a workflow go through the METS server (we currently lack proper support in bashlib processors).

Running a processor without --mets-server-url should happen like this:
- Save the METS of the server to disk: `PUT /`
- Run the processor
- Reload the METS: `POST /reload`