### PR TITLE
Dockerfile.cuda must set stage ocrd_core_base

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-FROM $BASE_IMAGE
+FROM $BASE_IMAGE AS ocrd_core_base
 
 ENV MAMBA_EXE=/usr/local/bin/conda
 ENV MAMBA_ROOT_PREFIX=/conda


### PR DESCRIPTION
We introduced multi-stage build in #1164 but forgot to also implement that in the `Dockerfile.cuda`. This PR rectifies that.