### PR TITLE
ocrd workpace list-page: ignore files without pageId, fix #1148

### DIFF
--- a/ocrd/ocrd/cli/workspace.py
+++ b/ocrd/ocrd/cli/workspace.py
@@ -610,7 +610,7 @@ def list_pages(ctx, output_format, chunk_number, chunk_index, page_id_range, num
     find_kwargs = {}
     if page_id_range:
         find_kwargs['pageId'] = page_id_range
-    ids = sorted({x.pageId for x in workspace.mets.find_files(**find_kwargs)})
+    ids = sorted({x.pageId for x in workspace.mets.find_files(**find_kwargs) if x.pageId})
     if numeric_range:
         start, end = map(int, numeric_range.split('..'))
         ids = ids[start-1:end]


### PR DESCRIPTION
Using `list-page` implies a need to know the list of pages, i.e. `mets:div` in the `PHYSICAL` structMap. So, we should not include `None` in the (generation of the) output list, which led to the issue raised in #1148.