### PR TITLE
--mets-server-url for ocrd workspace bulk-add

### DIFF
--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -302,7 +302,13 @@ def workspace_cli_bulk_add(ctx, regex, mimetype, page_id, file_id, url, local_fi
           -G '{{ filegrp }}' -g '{{ pageid }}' -i '{{ fileid }}' -S '{{ local_filename }}' -
     """
     log = getLogger('ocrd.cli.workspace.bulk-add') # pylint: disable=redefined-outer-name
-    workspace = Workspace(ctx.resolver, directory=ctx.directory, mets_basename=ctx.mets_basename, automatic_backup=ctx.automatic_backup)
+    workspace = Workspace(
+        ctx.resolver,
+        directory=ctx.directory,
+        mets_basename=ctx.mets_basename,
+        automatic_backup=ctx.automatic_backup,
+        mets_server_url=ctx.mets_server_url,
+    )
 
     try:
         pat = re.compile(regex)

--- a/ocrd/ocrd/lib.bash
+++ b/ocrd/ocrd/lib.bash
@@ -145,7 +145,7 @@ ocrd__parse_argv () {
             -I|--input-file-grp) ocrd__argv[input_file_grp]=$2 ; shift ;;
             -w|--working-dir) ocrd__argv[working_dir]=$(realpath "$2") ; shift ;;
             -m|--mets) ocrd__argv[mets_file]=$(realpath "$2") ; shift ;;
-            --mets-server-url) ocrd__argv[mets_server_url]="$2" ; shift ;;
+            -U|--mets-server-url) ocrd__argv[mets_server_url]="$2" ; shift ;;
             --overwrite) ocrd__argv[overwrite]=true ;;
             --profile) ocrd__argv[profile]=true ;;
             --profile-file) ocrd__argv[profile_file]=$(realpath "$2") ; shift ;;


### PR DESCRIPTION
Two fixes:

- `ocrd workspace bulk-add` omitted `mets_server_url` when instantiating the workspace, meaning `--mets-server-url` was ignored
- `-U` as a shortcut for `--mets-server-url` for consistency between bashlib and pythonic processors