### PR TITLE
OcrdMets: remove dead code __exit__ method, #1130

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -73,13 +73,6 @@ class OcrdMets(OcrdXmlDocument):
         if self._cache_flag:
             self.refresh_caches()
 
-    def __exit__(self):
-        """
-
-        """
-        if self._cache_flag:
-            self._clear_caches()
-
     def __str__(self):
         """
         String representation


### PR DESCRIPTION
The `__exit__` method in `OcrdMets` seems unnecessary, since the `OcrdMets` is not a `contextmanager` (i.e. it is not used as `with OcrdMets`), so the `__exit__` method is never called. Also the signature is wrong.

I guess the reasoning for the method is a C++ background where you declare destructors. In Python, garbage collector should take care of this.