### PR TITLE
docker: we need .git during build for setuptools_scm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 !Makefile
 !LICENSE
 !README.md
+!.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY ocrd_network/ ./ocrd_network
 COPY Makefile .
 COPY README.md .
 COPY LICENSE .
+COPY .git ./.git
 RUN echo 'APT::Install-Recommends "0"; APT::Install-Suggests "0";' >/etc/apt/apt.conf.d/ocr-d.conf
 RUN apt-get update && apt-get -y install software-properties-common \
     && apt-get update && apt-get -y install \


### PR DESCRIPTION
We now derive the version from the git repo, so we need to add it during the build.

BTW we don't need to add README.md and LICENSE, only to delete it in the last step, but not urgent.

Will merge and release right away so we can make sure dockerhub images get built.