### PR TITLE
WorkspaceBagger: Use, in order of preference, f.basename, f.contentids and f.ID for filenames

### DIFF
--- a/ocrd/ocrd/workspace_bagger.py
+++ b/ocrd/ocrd/workspace_bagger.py
@@ -18,6 +18,7 @@ from ocrd_utils import (
     unzip_file_to_dir,
     DEFAULT_METS_BASENAME,
     MIMETYPE_PAGE,
+    safe_filename,
     VERSION,
 )
 from ocrd_validators.constants import BAGIT_TXT, TMP_BAGIT_PREFIX, OCRD_BAGIT_PROFILE_URL
@@ -80,7 +81,10 @@ class WorkspaceBagger():
                     file_grp_dir.mkdir()
 
                 attr = 'local_filename' if f.local_filename else 'url'
-                basename = f.basename if f.basename else f"{f.ID}{MIME_TO_EXT.get(f.mimetype, '.xml')}"
+                if f.local_filename and f.basename:
+                    basename = f.basename
+                else:
+                    basename = safe_filename(f.contentids if f.contentids else f.ID) + MIME_TO_EXT.get(f.mimetype, '.xml')
                 _relpath = join(f.fileGrp, basename)
                 self.resolver.download_to_directory(file_grp_dir, getattr(f, attr), basename=basename)
                 changed_local_filenames[str(getattr(f, attr))] = _relpath

--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -27,6 +27,7 @@ class OcrdFile():
             local_filename (Path): ``@xlink:href`` pointing to the locally cached version of the file in the workspace
             ID (string): ``@ID`` of this ``mets:file``
             loctype (string): DEPRECATED do not use
