### PR TITLE
make OcrdFile.local_filename str again

### DIFF
--- a/ocrd_models/ocrd_models/ocrd_file.py
+++ b/ocrd_models/ocrd_models/ocrd_file.py
@@ -39,7 +39,7 @@ class OcrdFile():
         self.pageId = pageId
 
         if local_filename:
-            self.local_filename = Path(local_filename)
+            self.local_filename = local_filename
         if url:
             self.url = url
 


### PR DESCRIPTION
Fixes a regression in #1079 which changed `.local_filename` type from str to Path

see https://github.com/OCR-D/core/pull/1079/files#r1459238204