### PR TITLE
Fix ocrd workspace list-page: page ranges

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -309,11 +309,22 @@ def test_partition_list():
     assert partition_list(None, 1) == []
     assert partition_list([], 1) == []
     assert partition_list(lst_10, 1) == [lst_10]
-    assert partition_list(lst_10, 3) == [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10]]
-    assert partition_list(lst_10, 3, 1) == [[5, 6, 7, 8]]
+    assert partition_list(lst_10, 3) == [[1, 2, 3, 4], [5, 6, 7], [8, 9, 10]]
+    assert partition_list(lst_10, 3, 1) == [[5, 6, 7]]
     assert partition_list(lst_10, 3, 0) == [[1, 2, 3, 4]]
     with raises(IndexError):
-        partition_list(lst_10, 5, 5)
+        partition_list(lst_10, chunks=4, chunk_index=5)
+        partition_list(lst_10, chunks=5, chunk_index=5)
+        partition_list(lst_10, chunks=5, chunk_index=6)
+    with raises(ValueError):
+        partition_list(lst_10, chunks=11)
+    # odd prime number tests
+    lst_13 = list(range(1, 14))
+    assert partition_list(lst_13, chunks=2) == [[1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13]]
+    assert partition_list(lst_13, chunks=3) == [[1, 2, 3, 4, 5], [6, 7, 8, 9], [10, 11, 12, 13]]
+    assert partition_list(lst_13, chunks=4) == [[1, 2, 3, 4], [5, 6, 7], [8, 9, 10], [11, 12, 13]]
+    assert partition_list(lst_13, chunks=4, chunk_index=1) == [[5, 6, 7]]
+
 
 if __name__ == '__main__':
     main(__file__)


### PR DESCRIPTION
Problematic example case: 25 pages, 8 chunks -> 3,125 pages per chunk, the chunk should contain 3 pages, but contains 4 (due to the ceil method used), which makes the 7th chunk (chunk index 6) having only the 25th page, and the 8th chunk (chunk index 7) being empty which triggers an exception. Using the floor method would introduce other errors such as page overflowing (e.g., 3 pages per chunk is 24 pages, and the 25th page is lost).

Simply using NumPy, prevents such edge cases. 
Old output range: [[1, 2, 3, 4], [5, 6, 7, 8],..., [21, 22, 23, 24], [25]]
New output range: [[1, 2, 3, 4], [5, 6, 7],..., [20, 21, 22], [23, 24, 25]] 

Of course, it is also possible to have chunks divided based on leaps, e.g. [[1](https://stackoverflow.com/a/26021382)]:
```python
def chunks(l, amount):
    if amount < 1:
        raise ValueError('amount must be positive integer')
    chunk_len = len(l) // amount
    leap_parts = len(l) % amount
    remainder = amount // 2  # make it symmetrical
    i = 0
    while i < len(l):
        remainder += leap_parts
        end_index = i + chunk_len
        if remainder >= amount:
            remainder -= amount
            end_index += 1
        yield l[i:end_index]
        i = end_index
``` 

would produce:
[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12, 13], [14, 15, 16], [17, 18, 19], [20, 21, 22], [23, 24, 25]]