### PR TITLE
Update the RabbitMQ Version to 3.12

### DIFF
--- a/ocrd_network/ocrd_network/constants.py
+++ b/ocrd_network/ocrd_network/constants.py
@@ -1,4 +1,6 @@
 NETWORK_AGENT_SERVER = 'server'
 NETWORK_AGENT_WORKER = 'worker'
-DOCKER_IMAGE_RABBIT_MQ = 'rabbitmq:3.12-management'
 DOCKER_IMAGE_MONGO_DB = 'mongo'
+DOCKER_IMAGE_RABBIT_MQ = 'rabbitmq:3.12-management'
+# These feature flags are required by default to use the newer version
+DOCKER_RABBIT_MQ_FEATURES = 'quorum_queue,implicit_default_bindings,classic_mirrored_queue_version'

--- a/ocrd_network/ocrd_network/constants.py
+++ b/ocrd_network/ocrd_network/constants.py
@@ -1,4 +1,4 @@
 NETWORK_AGENT_SERVER = 'server'
 NETWORK_AGENT_WORKER = 'worker'
-DOCKER_IMAGE_RABBIT_MQ = 'rabbitmq:3-management'
+DOCKER_IMAGE_RABBIT_MQ = 'rabbitmq:3.12-management'
 DOCKER_IMAGE_MONGO_DB = 'mongo'

--- a/ocrd_network/ocrd_network/constants.py
+++ b/ocrd_network/ocrd_network/constants.py
@@ -1,2 +1,4 @@
 NETWORK_AGENT_SERVER = 'server'
 NETWORK_AGENT_WORKER = 'worker'
+DOCKER_IMAGE_RABBIT_MQ = 'rabbitmq:3-management'
+DOCKER_IMAGE_MONGO_DB = 'mongo'

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -15,7 +15,7 @@ from time import sleep
 
 from ocrd_utils import config, getLogger, safe_filename
 
-from .constants import NETWORK_AGENT_SERVER, NETWORK_AGENT_WORKER
+from .constants import NETWORK_AGENT_SERVER, NETWORK_AGENT_WORKER, DOCKER_RABBIT_MQ_FEATURES
 from .deployment_utils import (
     create_docker_client,
     DeployType,
@@ -280,7 +280,7 @@ class Deployer:
                 f'RABBITMQ_DEFAULT_USER={self.data_queue.username}',
                 f'RABBITMQ_DEFAULT_PASS={self.data_queue.password}',
                 # These feature flags are required by default to use the newer version
-                f'RABBITMQ_FEATURE_FLAGS=quorum_queue,implicit_default_bindings,classic_mirrored_queue_version'
+                f'RABBITMQ_FEATURE_FLAGS={DOCKER_RABBIT_MQ_FEATURES}'
             ]
         )
         assert res and res.id, \

--- a/ocrd_network/ocrd_network/deployer.py
+++ b/ocrd_network/ocrd_network/deployer.py
@@ -275,10 +275,12 @@ class Deployer:
             detach=detach,
             remove=remove,
             ports=ports_mapping,
-            # The default credentials to be used by the processing workers
             environment=[
+                # The default credentials to be used by the processing workers
                 f'RABBITMQ_DEFAULT_USER={self.data_queue.username}',
-                f'RABBITMQ_DEFAULT_PASS={self.data_queue.password}'
+                f'RABBITMQ_DEFAULT_PASS={self.data_queue.password}',
+                # These feature flags are required by default to use the newer version
+                f'RABBITMQ_FEATURE_FLAGS=quorum_queue,implicit_default_bindings,classic_mirrored_queue_version'
             ]
         )
         assert res and res.id, \

--- a/ocrd_network/ocrd_network/processing_server.py
+++ b/ocrd_network/ocrd_network/processing_server.py
@@ -25,7 +25,7 @@ from ocrd import Resolver, Workspace
 from ocrd.task_sequence import ProcessorTask
 from ocrd_utils import initLogging, getLogger, LOG_FORMAT
 
-from .constants import NETWORK_AGENT_SERVER, NETWORK_AGENT_WORKER
+from .constants import NETWORK_AGENT_SERVER, NETWORK_AGENT_WORKER, DOCKER_IMAGE_MONGO_DB, DOCKER_IMAGE_RABBIT_MQ
 from .database import (
     initiate_database,
     db_create_workspace,
@@ -255,10 +255,10 @@ class ProcessingServer(FastAPI):
         """ deploy agents (db, queue, workers) and start the processing server with uvicorn
         """
         try:
-            self.deployer.deploy_rabbitmq(image='rabbitmq:3-management', detach=True, remove=True)
+            self.deployer.deploy_rabbitmq(image=DOCKER_IMAGE_RABBIT_MQ, detach=True, remove=True)
             rabbitmq_url = self.deployer.data_queue.url
 
-            self.deployer.deploy_mongodb(image='mongo', detach=True, remove=True)
+            self.deployer.deploy_mongodb(image=DOCKER_IMAGE_MONGO_DB, detach=True, remove=True)
             self.mongodb_url = self.deployer.data_mongo.url
 
             # The RMQPublisher is initialized and a connection to the RabbitMQ is performed


### PR DESCRIPTION
Update the RabbitMQ version to 3.12 to allow usage of [poison message handling](https://www.rabbitmq.com/quorum-queues.html#poison-message-handling). Quorum queues allow to set the `delivery-limit` policy for queues. I.e., how many times a message could fail before being dropped.

Currently, the processing worker drops the messages after they fail **once** (unlike what we would like to have - 3 times). The older versions of RabbitMQ supported the `redelivered` feature for checking whether a message was redelivered or not, however, there was no way to know how many times it was redelivered. 


TODO: I am still experimenting and will extend the processing worker implementation to achieve a redelivery count of 3 or ideally any number configured with an env variable, say, 'OCRD_NETWORK_WORKER_QUEUE_MESSAGE_RETRIES'.