+            contentids (string): ``@CONTENTIDS`` of the ``mets:div`` in the ``mets:structMap[@TYPE="PHYSICAL]`` this file manifests
         """
         if el is None:
             raise ValueError("Must provide mets:file element this OcrdFile represents")
@@ -136,6 +137,15 @@ class OcrdFile():
         self.mets.set_physical_page_for_file(pageId, self)
 
     @property
+    def contentids(self):
+        """
+        Get the ``@CONTENTIDS`` of the physical ``mets:structMap`` entry corresponding to this ``mets:file``.
+        """
+        if self.mets is None:
+            raise Exception("OcrdFile %s has no member 'mets' pointing to parent OcrdMets" % self)
+        return self.mets.get_contentids_for_file(self)
+
+    @property
     def loctypes(self):
         """
         Get the ``@LOCTYPE``s of the ``mets:file``.
@@ -226,7 +236,7 @@ class ClientSideOcrdFile:
     this represents the response of the :py:class:`ocrd.mets_server.OcrdMetsServer`.
     """
 
-    def __init__(self, el, mimetype=None, pageId=None, loctype='OTHER', local_filename=None, mets=None, url=None, ID=None, fileGrp=None):
+    def __init__(self, el, mimetype=None, pageId=None, loctype='OTHER', local_filename=None, mets=None, url=None, ID=None, fileGrp=None, contentids=None):
         """
         Args:
             el (): ignored
@@ -238,6 +248,7 @@ class ClientSideOcrdFile:
             url (string): ignored XXX the remote/original file once we have proper mets:FLocat bookkeeping 
             local_filename (): ``@xlink:href`` of this ``mets:file`` - XXX the local file once we have proper mets:FLocat bookkeeping
             ID (string): ``@ID`` of this ``mets:file``
+            fileGrp (string): ``@USE`` of the ``mets:fileGrp`` this file belongs to
         """
         self.ID = ID
         self.mimetype = mimetype

--- a/ocrd_models/ocrd_models/ocrd_mets.py
+++ b/ocrd_models/ocrd_models/ocrd_mets.py
@@ -722,6 +722,25 @@ class OcrdMets(OcrdXmlDocument):
         if len(ret):
             return ret[0]
 
+    def get_contentids_for_file(self, ocrd_file):
+        """
+        Get the ``@CONTENTIDS` attribute of the physical page (``@CONTENTIDS`` of the ``mets:structMap[@TYPE="PHYSICAL"]//mets:div[@TYPE="PAGE"]`` entry)
+        corresponding to the ``mets:file`` :py:attr:`ocrd_file`.
+        """
+        ret = []
+        if self._cache_flag:
+            for pageId in self._fptr_cache.keys():
+                if ocrd_file.ID in self._fptr_cache[pageId].keys():
+                    ret.append(self._page_cache[pageId].get('CONTENTIDS'))
+        else:
+            ret = self._tree.getroot().xpath(
+                '/mets:mets/mets:structMap[@TYPE="PHYSICAL"]/mets:div[@TYPE="physSequence"]/mets:div[@TYPE="page"][./mets:fptr[@FILEID="%s"]]/@CONTENTIDS' %
+                ocrd_file.ID, namespaces=NS)
+
+        # To get rid of the python's FutureWarning
+        if len(ret):
+            return ret[0]
+
     def remove_physical_page(self, ID):
         """
         Delete page (physical ``mets:structMap`` ``mets:div`` entry ``@ID``) :py:attr:`ID`.

--- a/tests/model/test_ocrd_file.py
+++ b/tests/model/test_ocrd_file.py
@@ -4,6 +4,7 @@ import pytest
 
 from tests.base import (
     main,
+    assets,
     create_ocrd_file,
     create_ocrd_file_with_defaults
 )
@@ -121,6 +122,10 @@ def test_fptr_changed_for_change_id():
     assert mets.get_physical_pages(for_fileIds=['FOO_1']) == [None]
     assert mets.get_physical_pages(for_fileIds=['BAZ_1']) == ['p0001']
 
+def test_get_contentids():
+    mets = OcrdMets(filename=assets.url_of('pembroke_werke_1766/data/mets.xml'))
+    ocrd_file = next(mets.find_files(pageId='PHYS_0009'))
+    assert ocrd_file.contentids == 'http://resolver.staatsbibliothek-berlin.de/SBB0001CA7900000009'
 
 if __name__ == '__main__':
     main(__file__)

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -396,6 +396,9 @@ def test_update_physical_page_attributes(sbb_directory_ocrd_mets):
     assert b'ORDER' in m.to_xml()
     assert b'ORDERLABEL' in m.to_xml()
 
+def test_get_contentids():
+    mets = OcrdMets(filename=assets.url_of('pembroke_werke_1766/data/mets.xml'))
+    assert mets.get_contentids_for_file(next(mets.find_files(pageId='PHYS_0009'))) == 'http://resolver.staatsbibliothek-berlin.de/SBB0001CA7900000009'
 
 if __name__ == '__main__':
     main(__file__)


### PR DESCRIPTION
As requested in #1154, this PR introduces a `contentids` attribute for `OcrdFile`, which delegates to `OcrdMets.get_contentids_for_file`, which looks up the `CONTENTIDS` attribute of the `mets:div[@TYPE="page"]` that a file belongs to.

The bagger uses this information to set the filenames of the bagged files.

E.g. for this `mets:file`

```xml
<mets:file ID="FILE_0009_DEFAULT" MIMETYPE="image/tiff">                                                                                                             
  <mets:FLocat xmlns:xlink="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlink:href="http://content.staatsbibliothek-berlin.de/dms/PPN85249078X/800/0/00000010.tif"/> 
</mets:file>                                                                                                                                                         
...
<mets:div CONTENTIDS="http://resolver.staatsbibliothek-berlin.de/SBB0001CA7900000010" ID="PHYS_0010" ORDER="10" ORDERLABEL="2" TYPE="page">
  <mets:fptr FILEID="FILE_0009_DEFAULT"/>                                                                                                  
</mets:div>                                                                                                                                
```

This file will be bagged as `DEFAULT/http_resolver_staatsbibliothek_berlin_de_SBB0001CA7900000010.tif`

If there was no `@CONTENTIDS` for the corresponding `mets:div[@TYPE="PAGE"]`, then the filename would be `DEFAULT/FILE_0009_DEFAULT.tif`.

A quick proof-of-concept to make sure this is the desired behavior, to be polished (e.g. adding setters for `contentids` and potentially also for `@ORDER`, `@ORDERLABEL` and make sure that we're consistent in all places where files are written out.

@M3ssman cannot use the "request review" feature because you're not in the OCR-D organization but would appreciate you providing one very much, thanks!
