### PR TITLE
Remove old code for unsupported Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,19 +21,6 @@ jobs:
       - run: make install
       - run: export PATH="/Users/distiller/Library/Python/3.9/bin:$PATH"; make deps-test test benchmark
 
-  test-python37:
-    docker:
-      - image: cimg/python:3.7
-    working_directory: ~/ocrd-core
-    steps:
-      - checkout
-      - run: sudo apt-get -y update
-      - run: sudo make deps-ubuntu 
-      - run: make install deps-test
-      - run: make test benchmark
-      # smoke test to ensure that --editable install works
-      - run: make install-dev; ocrd --version
-
   test-python38:
     docker:
       - image: cimg/python:3.8

--- a/.github/workflows/network-testing.yml
+++ b/.github/workflows/network-testing.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pip install ocrd
 pip install ocrd_modelfactory
 ```
 
-All python software released by [OCR-D](https://github.com/OCR-D) requires Python 3.7 or higher.
+All Python software released by [OCR-D](https://github.com/OCR-D) requires Python 3.8 or higher.
 
 **NOTE** Some OCR-D-Tools (or even test cases) _might_ reveal an unintended behavior if you have specific environment modifications, like:
 * using a custom build of [ImageMagick](https://github.com/ImageMagick/ImageMagick), whose format delegates are different from what OCR-D supposes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "ocrd"
 authors = [{name = "Konstantin Baierer", email = "unixprog@gmail.com"}]
 license = {text = "Apache License 2.0"}
 description = "OCR-D framework"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = ['version', 'dependencies']
 
 [project.readme]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -16,5 +16,4 @@ click
 twine
 wheel
 # For typing-compatible lxml interface definitions
-types-lxml ; python_version > '3.7'
-lxml-stubs ; python_version <= '3.7'
+types-lxml


### PR DESCRIPTION
Since 27 June 2023, Python 3.8 is the oldest supported version of Python.