### PR TITLE
ocrd workspace list-page: implement partioning, #1140

### DIFF
--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -605,7 +605,7 @@ def list_pages(ctx, output_format, chunk_number, chunk_index, page_id_range, num
     ids = sorted(list(set([x.pageId for x in workspace.mets.find_files(**find_kwargs)])))
     if numeric_range:
         start, end = map(int, numeric_range.split('..'))
-        ids = ids[start:end]
+        ids = ids[start-1:end]
     chunks = list(np.array_split(ids, chunk_number))
     if chunk_index > -1:
         chunks = [chunks[chunk_index]]

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -9,11 +9,12 @@ import os
 from os import getcwd
 from os.path import relpath, exists, join, isabs
 from pathlib import Path
-from json import loads
+from json import loads, dumps
 import sys
 from glob import glob   # XXX pathlib.Path.glob does not support absolute globs
 import re
 import time
+import numpy as np
 
 import click
 
@@ -583,17 +584,37 @@ def list_groups(ctx):
     print("\n".join(workspace.mets.file_groups))
 
 # ----------------------------------------------------------------------
-# ocrd workspace list-pages
+# ocrd workspace list-page
 # ----------------------------------------------------------------------
 
 @workspace_cli.command('list-page')
+@click.option('-f', '--output-format', help="Output format", type=click.Choice(['one-per-line', 'comma-separated', 'json']), default='one-per-line')
+@click.option('-D', '--chunk-number', help="Partition the return value into n roughly equally sized chunks", default=1, type=int)
+@click.option('-C', '--chunk-index', help="Output the nth chunk of results, -1 for all of them.", default=-1, type=int)
+@click.option('-r', '--page-id-range', help="Restrict the pages to those matching the provided range, based on the @ID attribute. Separate start/end with ..")
+@click.option('-R', '--numeric-range', help="Restrict the pages to those in the range, in numerical document order. Separate start/end with ..")
 @pass_workspace
-def list_pages(ctx):
+def list_pages(ctx, output_format, chunk_number, chunk_index, page_id_range, numeric_range):
     """
     List physical page IDs
     """
     workspace = Workspace(ctx.resolver, directory=ctx.directory, mets_basename=ctx.mets_basename)
-    print("\n".join(workspace.mets.physical_pages))
+    find_kwargs = {}
+    if page_id_range:
+        find_kwargs['pageId'] = page_id_range
+    ids = sorted(list(set([x.pageId for x in workspace.mets.find_files(**find_kwargs)])))
+    if numeric_range:
+        start, end = map(int, numeric_range.split('..'))
+        ids = ids[start:end]
+    chunks = np.array_split(ids, chunk_number)
+    if chunk_index:
+        chunks = [chunks[chunk_index]]
+    if output_format == 'one-per-line':
+        print("\n".join(["\n".join(chunk) for chunk in chunks]))
+    elif output_format == 'comma-separated':
+        print("\n".join([",".join(chunk) for chunk in chunks]))
+    elif output_format == 'json':
+        print(json.dumps(chunks))
 
 # ----------------------------------------------------------------------
 # ocrd workspace get-id

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -20,7 +20,7 @@ import click
 
 from ocrd import Resolver, Workspace, WorkspaceValidator, WorkspaceBackupManager
 from ocrd.mets_server import OcrdMetsServer
-from ocrd_utils import getLogger, initLogging, pushd_popd, EXT_TO_MIME, safe_filename, parse_json_string_or_file
+from ocrd_utils import getLogger, initLogging, pushd_popd, EXT_TO_MIME, safe_filename, parse_json_string_or_file, partition_list
 from ocrd.decorators import mets_find_options
 from . import command_with_replaced_help
 
@@ -590,7 +590,7 @@ def list_groups(ctx):
 @workspace_cli.command('list-page')
 @click.option('-f', '--output-format', help="Output format", type=click.Choice(['one-per-line', 'comma-separated', 'json']), default='one-per-line')
 @click.option('-D', '--chunk-number', help="Partition the return value into n roughly equally sized chunks", default=1, type=int)
-@click.option('-C', '--chunk-index', help="Output the nth chunk of results, -1 for all of them.", default=-1, type=int)
+@click.option('-C', '--chunk-index', help="Output the nth chunk of results, -1 for all of them.", default=None, type=int)
 @click.option('-r', '--page-id-range', help="Restrict the pages to those matching the provided range, based on the @ID attribute. Separate start/end with ..")
 @click.option('-R', '--numeric-range', help="Restrict the pages to those in the range, in numerical document order. Separate start/end with ..")
 @pass_workspace
@@ -602,14 +602,11 @@ def list_pages(ctx, output_format, chunk_number, chunk_index, page_id_range, num
     find_kwargs = {}
     if page_id_range:
         find_kwargs['pageId'] = page_id_range
-    ids = sorted(list(set([x.pageId for x in workspace.mets.find_files(**find_kwargs)])))
+    ids = sorted({x.pageId for x in workspace.mets.find_files(**find_kwargs)})
     if numeric_range:
         start, end = map(int, numeric_range.split('..'))
         ids = ids[start-1:end]
-    chunks = list(np.array_split(ids, chunk_number))
-    if chunk_index > -1:
-        chunks = [chunks[chunk_index]]
-    chunks = [list(x) for x in chunks]
+    chunks = partition_list(ids, chunk_number, chunk_index)
     if output_format == 'one-per-line':
         print("\n".join(["\n".join(chunk) for chunk in chunks]))
     elif output_format == 'comma-separated':

--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -606,15 +606,16 @@ def list_pages(ctx, output_format, chunk_number, chunk_index, page_id_range, num
     if numeric_range:
         start, end = map(int, numeric_range.split('..'))
         ids = ids[start:end]
-    chunks = np.array_split(ids, chunk_number)
-    if chunk_index:
+    chunks = list(np.array_split(ids, chunk_number))
+    if chunk_index > -1:
         chunks = [chunks[chunk_index]]
+    chunks = [list(x) for x in chunks]
     if output_format == 'one-per-line':
         print("\n".join(["\n".join(chunk) for chunk in chunks]))
     elif output_format == 'comma-separated':
         print("\n".join([",".join(chunk) for chunk in chunks]))
     elif output_format == 'json':
-        print(json.dumps(chunks))
+        print(dumps(chunks))
 
 # ----------------------------------------------------------------------
 # ocrd workspace get-id

--- a/ocrd_utils/ocrd_utils/__init__.py
+++ b/ocrd_utils/ocrd_utils/__init__.py
@@ -194,6 +194,7 @@ from .str import (
     is_string,
     make_file_id,
     nth_url_segment,
+    partition_list,
     parse_json_string_or_file,
     parse_json_string_with_comments,
     remove_non_path_from_url,

--- a/ocrd_utils/ocrd_utils/str.py
+++ b/ocrd_utils/ocrd_utils/str.py
@@ -16,7 +16,11 @@ if sys.version_info >= (3, 12):
 else:
     def batched(iterable, chunk_size):
         iterator = iter(iterable)
-        while chunk := tuple(islice(iterator, chunk_size)):
+        chunk = None
+        while True:
+            chunk = tuple(islice(iterator, chunk_size))
+            if not chunk:
+                break
             yield chunk
 
 __all__ = [

--- a/ocrd_utils/ocrd_utils/str.py
+++ b/ocrd_utils/ocrd_utils/str.py
@@ -7,12 +7,24 @@ import json
 from .constants import REGEX_FILE_ID
 from .deprecate import deprecation_warning
 from warnings import warn
+from math import ceil
+import sys
+from itertools import islice
+
+if sys.version_info >= (3, 12):
+    from itertools import batched
+else:
+    def batched(iterable, chunk_size):
+        iterator = iter(iterable)
+        while chunk := tuple(islice(iterator, chunk_size)):
+            yield chunk
 
 __all__ = [
     'assert_file_grp_cardinality',
     'concat_padded',
     'get_local_filename',
     'is_local_filename',
+    'partition_list',
     'is_string',
     'make_file_id',
     'nth_url_segment',
@@ -206,4 +218,26 @@ def generate_range(start, end):
         warn("Range '%s..%s': evaluates to the same number")
     for i in range(int(start_num), int(end_num) + 1):
         ret.append(start.replace(start_num, str(i).zfill(len(start_num))))
+    return ret
+
+def partition_list(lst, chunks, chunk_index=None):
+    """
+    Partition a list into roughly equally-sized chunks
+
+    Args:
+        lst (list): list to partition
+        chunks (int): number of chunks to generate (not per chunk!)
+
+    Keyword Args:
+        chunk_index (None|int): If provided, return only a list consisting of this chunk
+
+    Returns:
+        list(list())
+    """
+    if not lst:
+        return []
+    items_per_chunk = ceil(len(lst) / chunks)
+    ret = list(map(list, batched(lst, items_per_chunk)))
+    if chunk_index is not None:
+        return [ret[chunk_index]]
     return ret

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -553,5 +553,21 @@ class TestCli(TestCase):
                 assert f.local_filename == Path('BIN/FILE_0001_BIN.IMG-wolf.png')
                 assert f.url == 'https://host/FILE_0001_BIN.IMG-wolf/BIN/FILE_0001_BIN.IMG-wolf.png'
 
+    def test_list_page(self):
+        def _call(args):
+            _, out, _ = self.invoke_cli(workspace_cli, ['list-page', *args])
+            return out.rstrip('\n')
+        with pushd_popd(Path(__file__).parent.parent / 'data/list-page-workspace'):
+            assert _call([]) == 'PHYS_0001\nPHYS_0002\nPHYS_0003\nPHYS_0004\nPHYS_0005\nPHYS_0006\nPHYS_0008\nPHYS_0009\nPHYS_0010\nPHYS_0011\nPHYS_0012\nPHYS_0013\nPHYS_0014\nPHYS_0015\nPHYS_0016\nPHYS_0017\nPHYS_0018\nPHYS_0019\nPHYS_0020\nPHYS_0022\nPHYS_0023\nPHYS_0024\nPHYS_0025\nPHYS_0026\nPHYS_0027\nPHYS_0028\nPHYS_0029'
+            assert _call(['-f', 'comma-separated']) == 'PHYS_0001,PHYS_0002,PHYS_0003,PHYS_0004,PHYS_0005,PHYS_0006,PHYS_0008,PHYS_0009,PHYS_0010,PHYS_0011,PHYS_0012,PHYS_0013,PHYS_0014,PHYS_0015,PHYS_0016,PHYS_0017,PHYS_0018,PHYS_0019,PHYS_0020,PHYS_0022,PHYS_0023,PHYS_0024,PHYS_0025,PHYS_0026,PHYS_0027,PHYS_0028,PHYS_0029'
+            assert _call(['-f', 'json']) == '[["PHYS_0001", "PHYS_0002", "PHYS_0003", "PHYS_0004", "PHYS_0005", "PHYS_0006", "PHYS_0008", "PHYS_0009", "PHYS_0010", "PHYS_0011", "PHYS_0012", "PHYS_0013", "PHYS_0014", "PHYS_0015", "PHYS_0016", "PHYS_0017", "PHYS_0018", "PHYS_0019", "PHYS_0020", "PHYS_0022", "PHYS_0023", "PHYS_0024", "PHYS_0025", "PHYS_0026", "PHYS_0027", "PHYS_0028", "PHYS_0029"]]'
+            assert _call(['-f', 'comma-separated', '-R', '5..5']) == 'PHYS_0005'
+            assert _call(['-f', 'comma-separated', '-R', '6..8']) == 'PHYS_0006,PHYS_0008,PHYS_0009'
+            assert _call(['-f', 'comma-separated', '-r', 'PHYS_0006..PHYS_0009']) == 'PHYS_0006,PHYS_0008,PHYS_0009'
+            assert _call(['-f', 'comma-separated', '-r', 'PHYS_0001..PHYS_0010', '-D', '3']) == 'PHYS_0001,PHYS_0002,PHYS_0003\nPHYS_0004,PHYS_0005,PHYS_0006\nPHYS_0008,PHYS_0009,PHYS_0010'
+            assert _call(['-f', 'comma-separated', '-r', 'PHYS_0001..PHYS_0010', '-D', '3', '-C', '2']) == 'PHYS_0008,PHYS_0009,PHYS_0010'
+            from json import loads
+            assert loads(_call(['-f', 'json', '-r', 'PHYS_0001..PHYS_0010', '-D', '3', '-C', '2'])) == [['PHYS_0008', 'PHYS_0009', 'PHYS_0010']]
+
 if __name__ == '__main__':
     main(__file__)

--- a/tests/data/list-page-workspace/mets.xml
+++ b/tests/data/list-page-workspace/mets.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-0.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mix/v10 http://www.loc.gov/standards/mix/mix10/mix10.xsd">
+  <mets:metsHdr CREATEDATE="2023-11-20T19:35:02.939335">
+    <mets:agent TYPE="OTHER" OTHERTYPE="SOFTWARE" ROLE="CREATOR">
+      <mets:name>ocrd/core v2.58.1</mets:name>
+    </mets:agent>
+  </mets:metsHdr>
+  <mets:dmdSec ID="DMDLOG_0001">
+    <mets:mdWrap MDTYPE="MODS">
+      <mets:xmlData>
+        <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
+                </mods:mods>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:amdSec ID="AMD">
+    </mets:amdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="FOO">
+      <mets:file ID="FOO_1" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_2" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_3" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_4" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_5" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_6" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_8" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_9" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_10" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_11" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_12" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_13" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_14" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_15" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_16" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_17" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_18" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_19" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_20" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_22" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_23" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_24" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_25" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_26" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_27" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_28" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+      <mets:file ID="FOO_29" MIMETYPE="foo/bar">
+        <mets:FLocat xlink:href="mets.xml" LOCTYPE="OTHER" OTHERLOCTYPE="FILE"/>
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap TYPE="PHYSICAL">
+    <mets:div TYPE="physSequence">
+      <mets:div TYPE="page" ID="PHYS_0001">
+        <mets:fptr FILEID="FOO_1"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0002">
+        <mets:fptr FILEID="FOO_2"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0003">
+        <mets:fptr FILEID="FOO_3"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0004">
+        <mets:fptr FILEID="FOO_4"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0005">
+        <mets:fptr FILEID="FOO_5"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0006">
+        <mets:fptr FILEID="FOO_6"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0008">
+        <mets:fptr FILEID="FOO_8"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0009">
+        <mets:fptr FILEID="FOO_9"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0010">
+        <mets:fptr FILEID="FOO_10"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0011">
+        <mets:fptr FILEID="FOO_11"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0012">
+        <mets:fptr FILEID="FOO_12"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0013">
+        <mets:fptr FILEID="FOO_13"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0014">
+        <mets:fptr FILEID="FOO_14"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0015">
+        <mets:fptr FILEID="FOO_15"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0016">
+        <mets:fptr FILEID="FOO_16"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0017">
+        <mets:fptr FILEID="FOO_17"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0018">
+        <mets:fptr FILEID="FOO_18"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0019">
+        <mets:fptr FILEID="FOO_19"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0020">
+        <mets:fptr FILEID="FOO_20"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0022">
+        <mets:fptr FILEID="FOO_22"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0023">
+        <mets:fptr FILEID="FOO_23"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0024">
+        <mets:fptr FILEID="FOO_24"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0025">
+        <mets:fptr FILEID="FOO_25"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0026">
+        <mets:fptr FILEID="FOO_26"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0027">
+        <mets:fptr FILEID="FOO_27"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0028">
+        <mets:fptr FILEID="FOO_28"/>
+      </mets:div>
+      <mets:div TYPE="page" ID="PHYS_0029">
+        <mets:fptr FILEID="FOO_29"/>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,282 +48,259 @@ from ocrd_models.utils import xmllint_format
 from ocrd_models import OcrdMets
 
 
-class TestUtils(TestCase):
+def test_abspath():
+    assert abspath('file:///') == '/'
 
-    def test_abspath(self):
-        self.assertEqual(abspath('file:///'), '/')
+def test_points_from_xywh():
+    assert points_from_xywh({'x': 100, 'y': 100, 'w': 100, 'h': 100}) == '100,100 200,100 200,200 100,200'
 
-    def test_points_from_xywh(self):
-        self.assertEqual(
-            points_from_xywh({'x': 100, 'y': 100, 'w': 100, 'h': 100}),
-            '100,100 200,100 200,200 100,200')
+def test_points_from_bbox():
+    assert points_from_bbox(100, 100, 200, 200) == '100,100 200,100 200,200 100,200'
 
-    def test_points_from_bbox(self):
-        self.assertEqual(
-            points_from_bbox(100, 100, 200, 200),
-            '100,100 200,100 200,200 100,200')
+def test_points_from_polygon():
+    assert points_from_polygon([[100, 100], [200, 100], [200, 200], [100, 200]]) == '100,100 200,100 200,200 100,200'
 
-    def test_points_from_polygon(self):
-        self.assertEqual(
-            points_from_polygon([[100, 100], [200, 100], [200, 200], [100, 200]]),
-            '100,100 200,100 200,200 100,200')
+def test_polygon_from_x0y0x1y1():
+    assert polygon_from_x0y0x1y1([100, 100, 200, 200]) == [[100, 100], [200, 100], [200, 200], [100, 200]]
 
-    def test_polygon_from_x0y0x1y1(self):
-        self.assertEqual(
-            polygon_from_x0y0x1y1([100, 100, 200, 200]),
-            [[100, 100], [200, 100], [200, 200], [100, 200]])
+def test_points_from_x0y0x1y1():
+    assert points_from_x0y0x1y1([100, 100, 200, 200]) == '100,100 200,100 200,200 100,200'
 
-    def test_points_from_x0y0x1y1(self):
-        self.assertEqual(
-            points_from_x0y0x1y1([100, 100, 200, 200]),
-            '100,100 200,100 200,200 100,200')
+def test_bbox_from_points():
+    assert bbox_from_points('100,100 200,100 200,200 100,200') == (100, 100, 200, 200)
 
-    def test_bbox_from_points(self):
-        self.assertEqual(
-            bbox_from_points('100,100 200,100 200,200 100,200'), (100, 100, 200, 200))
+def test_bbox_from_xywh():
+    assert bbox_from_xywh({'x': 100, 'y': 100, 'w': 100, 'h': 100}) == (100, 100, 200, 200)
 
-    def test_bbox_from_xywh(self):
-        self.assertEqual(
-            bbox_from_xywh({'x': 100, 'y': 100, 'w': 100, 'h': 100}),
-            (100, 100, 200, 200))
+def test_xywh_from_polygon():
+    assert xywh_from_polygon([[100, 100], [200, 100], [200, 200], [100, 200]]) == {'x': 100, 'y': 100, 'w': 100, 'h': 100}
 
-    def test_xywh_from_polygon(self):
-        self.assertEqual(
-            xywh_from_polygon([[100, 100], [200, 100], [200, 200], [100, 200]]),
-            {'x': 100, 'y': 100, 'w': 100, 'h': 100})
+def test_xywh_from_points():
+    assert xywh_from_points('100,100 200,100 200,200 100,200') == {'x': 100, 'y': 100, 'w': 100, 'h': 100}
 
-    def test_xywh_from_points(self):
-        self.assertEqual(
-            xywh_from_points('100,100 200,100 200,200 100,200'),
-            {'x': 100, 'y': 100, 'w': 100, 'h': 100})
+def test_xywh_from_points_unordered():
+    assert xywh_from_points('500,500 100,100 200,100 200,200 100,200') == {'x': 100, 'y': 100, 'w': 400, 'h': 400}
 
-    def test_xywh_from_points_unordered(self):
-        self.assertEqual(
-            xywh_from_points('500,500 100,100 200,100 200,200 100,200'),
-            {'x': 100, 'y': 100, 'w': 400, 'h': 400})
+def test_polygon_from_points():
+    assert polygon_from_points('100,100 200,100 200,200 100,200') == [[100, 100], [200, 100], [200, 200], [100, 200]]
 
-    def test_polygon_from_points(self):
-        self.assertEqual(
-            polygon_from_points('100,100 200,100 200,200 100,200'),
-            [[100, 100], [200, 100], [200, 200], [100, 200]])
+def test_concat_padded():
+    assert concat_padded('x', 1) == 'x_0001'
+    assert concat_padded('x', 1, 2, 3) == 'x_0001_0002_0003'
+    assert concat_padded('x', 1, '2', 3) == 'x_0001_2_0003'
 
-    def test_concat_padded(self):
-        self.assertEqual(concat_padded('x', 1), 'x_0001')
-        self.assertEqual(concat_padded('x', 1, 2, 3), 'x_0001_0002_0003')
-        self.assertEqual(concat_padded('x', 1, '2', 3), 'x_0001_2_0003')
+def test_is_string():
+    assert is_string('x')
+    assert is_string(u'x')
 
-    def test_is_string(self):
-        self.assertTrue(is_string('x'))
-        self.assertTrue(is_string(u'x'))
+def test_xmllint():
+    xml_str = '<beep>\n  <boop>42</boop>\n</beep>\n'
+    pretty_xml = xmllint_format(xml_str).decode('utf-8')
+    assert pretty_xml == '<?xml version="1.0" encoding="UTF-8"?>\n' + xml_str
 
-    def test_xmllint(self):
-        xml_str = '<beep>\n  <boop>42</boop>\n</beep>\n'
-        pretty_xml = xmllint_format(xml_str).decode('utf-8')
-        self.assertEqual(pretty_xml, '<?xml version="1.0" encoding="UTF-8"?>\n' + xml_str)
+def test_membername():
+    class Klazz:
+        def __init__(self):
+            self.prop = 42
+    instance = Klazz()
+    assert membername(instance, 42) == 'prop'
 
-    def test_membername(self):
-        class Klazz:
-            def __init__(self):
-                self.prop = 42
-        instance = Klazz()
-        self.assertEqual(membername(instance, 42), 'prop')
+def test_pil_version():
+    """
+    Test segfault issue in PIL TiffImagePlugin
 
-    def test_pil_version(self):
-        """
-        Test segfault issue in PIL TiffImagePlugin
+    Run the same code multiple times to make segfaults more probable
 
-        Run the same code multiple times to make segfaults more probable
+    Test is failing due to segfaults in Pillow versions:
+        6.0.0
+        6.1.0
 
-        Test is failing due to segfaults in Pillow versions:
-            6.0.0
-            6.1.0
+    Test succeeds in Pillow versions:
+        5.3.1
+        5.4.1
+        6.2.0
+    """
+    for _ in range(0, 10):
+        pil_image = Image.open(assets.path_to('grenzboten-test/data/OCR-D-IMG-BIN/p179470.tif'))
+        pil_image.crop(box=[1539, 202, 1626, 271])
 
-        Test succeeds in Pillow versions:
-            5.3.1
-            5.4.1
-            6.2.0
-        """
-        for _ in range(0, 10):
-            pil_image = Image.open(assets.path_to('grenzboten-test/data/OCR-D-IMG-BIN/p179470.tif'))
-            pil_image.crop(box=[1539, 202, 1626, 271])
+def test_pushd_popd_newcwd():
+    cwd = getcwd()
+    tmp_dir = Path(gettempdir()).resolve()
+    with pushd_popd(tmp_dir):
+        assert getcwd() == str(tmp_dir)
+    assert getcwd() == cwd
+    assert getcwd() == cwd
 
-    def test_pushd_popd_newcwd(self):
-        cwd = getcwd()
-        tmp_dir = Path(gettempdir()).resolve()
-        with pushd_popd(tmp_dir):
-            self.assertEqual(getcwd(), str(tmp_dir))
-        self.assertEqual(getcwd(), cwd)
-        assert getcwd() == cwd
+def test_pushd_popd_tempdir():
+    cwd = getcwd()
+    tmp_dir = str(Path(gettempdir()).resolve())
+    with pushd_popd(tempdir=True) as newcwd:
+        newcwd_str = str(newcwd)
+        assert getcwd() == newcwd_str
+        assert newcwd_str.startswith(tmp_dir)
+    assert getcwd() == cwd
+    assert getcwd() == cwd
 
-    def test_pushd_popd_tempdir(self):
-        cwd = getcwd()
-        tmp_dir = str(Path(gettempdir()).resolve())
-        with pushd_popd(tempdir=True) as newcwd:
-            newcwd_str = str(newcwd)
-            self.assertEqual(getcwd(), newcwd_str)
-            self.assertTrue(newcwd_str.startswith(tmp_dir))
-        self.assertEqual(getcwd(), cwd)
-        assert getcwd() == cwd
+def test_pushd_popd_bad_call():
+    with raises(Exception, match='pushd_popd can accept either newcwd or tempdir, not both'):
+        with pushd_popd('/foo/bar', True):
+            pass
 
-    def test_pushd_popd_bad_call(self):
-        with self.assertRaisesRegex(Exception, 'pushd_popd can accept either newcwd or tempdir, not both'):
-            with pushd_popd('/foo/bar', True):
-                pass
+def test_is_local_filename():
+    assert is_local_filename('/foo/bar')
+    assert is_local_filename('file:///foo/bar')
+    assert is_local_filename('file:/foo/bar')
+    assert is_local_filename('foo/bar')
+    assert not is_local_filename('bad-scheme://foo/bar')
 
-    def test_is_local_filename(self):
-        self.assertTrue(is_local_filename('/foo/bar'))
-        self.assertTrue(is_local_filename('file:///foo/bar'))
-        self.assertTrue(is_local_filename('file:/foo/bar'))
-        self.assertTrue(is_local_filename('foo/bar'))
-        self.assertFalse(is_local_filename('bad-scheme://foo/bar'))
+def test_local_filename():
+    assert get_local_filename('/foo/bar') == '/foo/bar'
+    assert get_local_filename('file:///foo/bar') == '/foo/bar'
+    assert get_local_filename('file:/foo/bar') == '/foo/bar'
+    assert get_local_filename('/foo/bar', '/foo/') == 'bar'
+    assert get_local_filename('/foo/bar', '/foo') == 'bar'
+    assert get_local_filename('foo/bar', 'foo') == 'bar'
 
-    def test_local_filename(self):
-        self.assertEqual(get_local_filename('/foo/bar'), '/foo/bar')
-        self.assertEqual(get_local_filename('file:///foo/bar'), '/foo/bar')
-        self.assertEqual(get_local_filename('file:/foo/bar'), '/foo/bar')
-        self.assertEqual(get_local_filename('/foo/bar', '/foo/'), 'bar')
-        self.assertEqual(get_local_filename('/foo/bar', '/foo'), 'bar')
-        self.assertEqual(get_local_filename('foo/bar', 'foo'), 'bar')
+def test_remove_non_path_from_url():
+    assert remove_non_path_from_url('https://foo/bar') == 'https://foo/bar'
+    assert remove_non_path_from_url('https://foo//?bar#frag') == 'https://foo'
+    assert remove_non_path_from_url('/path/to/foo#frag') == '/path/to/foo'
 
-    def test_remove_non_path_from_url(self):
-        self.assertEqual(remove_non_path_from_url('https://foo/bar'), 'https://foo/bar')
-        self.assertEqual(remove_non_path_from_url('https://foo//?bar#frag'), 'https://foo')
-        self.assertEqual(remove_non_path_from_url('/path/to/foo#frag'), '/path/to/foo')
+def test_nth_url_segment():
+    assert nth_url_segment('') == ''
+    assert nth_url_segment('foo') == 'foo'
+    assert nth_url_segment('foo', n=-1) == 'foo'
+    assert nth_url_segment('foo', n=-2) == ''
+    assert nth_url_segment('foo/bar', n=-2) == 'foo'
+    assert nth_url_segment('/baz/bar', n=-2) == 'baz'
+    assert nth_url_segment('foo/') == 'foo'
+    assert nth_url_segment('foo//?bar#frag') == 'foo'
+    assert nth_url_segment('/path/to/foo#frag') == 'foo'
+    assert nth_url_segment('/path/to/foo#frag', n=-2) == 'to'
+    assert nth_url_segment('https://server/foo?xyz=zyx') == 'foo'
 
-    def test_nth_url_segment(self):
-        self.assertEqual(nth_url_segment(''), '')
-        self.assertEqual(nth_url_segment('foo'), 'foo')
-        self.assertEqual(nth_url_segment('foo', n=-1), 'foo')
-        self.assertEqual(nth_url_segment('foo', n=-2), '')
-        self.assertEqual(nth_url_segment('foo/bar', n=-2), 'foo')
-        self.assertEqual(nth_url_segment('/baz/bar', n=-2), 'baz')
-        self.assertEqual(nth_url_segment('foo/'), 'foo')
-        self.assertEqual(nth_url_segment('foo//?bar#frag'), 'foo')
-        self.assertEqual(nth_url_segment('/path/to/foo#frag'), 'foo')
-        self.assertEqual(nth_url_segment('/path/to/foo#frag', n=-2), 'to')
-        self.assertEqual(nth_url_segment('https://server/foo?xyz=zyx'), 'foo')
+def test_parse_json_string_or_file():
+    assert parse_json_string_or_file() == {}
+    assert parse_json_string_or_file('') == {}
+    assert parse_json_string_or_file(' ') == {}
+    assert parse_json_string_or_file('{}') == {}
+    assert parse_json_string_or_file('{"foo": 32}') == {'foo': 32}
+    assert parse_json_string_or_file(
+      '{"dpi": -1, "textequiv_level": "word", "overwrite_words": false, "raw_lines": false, "char_whitelist": "", "char_blacklist": "", "char_unblacklist": ""}') == \
+      {"dpi": -1, "textequiv_level": "word", "overwrite_words": False, "raw_lines": False, "char_whitelist": "", "char_blacklist": "", "char_unblacklist": ""}
 
-    def test_parse_json_string_or_file(self):
-        self.assertEqual(parse_json_string_or_file(), {})
-        self.assertEqual(parse_json_string_or_file(''), {})
-        self.assertEqual(parse_json_string_or_file(' '), {})
-        self.assertEqual(parse_json_string_or_file('{}'), {})
-        self.assertEqual(parse_json_string_or_file('{"foo": 32}'), {'foo': 32})
-        self.assertEqual(parse_json_string_or_file(
-          '{"dpi": -1, "textequiv_level": "word", "overwrite_words": false, "raw_lines": false, "char_whitelist": "", "char_blacklist": "", "char_unblacklist": ""}'
-        ), {"dpi": -1, "textequiv_level": "word", "overwrite_words": False, "raw_lines": False, "char_whitelist": "", "char_blacklist": "", "char_unblacklist": ""})
+def test_parameter_file():
+    """
+    Verify that existing filenames get priority over valid JSON string interpretation
+    """
+    with TemporaryDirectory() as tempdir:
+        paramfile = Path(tempdir, '{"foo":23}')  # XXX yes, the file is called '{"foo":23}'
+        paramfile.write_text('{"bar": 42}')
+        # /tmp/<var>/{"foo":23} -- exists, read file and parse as JSON
+        assert parse_json_string_or_file(str(paramfile)) == {'bar': 42}
+        # $PWD/{"foo":23} -- does not exist, parse as json
+        assert parse_json_string_or_file(paramfile.name) == {'foo': 23}
 
-    def test_parameter_file(self):
-        """
-        Verify that existing filenames get priority over valid JSON string interpretation
-        """
-        with TemporaryDirectory() as tempdir:
-            paramfile = Path(tempdir, '{"foo":23}')  # XXX yes, the file is called '{"foo":23}'
-            paramfile.write_text('{"bar": 42}')
-            # /tmp/<var>/{"foo":23} -- exists, read file and parse as JSON
-            self.assertEqual(parse_json_string_or_file(str(paramfile)), {'bar': 42})
-            # $PWD/{"foo":23} -- does not exist, parse as json
-            self.assertEqual(parse_json_string_or_file(paramfile.name), {'foo': 23})
+def test_parameter_file_comments():
+    with TemporaryDirectory() as tempdir:
+        jsonpath = Path(tempdir, 'test.json')
+        jsonpath.write_text("""\
+                {
+                    # Metasyntactical variables are rarely imaginative
+                    "foo": 42,
+                    # case in point:
+                    "bar": 23
+                }""")
+        assert parse_json_string_or_file(str(jsonpath)) == {'foo': 42, 'bar': 23}
 
-    def test_parameter_file_comments(self):
-        with TemporaryDirectory() as tempdir:
-            jsonpath = Path(tempdir, 'test.json')
-            jsonpath.write_text("""\
-                    {
-                        # Metasyntactical variables are rarely imaginative
-                        "foo": 42,
-                        # case in point:
-                        "bar": 23
-                    }""")
-            self.assertEqual(parse_json_string_or_file(str(jsonpath)), {'foo': 42, 'bar': 23})
+def test_parameters_invalid():
+    with raises(ValueError, match='Not a valid JSON object'):
+        parse_json_string_or_file('[]')
+    with raises(ValueError, match='Error parsing'):
+        parse_json_string_or_file('[}')
 
-    def test_parameters_invalid(self):
-        with self.assertRaisesRegex(ValueError, 'Not a valid JSON object'):
-            parse_json_string_or_file('[]')
-        with self.assertRaisesRegex(ValueError, 'Error parsing'):
-            parse_json_string_or_file('[}')
-
-    def test_mime_ext(self):
-        self.assertEqual(MIME_TO_EXT['image/jp2'], '.jp2')
-        self.assertEqual(EXT_TO_MIME['.jp2'], 'image/jp2')
-        self.assertEqual(MIME_TO_PIL['image/jp2'], 'JP2')
-        self.assertEqual(PIL_TO_MIME['JP2'], 'image/jp2')
+def test_mime_ext():
+    assert MIME_TO_EXT['image/jp2'] == '.jp2'
+    assert EXT_TO_MIME['.jp2'] == 'image/jp2'
+    assert MIME_TO_PIL['image/jp2'] == 'JP2'
+    assert PIL_TO_MIME['JP2'] == 'image/jp2'
 
 
-    def test_set_json_key_value_overrides(self):
-        self.assertEqual(set_json_key_value_overrides({}, ('foo', 'true')), {'foo': True})
-        self.assertEqual(set_json_key_value_overrides({}, ('foo', 'false')), {'foo': False})
-        self.assertEqual(set_json_key_value_overrides({}, ('foo', '42')), {'foo': 42})
-        self.assertEqual(set_json_key_value_overrides({}, ('foo', '42.3')), {'foo': 42.3})
-        self.assertEqual(set_json_key_value_overrides({}, ('foo', '["one", 2, 3.33]')), {'foo': ['one', 2, 3.33]})
-        self.assertEqual(set_json_key_value_overrides({}, ('foo', '{"one": 2}')), {'foo': {'one': 2}})
-        self.assertEqual(set_json_key_value_overrides({}, ('foo', '"a string"')), {'foo': 'a string'})
-        self.assertEqual(set_json_key_value_overrides({}, ('foo', 'a string')), {'foo': 'a string'})
+def test_set_json_key_value_overrides():
+    assert set_json_key_value_overrides({}, ('foo', 'true')) == {'foo': True}
+    assert set_json_key_value_overrides({}, ('foo', 'false')) == {'foo': False}
+    assert set_json_key_value_overrides({}, ('foo', '42')) == {'foo': 42}
+    assert set_json_key_value_overrides({}, ('foo', '42.3')) == {'foo': 42.3}
+    assert set_json_key_value_overrides({}, ('foo', '["one", 2, 3.33]')) == {'foo': ['one', 2, 3.33]}
+    assert set_json_key_value_overrides({}, ('foo', '{"one": 2}')) == {'foo': {'one': 2}}
+    assert set_json_key_value_overrides({}, ('foo', '"a string"')) == {'foo': 'a string'}
+    assert set_json_key_value_overrides({}, ('foo', 'a string')) == {'foo': 'a string'}
 
-    def test_assert_file_grp_cardinality(self):
-        with self.assertRaisesRegex(AssertionError, "Expected exactly 5 output file groups, but '.'FOO', 'BAR'.' has 2"):
-            assert_file_grp_cardinality('FOO,BAR', 5)
-        with self.assertRaisesRegex(AssertionError, "Expected exactly 1 output file group, but '.'FOO', 'BAR'.' has 2"):
-            assert_file_grp_cardinality('FOO,BAR', 1)
-        assert_file_grp_cardinality('FOO,BAR', 2)
-        with self.assertRaisesRegex(AssertionError, r"Expected exactly 1 output file group .foo bar., but '.'FOO', 'BAR'.' has 2"):
-            assert_file_grp_cardinality('FOO,BAR', 1, 'foo bar')
+def test_assert_file_grp_cardinality():
+    with raises(AssertionError, match="Expected exactly 5 output file groups, but '.'FOO', 'BAR'.' has 2"):
+        assert_file_grp_cardinality('FOO,BAR', 5)
+    with raises(AssertionError, match="Expected exactly 1 output file group, but '.'FOO', 'BAR'.' has 2"):
+        assert_file_grp_cardinality('FOO,BAR', 1)
+    assert_file_grp_cardinality('FOO,BAR', 2)
+    with raises(AssertionError, match="Expected exactly 1 output file group .foo bar., but '.'FOO', 'BAR'.' has 2"):
+        assert_file_grp_cardinality('FOO,BAR', 1, 'foo bar')
 
-    def test_make_file_id_simple(self):
-        f = create_ocrd_file('MAX', ID="MAX_0012")
-        self.assertEqual(make_file_id(f, 'FOO'), 'FOO_0012')
+def test_make_file_id_simple():
+    f = create_ocrd_file('MAX', ID="MAX_0012")
+    assert make_file_id(f, 'FOO') == 'FOO_0012'
 
-    def test_make_file_id_mets(self):
-        mets = OcrdMets.empty_mets()
-        for i in range(1, 10):
-            mets.add_file('FOO', ID="FOO_%04d" % (i), mimetype="image/tiff", pageId='FOO_%04d' % i)
-            mets.add_file('BAR', ID="BAR_%04d" % (i), mimetype="image/tiff", pageId='BAR_%04d' % i)
-        self.assertEqual(make_file_id(mets.find_all_files(ID='BAR_0007')[0], 'FOO'), 'FOO_0007')
-        f = mets.add_file('ABC', ID="BAR_42", mimetype="image/tiff")
-        mets.remove_file(fileGrp='FOO')
-        self.assertEqual(make_file_id(f, 'FOO'), 'FOO_BAR_42')
-        mets.add_file('FOO', ID="FOO_0001", mimetype="image/tiff")
+def test_make_file_id_mets():
+    mets = OcrdMets.empty_mets()
+    for i in range(1, 10):
+        mets.add_file('FOO', ID="FOO_%04d" % (i), mimetype="image/tiff", pageId='FOO_%04d' % i)
+        mets.add_file('BAR', ID="BAR_%04d" % (i), mimetype="image/tiff", pageId='BAR_%04d' % i)
+    assert make_file_id(mets.find_all_files(ID='BAR_0007')[0], 'FOO') == 'FOO_0007'
+    f = mets.add_file('ABC', ID="BAR_42", mimetype="image/tiff")
+    mets.remove_file(fileGrp='FOO')
+    assert make_file_id(f, 'FOO') == 'FOO_BAR_42'
+    mets.add_file('FOO', ID="FOO_0001", mimetype="image/tiff")
 
-    def test_make_file_id_570(self):
-        """https://github.com/OCR-D/core/pull/570"""
-        mets = OcrdMets.empty_mets()
-        f = mets.add_file('GRP', ID='FOO_0001', pageId='phys0001')
-        mets.add_file('GRP', ID='GRP2_0001', pageId='phys0002')
-        self.assertEqual(make_file_id(f, 'GRP2'), 'GRP2_phys0001')
+def test_make_file_id_570():
+    """https://github.com/OCR-D/core/pull/570"""
+    mets = OcrdMets.empty_mets()
+    f = mets.add_file('GRP', ID='FOO_0001', pageId='phys0001')
+    mets.add_file('GRP', ID='GRP2_0001', pageId='phys0002')
+    assert make_file_id(f, 'GRP2') == 'GRP2_phys0001'
 
-    def test_make_file_id_605(self):
-        """
-        https://github.com/OCR-D/core/pull/605
-        Also: Same fileGrp!
-        """
-        mets = OcrdMets.empty_mets()
-        f = mets.add_file('GRP1', ID='FOO_0001', pageId='phys0001')
-        f = mets.add_file('GRP2', ID='FOO_0002', pageId='phys0002')
-        # NB: same fileGrp
-        self.assertEqual(make_file_id(f, 'GRP2'), 'FOO_0002')
-        self.assertEqual(make_file_id(f, 'GRP3'), 'GRP3_phys0002')
+def test_make_file_id_605():
+    """
+    https://github.com/OCR-D/core/pull/605
+    Also: Same fileGrp!
+    """
+    mets = OcrdMets.empty_mets()
+    f = mets.add_file('GRP1', ID='FOO_0001', pageId='phys0001')
+    f = mets.add_file('GRP2', ID='FOO_0002', pageId='phys0002')
+    # NB: same fileGrp
+    assert make_file_id(f, 'GRP2') == 'FOO_0002'
+    assert make_file_id(f, 'GRP3') == 'GRP3_phys0002'
 
-    def test_make_file_id_744(self):
-        """
-        https://github.com/OCR-D/core/pull/744
-        > Often file IDs have two numbers, one of which will clash. In that case only the numerical fallback works.
-        """
-        mets = OcrdMets.empty_mets()
-        f = mets.add_file('GRP2', ID='img1796-97_00000024_img', pageId='phys0024')
-        f = mets.add_file('GRP2', ID='img1796-97_00000025_img', pageId='phys0025')
-        self.assertEqual(make_file_id(f, 'GRP3'), 'GRP3_phys0025')
+def test_make_file_id_744():
+    """
+    https://github.com/OCR-D/core/pull/744
+    > Often file IDs have two numbers, one of which will clash. In that case only the numerical fallback works.
+    """
+    mets = OcrdMets.empty_mets()
+    f = mets.add_file('GRP2', ID='img1796-97_00000024_img', pageId='phys0024')
+    f = mets.add_file('GRP2', ID='img1796-97_00000025_img', pageId='phys0025')
+    assert make_file_id(f, 'GRP3') == 'GRP3_phys0025'
 
-    def test_generate_range(self):
-        assert generate_range('PHYS_0001', 'PHYS_0005') == ['PHYS_0001', 'PHYS_0002', 'PHYS_0003', 'PHYS_0004', 'PHYS_0005']
-        with self.assertRaisesRegex(ValueError, 'could not find numeric part'):
-            generate_range('NONUMBER', 'ALSO_NONUMBER')
-        with warns(UserWarning, match='same number'):
-            generate_range('PHYS_0001_123', 'PHYS_0010_123') == 'PHYS_0001_123'
+def test_generate_range():
+    assert generate_range('PHYS_0001', 'PHYS_0005') == ['PHYS_0001', 'PHYS_0002', 'PHYS_0003', 'PHYS_0004', 'PHYS_0005']
+    with raises(ValueError, match='could not find numeric part'):
+        generate_range('NONUMBER', 'ALSO_NONUMBER')
+    with warns(UserWarning, match='same number'):
+        generate_range('PHYS_0001_123', 'PHYS_0010_123') == 'PHYS_0001_123'
 
-    def test_safe_filename(self):
-        assert safe_filename('Hello world,!') == 'Hello_world_'
-        assert safe_filename(' Καλημέρα κόσμε,') == '_Καλημέρα_κόσμε_'
-        assert safe_filename(':コンニチハ:') == '_コンニチハ_'
+def test_safe_filename():
+    assert safe_filename('Hello world,!') == 'Hello_world_'
+    assert safe_filename(' Καλημέρα κόσμε,') == '_Καλημέρα_κόσμε_'
+    assert safe_filename(':コンニチハ:') == '_コンニチハ_'
 
 if __name__ == '__main__':
     main(__file__)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,8 @@ from ocrd_utils import (
     parse_json_string_or_file,
     set_json_key_value_overrides,
 
+    partition_list,
+
     points_from_bbox,
     points_from_x0y0x1y1,
     points_from_xywh,
@@ -301,6 +303,17 @@ def test_safe_filename():
     assert safe_filename('Hello world,!') == 'Hello_world_'
     assert safe_filename(' Καλημέρα κόσμε,') == '_Καλημέρα_κόσμε_'
     assert safe_filename(':コンニチハ:') == '_コンニチハ_'
+
+def test_partition_list():
+    lst_10 = list(range(1, 11))
+    assert partition_list(None, 1) == []
+    assert partition_list([], 1) == []
+    assert partition_list(lst_10, 1) == [lst_10]
+    assert partition_list(lst_10, 3) == [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10]]
+    assert partition_list(lst_10, 3, 1) == [[5, 6, 7, 8]]
+    assert partition_list(lst_10, 3, 0) == [[1, 2, 3, 4]]
+    with raises(IndexError):
+        partition_list(lst_10, 5, 5)
 
 if __name__ == '__main__':
     main(__file__)


### PR DESCRIPTION
This extends the functionality of `ocrd workspace list-page` with a number of options to support different output formats, partitioning the list of pageIds into roughly equally distributed chunks and supporting both pageId and numerical ranges.

E.g. for a workspace with non-contiguous pageIds `PHYS_0001..PHYS_0006,PHYS_0008..PHYS_0009..PHYS_0021,PHYS_0023..PHYS_0029` (i.e. PHYS_007 and PHYS_0021 missing, cf. test workspace in the PR).

```
ocrd workspace list-page --help
Usage: ocrd workspace list-page [OPTIONS]

  List physical page IDs

Options:
  -f, --output-format [one-per-line|comma-separated|json]
                                  Output format
  -D, --chunk-number INTEGER      Partition the return value into n roughly
                                  equally sized chunks
  -C, --chunk-index INTEGER       Output the nth chunk of results, -1 for all
                                  of them.
  -r, --page-id-range TEXT        Restrict the pages to those matching the
                                  provided range, based on the @ID attribute.
                                  Separate start/end with ..
  -R, --numeric-range TEXT        Restrict the pages to those in the range, in
                                  numerical document order. Separate start/end
                                  with ..
  --help                          Show this message and exit.


# all IDs but comma-separated
ocrd workspace list-page -f comma-separated          
PHYS_0001,PHYS_0002,PHYS_0003,PHYS_0004,PHYS_0005,PHYS_0006,PHYS_0008,PHYS_0009,PHYS_0010,PHYS_0011,PHYS_0012,PHYS_0013,PHYS_0014,PHYS_0015,PHYS_0016,PHYS_0017,PHYS_0018,PHYS_0019,PHYS_0020,PHYS_0022,PHYS_0023,PHYS_0024,PHYS_0025,PHYS_0026,PHYS_0027,PHYS_0028,PHYS_0029

# all IDs but as JSON
ocrd workspace list-page -f json           
[["PHYS_0001", "PHYS_0002", "PHYS_0003", "PHYS_0004", "PHYS_0005", "PHYS_0006", "PHYS_0008", "PHYS_0009", "PHYS_0010", "PHYS_0011", "PHYS_0012", "PHYS_0013", "PHYS_0014", "PHYS_0015", "PHYS_0016", "PHYS_0017", "PHYS_0018", "PHYS_0019", "PHYS_0020", "PHYS_0022", "PHYS_0023", "PHYS_0024", "PHYS_0025", "PHYS_0026", "PHYS_0027", "PHYS_0028", "PHYS_0029"]]

# numeric page id range
ocrd workspace list-page -f comma-separated -R 5..20
PHYS_0006,PHYS_0008,PHYS_0009,PHYS_0010,PHYS_0011,PHYS_0012,PHYS_0013,PHYS_0014,PHYS_0015,PHYS_0016,PHYS_0017,PHYS_0018,PHYS_0019,PHYS_0020,PHYS_0022

# pageID range
ocrd workspace list-page -f comma-separated -r 'PHYS_0006..PHYS_0009'
PHYS_0006,PHYS_0008,PHYS_0009

# Partition into 5 chunks
ocrd workspace list-page -f comma-separated -D 5                     
PHYS_0001,PHYS_0002,PHYS_0003,PHYS_0004,PHYS_0005,PHYS_0006
PHYS_0008,PHYS_0009,PHYS_0010,PHYS_0011,PHYS_0012,PHYS_0013
PHYS_0014,PHYS_0015,PHYS_0016,PHYS_0017,PHYS_0018
PHYS_0019,PHYS_0020,PHYS_0022,PHYS_0023,PHYS_0024
PHYS_0025,PHYS_0026,PHYS_0027,PHYS_0028,PHYS_0029

# Partition into 5 chunks and output only the third chunk
ocrd workspace list-page -f comma-separated -D 5 -C 2
PHYS_0014,PHYS_0015,PHYS_0016,PHYS_0017,PHYS_0018
```

This uses `numpy.array_split` to do the chunking.

It's inefficient at the moment, using `find_files` and then sorting and I cannot guarantee off-by-one errors with the indexing, but if the general behavior is what has been wished for, then I can optimize it properly.