### PR TITLE
use lxml-stubs/types-lxml for typing support of lxml.etree

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -15,3 +15,6 @@ deprecated
 click
 twine
 wheel
+# For typing-compatible lxml interface definitions
+types-lxml ; python_version > '3.7'
+lxml-stubs ; python_version <= '3.7'

--- a/src/ocrd_models/ocrd_mets.py
+++ b/src/ocrd_models/ocrd_mets.py
@@ -5,13 +5,11 @@ from datetime import datetime
 import re
 import typing
 from typing_extensions import Optional
-from lxml import etree as ET   # type: ignore
-from copy import deepcopy
+from lxml import etree as ET
 from warnings import warn
 
 from ocrd_utils import (
     getLogger,
-    deprecation_warning,
     generate_range,
     VERSION,
     REGEX_PREFIX,
@@ -188,6 +186,7 @@ class OcrdMets(OcrdXmlDocument):
                 break
         if id_el is None:
             mods = self._tree.getroot().find('.//mods:mods', NS)
+            assert mods is not None
             id_el = ET.SubElement(mods, TAG_MODS_IDENTIFIER)
             id_el.set('type', 'purl')
         id_el.text = purl
@@ -482,7 +481,6 @@ class OcrdMets(OcrdXmlDocument):
             raise ValueError("Invalid syntax for mets:file/@ID %s (not an xs:ID)" % ID)
         if not REGEX_FILE_ID.fullmatch(fileGrp):
             raise ValueError("Invalid syntax for mets:fileGrp/@USE %s (not an xs:ID)" % fileGrp)
-        log = getLogger('ocrd.models.ocrd_mets.add_file')
 
         el_fileGrp = self.add_file_group(fileGrp)
         if not ignore:
@@ -566,7 +564,7 @@ class OcrdMets(OcrdXmlDocument):
             if self._cache_flag:
                 del self._fptr_cache[page_div.get('ID')][ID]
             # delete empty pages
-            if not page_div.getchildren():
+            if not list(page_div):
                 log.debug("Delete empty page %s", page_div)
                 page_div.getparent().remove(page_div)
                 # Delete the empty pages from caches as well

--- a/src/ocrd_models/ocrd_page_generateds.py
+++ b/src/ocrd_models/ocrd_page_generateds.py
@@ -24,6 +24,8 @@
 #   core
 #
 
+# type: ignore
+
 from itertools import zip_longest
 import os
 import sys

--- a/src/ocrd_models/ocrd_xml_base.py
+++ b/src/ocrd_models/ocrd_xml_base.py
@@ -2,7 +2,7 @@
 Base class for XML documents loaded from either content or filename.
 """
 from os.path import exists
-from lxml import etree as ET   # type: ignore
+from lxml import etree as ET
 
 from .constants import NAMESPACES
 from .utils import xmllint_format
@@ -29,11 +29,11 @@ class OcrdXmlDocument():
         elif content:
             self._tree = ET.ElementTree(ET.XML(content, parser=ET.XMLParser(encoding='utf-8')))
         else:
-            self._tree = ET.ElementTree()
+            assert filename
             filename = filename.replace('file://', '')
             if not exists(filename):
                 raise Exception('File does not exist: %s' % filename)
-            self._tree.parse(filename)
+            self._tree = ET.parse(filename)
 
         # Cache enabled - True/False
         self._cache_flag = cache_flag

--- a/src/ocrd_models/utils.py
+++ b/src/ocrd_models/utils.py
@@ -20,7 +20,6 @@ def xmllint_format(xml):
     Arguments:
         xml (string): Serialized XML
     """
-    log = getLogger('ocrd.models.utils.xmllint_format')
     parser = ET.XMLParser(resolve_entities=False, strip_cdata=False, remove_blank_text=True)
     document = ET.fromstring(xml, parser)
     return ('%s\n%s' % ('<?xml version="1.0" encoding="UTF-8"?>',

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -7,7 +7,7 @@ from os import environ
 from contextlib import contextmanager
 import shutil
 from logging import StreamHandler
-import lxml
+from lxml import etree as ET
 
 from tests.base import (
     main,
@@ -104,7 +104,7 @@ def test_physical_pages(sbb_sample_01):
     assert len(sbb_sample_01.physical_pages) == 3, '3 physical pages'
     assert isinstance(sbb_sample_01.physical_pages, list)
     assert isinstance(sbb_sample_01.physical_pages[0], str)
-    assert not isinstance(sbb_sample_01.physical_pages[0], lxml.etree._ElementUnicodeResult)
+    assert not isinstance(sbb_sample_01.physical_pages[0], ET._ElementUnicodeResult)
 
 def test_physical_pages_from_empty_mets():
     mets = OcrdMets(content="<mets></mets>")
@@ -236,9 +236,9 @@ def test_metshdr():
     Test whether metsHdr is created on-demand
     """
     mets = OcrdMets(content="<mets></mets>")
-    assert not mets._tree.getroot().getchildren()
+    assert not list(mets._tree.getroot())
     mets.add_agent()
-    assert len(mets._tree.getroot().getchildren()) == 1
+    assert len(mets._tree.getroot()) == 1
 
 
 def test_nocontent_nofilename_exception():


### PR DESCRIPTION
This adds typing support for lxml, to spot issues like using `_Element.getchildren` which apparently has been deprecated since 2008...