### PR TITLE
Fixed Improper Method Call: Modified `__exit__()`

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -73,7 +73,10 @@ class OcrdMets(OcrdXmlDocument):
         if self._cache_flag:
             self.refresh_caches()
 
-    def __exit__(self):
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
         """
 
         """


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [ocrd_mets.py](https://github.com/OCR-D/core/blob/master/ocrd_models/ocrd_models/ocrd_mets.py#L76), class: OcrdMets, there is a special method `__exit__` that contains an unexpected number of parameters. Each call to this method will result in a TypeError. iCR suggested that special methods should have an expected number of parameters. More infomation can be found in the [Python documentation on the various special method.](https://docs.python.org/3/reference/datamodel.html#special-method-names)


### Proof of Concept
Executing the test code -
```py
from ocrd_models.ocrd_mets import OcrdMets

print("Before context")
with OcrdMets(content='<mets></mets>') as mets:
    print(mets.__class__)
print("After context")
```
Gives the output -
```shell
(env) ataf@openrefactory:~/BFAS/Source/core$ python3 _test.py 
Before context
Traceback (most recent call last):
  File "_test.py", line 4, in <module>
    with OcrdMets(content='<mets></mets>') as mets:
AttributeError: __enter__
```

The error is due to the class `OcrdMets` not having the `__enter__` method. After implementing the method like below - 
```py
def __enter__(self):
    pass
```
And executing the following script gives us a different output.
```shell
(env) ataf@openrefactory:~/BFAS/Source/core$ python3 _test.py 
Before context
<class 'NoneType'>
Traceback (most recent call last):
  File "_test.py", line 5, in <module>
    print(mets.__class__)
TypeError: __exit__() takes 1 positional argument but 4 were given
```
This is because the `__exit__` method expects 4 arguments `(self, exc_type, exc_value, traveback)` according to the the [documentation](https://docs.python.org/3/reference/datamodel.html#object.__exit__). After modifying the `__exit__` method and executing the script again results in sucess.


## Changes
- Added a new method called `__enter__`
- Modified the `__exit__` method to overcome `TypeError`


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
