### PR TITLE
METS Server: try to remove UDS socket at sys.exit

### DIFF
--- a/src/ocrd/workspace.py
+++ b/src/ocrd/workspace.py
@@ -82,7 +82,7 @@ class Workspace():
                 mets = ClientSideOcrdMets(mets_server_url)
                 if mets.workspace_path != self.directory:
                     raise ValueError(f"METS server {mets_server_url} workspace directory {mets.workspace_path} differs "
-                            "from local workspace directory {self.directory}. These are not the same workspaces.")
+                            f"from local workspace directory {self.directory}. These are not the same workspaces.")
             else:
                 mets = OcrdMets(filename=self.mets_target)
         self.mets = mets


### PR DESCRIPTION
Basically, just add `atexit(self.shutdown)`, so the socket file is removed when the process exits. This should cover most of the things that can go wrong, except `kill -9`/`C-\` which cannot be caught.