### PR TITLE
Fix --editable install for setuptools>=64, pypa/setuptools#3548

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ jobs:
       - run: sudo make deps-ubuntu 
       - run: make install deps-test
       - run: make test benchmark
+      # smoke test to ensure that --editable install works
+      - run: make install-dev; ocrd --version
 
   test-python38:
     docker:
@@ -41,6 +43,8 @@ jobs:
       - run: sudo make deps-ubuntu
       - run: make install deps-test
       - run: make test benchmark
+      # smoke test to ensure that --editable install works
+      - run: make install-dev; ocrd --version
 
   test-python39:
     docker:
@@ -52,6 +56,8 @@ jobs:
       - run: sudo make deps-ubuntu
       - run: make install deps-test
       - run: make test benchmark
+      # smoke test to ensure that --editable install works
+      - run: make install-dev; ocrd --version
 
   test-python310:
     docker:
@@ -63,6 +69,8 @@ jobs:
       - run: sudo make deps-ubuntu
       - run: make install deps-test
       - run: make test benchmark
+      # smoke test to ensure that --editable install works
+      - run: make install-dev; ocrd --version
 
   test-python311:
     docker:
@@ -74,6 +82,8 @@ jobs:
       - run: sudo make deps-ubuntu
       - run: make install deps-test
       - run: make test benchmark
+      # smoke test to ensure that --editable install works
+      - run: make install-dev; ocrd --version
 
   deploy:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ help:
 
 # pip install command. Default: $(PIP_INSTALL)
 PIP_INSTALL ?= $(PIP) install
+PIP_INSTALL_CONFIG_OPTION ?=
 
 .PHONY: deps-cuda deps-ubuntu deps-test
 
@@ -125,12 +126,13 @@ build:
 # (Re)install the tool
 install: #build
 #	$(PIP_INSTALL) $(BUILD_ORDER:%=./%/dist/ocrd*`$(PYTHON) -m setuptools_scm 2>/dev/null`*.whl)
-	$(foreach MODULE,$(BUILD_ORDER),$(PIP_INSTALL) ./$(MODULE) &&) echo done
+	$(foreach MODULE,$(BUILD_ORDER),$(PIP_INSTALL) ./$(MODULE) $(PIP_INSTALL_CONFIG_OPTION) &&) echo done
 	@# workaround for shapely#1598
 	$(PIP) config set global.no-binary shapely
 
 # Install with pip install -e
-install-dev: PIP_INSTALL = $(PIP) install -e
+install-dev: PIP_INSTALL = $(PIP) install -e 
+install-dev: PIP_INSTALL_CONFIG_OPTION = --config-settings editable_mode=strict
 install-dev: uninstall
 	$(MAKE) install
 


### PR DESCRIPTION
Since we switched to `pyproject.toml`, we also require `setuptools>61`. And it looks like setuptools, since at least `64` does not support `pip install --editable` the way it used to. In particular, it does not seem to be able to handle the folder structure `ocrd_x/ocrd_x/__init__.py`.

To reproduce:

```
$ pip install 'setuptools>=64'
$ make install-dev
$ python -c 'from ocrd_utils import getLogger'                                                                                                                                    
Traceback (most recent call last):                                                                                                                                                  
  File "<string>", line 1, in <module>                                                                                                                                              
ImportError: cannot import name 'getLogger' from 'ocrd_utils' (unknown location)
```

The problem is in [setuptools package discovery](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html):

> File system entries in the current working directory whose names coincidentally match installed packages may take precedence in Python’s import system. Users are encouraged to avoid such scenarios [2].

The workaround is to use `pip install -e --config-settings editable_mode=strict` which this PR implements.

The proper solution is to either

a. switch away from setuptools
b. refactor the folder structure

Considering we've moved to `pyproject.toml` now and breaking the git history just to get `--editable` working without workarounds, I tend to `a.`.

But first, let's fix with this workaround so `make install-dev` works again.