### PR TITLE
expose uninstall-workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ build-workaround: pyclean
 
 # test that the aliased packages work in isolation and combined
 test-workaround: build-workaround
-	for dist in $(BUILD_ORDER);do pip uninstall --yes $$dist;done
+	$(MAKE) uninstall-workaround
 	for dist in $(BUILD_ORDER);do \
 		pip install dist/$$dist-*.whl ;\
 		ocrd --version ;\
@@ -345,3 +345,7 @@ test-workaround: build-workaround
 	ocrd --version ;\
 	make test ;\
 	for dist in $(BUILD_ORDER);do pip uninstall --yes $$dist;done
+
+uninstall-workaround:
+	for dist in $(BUILD_ORDER);do $(PIP) uninstall --yes $$dist;done
+


### PR DESCRIPTION
Because of the alias workaround, `make uninstall` is not enough. Hence the additional target.

See also https://github.com/OCR-D/ocrd_all/issues/416