### PR TITLE
Change api processor paths in ocrd_network

### DIFF
--- a/ocrd_network/ocrd_network/processing_server.py
+++ b/ocrd_network/ocrd_network/processing_server.py
@@ -135,7 +135,7 @@ class ProcessingServer(FastAPI):
         )
 
         self.router.add_api_route(
-            path='/processor/{processor_name}',
+            path='/processor/run/{processor_name}',
             endpoint=self.push_processor_job,
             methods=['POST'],
             tags=['processing'],
@@ -147,7 +147,7 @@ class ProcessingServer(FastAPI):
         )
 
         self.router.add_api_route(
-            path='/processor/{processor_name}/{job_id}',
+            path='/processor/job/{job_id}',
             endpoint=self.get_processor_job,
             methods=['GET'],
             tags=['processing'],
@@ -159,7 +159,7 @@ class ProcessingServer(FastAPI):
         )
 
         self.router.add_api_route(
-            path='/processor/{processor_name}/{job_id}/log',
+            path='/processor/log/{job_id}',
             endpoint=self.get_processor_job_log,
             methods=['GET'],
             tags=['processing'],
@@ -177,7 +177,7 @@ class ProcessingServer(FastAPI):
         )
 
         self.router.add_api_route(
-            path='/processor/{processor_name}',
+            path='/processor/info/{processor_name}',
             endpoint=self.get_processor_info,
             methods=['GET'],
             tags=['processing', 'discovery'],
@@ -361,6 +361,11 @@ class ProcessingServer(FastAPI):
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=f"Job id field is set but must not be: {data.job_id}"
             )
+        if not data.workspace_id and not data.path_to_mets:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="either 'path_to_mets' or 'workspace_id' must be provided"
+            )
         # Generate processing job id
         data.job_id = generate_id()
 
@@ -531,11 +536,11 @@ class ProcessingServer(FastAPI):
         job_output = response.json()
         return job_output
 
-    async def get_processor_job(self, processor_name: str, job_id: str) -> PYJobOutput:
-        return await _get_processor_job(self.log, processor_name, job_id)
+    async def get_processor_job(self, job_id: str) -> PYJobOutput:
+        return await _get_processor_job(self.log, job_id)
 
-    async def get_processor_job_log(self, processor_name: str, job_id: str) -> FileResponse:
-        return await _get_processor_job_log(self.log, processor_name, job_id)
+    async def get_processor_job_log(self, job_id: str) -> FileResponse:
+        return await _get_processor_job_log(self.log, job_id)
 
     async def remove_from_request_cache(self, result_message: PYResultMessage):
         result_job_id = result_message.job_id

--- a/ocrd_network/ocrd_network/processing_server.py
+++ b/ocrd_network/ocrd_network/processing_server.py
@@ -63,7 +63,7 @@ from .utils import (
     generate_id,
     get_ocrd_workspace_physical_pages
 )
-import time
+from urllib.parse import urljoin
 
 
 class ProcessingServer(FastAPI):
@@ -343,7 +343,7 @@ class ProcessingServer(FastAPI):
             )
         # Request the tool json from the Processor Server
         response = requests.get(
-            processor_server_url,
+            urljoin(processor_server_url, 'info'),
             headers={'Content-Type': 'application/json'}
         )
         if not response.status_code == 200:
@@ -522,7 +522,7 @@ class ProcessingServer(FastAPI):
         timeout = httpx.Timeout(timeout=request_timeout, connect=30.0)
         async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.post(
-                processor_server_url,
+                urljoin(processor_server_url, 'run'),
                 headers={'Content-Type': 'application/json'},
                 json=json.loads(json_data)
             )
@@ -648,7 +648,7 @@ class ProcessingServer(FastAPI):
         ocrd_tool = self.ocrd_all_tool_json.get(processor_name, None)
         if not ocrd_tool:
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Ocrd tool JSON of '{processor_name}' not available!"
             )
 

--- a/ocrd_network/ocrd_network/server_utils.py
+++ b/ocrd_network/ocrd_network/server_utils.py
@@ -15,23 +15,22 @@ from .database import (
 from .models import PYJobInput, PYJobOutput
 
 
-async def _get_processor_job(logger, processor_name: str, job_id: str) -> PYJobOutput:
+async def _get_processor_job(logger, job_id: str) -> PYJobOutput:
     """ Return processing job-information from the database
     """
     try:
         job = await db_get_processing_job(job_id)
         return job.to_job_output()
     except ValueError as e:
-        logger.exception(f"Processing job with id '{job_id}' of processor type "
-                         f"'{processor_name}' not existing, error: {e}")
+        logger.exception(f"Processing job with id '{job_id}' not existing, error: {e}")
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Processing job with id '{job_id}' of processor type '{processor_name}' not existing"
+            detail=f"Processing job with id '{job_id}' not existing"
         )
 
 
-async def _get_processor_job_log(logger, processor_name: str, job_id: str) -> FileResponse:
-    db_job = await _get_processor_job(logger, processor_name, job_id)
+async def _get_processor_job_log(logger, job_id: str) -> FileResponse:
+    db_job = await _get_processor_job(logger, job_id)
     log_file_path = Path(db_job.log_file_path)
     return FileResponse(path=log_file_path, filename=log_file_path.name)
 


### PR DESCRIPTION
This is to simplify the api for handling processor requests. `processor_name` is removed where it is not needed and the remaining paths are adapted to that.
As discussed on Monday. Separate PR for workflow will follow later.