### PR TITLE
ocrd_utils.is_oai_content: downgrade loglevel

### DIFF
--- a/ocrd_models/ocrd_models/utils.py
+++ b/ocrd_models/ocrd_models/utils.py
@@ -49,7 +49,7 @@ def is_oai_content(data):
     log = getLogger('ocrd.models.utils.is_oai_content')
     xml_root = ET.fromstring(data)
     root_tag = xml_root.tag
-    log.info("response data root.tag: '%s'" % root_tag)
+    log.debug("response data root.tag: '%s'" % root_tag)
     return str(root_tag).endswith('OAI-PMH')
 
 


### PR DESCRIPTION
Perhaps we should exhaustively search for all such places...

IMHO core logging should not be gabby by default. 

You can of course argue that the user could increase their default logger `ocrd*` filter levels. But that's already an expert step.

In that light, I really don't understand what motivated https://github.com/OCR-D/core/commit/ed33ac69b4fd3c6ffd7033245ab2ff37f6d80b16 (maybe @kba can elaborate) and recommend reverting (i.e. raising the root and `ocrd` loggers, used both on the default console and file handler, to `INFO` again).