### PR TITLE
Fix some typos and help texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ Fixed:
 
 Fixed:
 
-  * Log level downgraded from DEBUG to INFO in loggin.conf, #1161
+  * Log level downgraded from DEBUG to INFO in logging.conf, #1161
   * log OAI check as `DEBUG` not `INFO`, #1160
 
 ## [2.60.1] - 2023-12-15
@@ -121,7 +121,7 @@ Changed:
 Fixed:
 
   * Chunking algorithm for `ocrd workspace list-page` now handles edge cases properly, #1145
-  * Avoid deadlocks in `ocrd_network` if procesing workers not deployed, #1125, #1142
+  * Avoid deadlocks in `ocrd_network` if processing workers not deployed, #1125, #1142
 
 ## [2.59.0] - 2023-11-27
 
@@ -262,7 +262,7 @@ Changed:
 
 Added
 
-  * Environement variables to control optional retries and timeouts for downloading files:
+  * Environment variables to control optional retries and timeouts for downloading files:
     * `OCRD_DOWNLOAD_RETRIES`: Number of times to retry failed attempts for downloads of workspace files. #1073
     * `OCRD_DOWNLOAD_TIMEOUT`: Timeout in seconds for connecting or reading (comma-separated) when downloading. #1073
   * Environment variables used throughout core are now documented in README and `ocrd --help`,  #1073
@@ -548,7 +548,7 @@ Fixed:
 
 Changed:
 
-  * Consistenly use snake_case but continue to support CamelCase for kwargs and CLI options, #874, #862
+  * Consistently use snake_case but continue to support CamelCase for kwargs and CLI options, #874, #862
   * Update to spec to 3.19.0, introducing greater flexibility in describing parameters, #872, #848, OCR-D/spec#206
   * `ocrd workspace merge`: support mapping `file_id` and `page_id` in addition to `file_grp`, #886, #888
   * `ocrd workspace merge`: rebase `OcrdFile.url` to target workspace, #887, #888
@@ -958,7 +958,7 @@ Changed:
 
 Added:
 
-  * processors can `self.add_metada(pcgts)` to add a self-describing `pg:MetadataItem`, #574
+  * processors can `self.add_metadata(pcgts)` to add a self-describing `pg:MetadataItem`, #574
 
 
 ## [2.13.2] - 2020-08-13
@@ -1005,7 +1005,7 @@ Fixed:
 
 Fixed:
 
-  * logging no longer intereferes with `--dump-json`/`--help`/`--version`, #540, #546
+  * logging no longer interferes with `--dump-json`/`--help`/`--version`, #540, #546
 
 ## [2.12.3] - 2020-07-23
 
@@ -1122,7 +1122,7 @@ Changed:
 Added:
 
   * Workspace: Optional `overwrite_mode` that sets `force` for all operations
-  * `OcrdPage`: `get_AllAlternaiveImagePaths` to list all `pc:AlternativeImage/@filename` referenced in a PcGts, #434, #471
+  * `OcrdPage`: `get_AllAlternativeImagePaths` to list all `pc:AlternativeImage/@filename` referenced in a PcGts, #434, #471
   * `ocrd workspace bulk-add` to add many files at once to a workspace, #428
   * `OcrdMets.add_file`: `ignore` parameter to optionally disable looking for existing files, #428
 
@@ -1832,7 +1832,7 @@ Changed:
       a temporary directory but reuse the existing directory
     * When not providing `mets_basename`, assume the last URL path segment to be
       the METS basename instead of the fixed string `mets.xml`
-  * incoroporate changes to ocrd_tool schema from spec/v2.2.1
+  * incorporate changes to ocrd_tool schema from spec/v2.2.1
 
 ## [0.6.0] - 2018-07-23
 

--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -35,7 +35,7 @@ from ocrd_utils import (
 from ocrd_validators import ParameterValidator
 from ocrd_models.ocrd_page import MetadataItemType, LabelType, LabelsType
 
-# XXX imports must remain for backwards-compatibilty
+# XXX imports must remain for backwards-compatibility
 from .helpers import run_cli, run_processor, generate_processor_help # pylint: disable=unused-import
 
 class Processor():

--- a/src/ocrd/workspace_bagger.py
+++ b/src/ocrd/workspace_bagger.py
@@ -272,7 +272,7 @@ class WorkspaceBagger():
         appropriate value.
 
         Arguments:
-            src (string):    Path to Bag. May be an zipped or unziped bagit
+            src (string):    Path to Bag. May be a zipped or unzipped bagit
             dest (string):   Path to where the result should be stored. Not needed if overwrite is
                              set
             overwrite(bool): Replace bag with newly created bag

--- a/src/ocrd_models/ocrd_mets.py
+++ b/src/ocrd_models/ocrd_mets.py
@@ -267,8 +267,8 @@ class OcrdMets(OcrdXmlDocument):
             local_filename (string) : ``@xlink:href`` local/cached filename of ``mets:Flocat`` of ``mets:file``
             mimetype (string) : ``@MIMETYPE`` of ``mets:file``
             local (boolean) : Whether to restrict results to local files in the filesystem
-            include_fileGrp (list[str]) : Whitelist of allowd file groups 
-            exclude_fileGrp (list[str]) : Blacklist of disallowd file groups 
+            include_fileGrp (list[str]) : List of allowed file groups
+            exclude_fileGrp (list[str]) : List of disallowd file groups
         Yields:
             :py:class:`ocrd_models:ocrd_file:OcrdFile` instantiations
         """

--- a/src/ocrd_models/ocrd_page_generateds.py
+++ b/src/ocrd_models/ocrd_page_generateds.py
@@ -223,7 +223,7 @@ class GeneratedsSuper(object):
             try:
                 int(value)
             except (TypeError, ValueError):
-                raise_parse_error(node, 'Requires sequence of integer valuess')
+                raise_parse_error(node, 'Requires sequence of integer values')
         return values
     def gds_format_float(self, input_data, input_name=''):
         return ('%.15f' % input_data).rstrip('0')

--- a/src/ocrd_network/runtime_data/network_agents.py
+++ b/src/ocrd_network/runtime_data/network_agents.py
@@ -15,7 +15,7 @@ def deploy_agent_native_get_pid_hack(logger: Logger, ssh_client, start_cmd: str)
     #   Note left from @joschrew
     #   the only way (I could find) to make it work to start a process in the background and
     #   return early is this construction. The pid of the last started background process is
-    #   printed with `echo $!` but it is printed inbetween other output. Because of that I added
+    #   printed with `echo $!` but it is printed between other output. Because of that I added
     #   `xyz` before and after the code to easily be able to filter out the pid via regex when
     #   returning from the function
 

--- a/src/ocrd_utils/config.py
+++ b/src/ocrd_utils/config.py
@@ -20,7 +20,7 @@ class OcrdEnvVariable():
         An environment variable for use in OCR-D.
 
         Args:
-            name (str): Name of the environment vairable
+            name (str): Name of the environment variable
             description (str): Description of what the variable is used for.
 
         Keyword Args:
@@ -28,7 +28,7 @@ class OcrdEnvVariable():
             validator (callable): Function to validate that the raw (string) value is parseable.
             default (tuple(bool, any)): 2-tuple, first element is a bool whether there is a default
                 value defined and second element contains that default value, which can be a callable
-                for defered evaluation
+                for deferred evaluation
         """
         self.name = name
         self.description = description

--- a/src/ocrd_utils/logging.py
+++ b/src/ocrd_utils/logging.py
@@ -101,7 +101,7 @@ def getLevelName(lvl):
 
 def getLogger(*args, **kwargs):
     """
-    Wrapper around ``logging.getLogger`` that alls :py:func:`initLogging` if
+    Wrapper around ``logging.getLogger`` that calls :py:func:`initLogging` if
     that wasn't explicitly called before.
     """
     logger = logging.getLogger(*args, **kwargs)

--- a/src/ocrd_utils/os.py
+++ b/src/ocrd_utils/os.py
@@ -124,7 +124,7 @@ def list_all_resources(executable, moduled=None, xdg_data_home=None):
     try:
         resource_locations = get_ocrd_tool_json(executable)['resource_locations']
     except FileNotFoundError:
-        # processor we're looking for ressource_locations of is not installed.
+        # processor we're looking for resource_locations of is not installed.
         # Assume the default
         resource_locations = ['data', 'cwd', 'system', 'module']
     xdg_data_home = config.XDG_DATA_HOME if not xdg_data_home else xdg_data_home
@@ -180,7 +180,7 @@ def get_processor_resource_types(executable, ocrd_tool=None):
         ocrd_tool = get_ocrd_tool_json(executable)
     if not next((True for p in ocrd_tool.get('parameters', {}).values() if 'content-type' in p), False):
         # None of the parameters for this processor are resources (or not
-        # the resource parametrs are not properly declared, so output both
+        # the resource parameters are not properly declared, so output both
         # directories and files
         return ['*/*']
     return [p['content-type'] for p in ocrd_tool['parameters'].values()
@@ -229,7 +229,7 @@ def itertree(path):
 
 def directory_size(path):
     """
-    Calculcates size of all files in directory ``path``
+    Calculates size of all files in directory ``path``
     """
     path = Path(path)
     return sum(f.stat().st_size for f in path.glob('**/*') if f.is_file())

--- a/tests/model/test_ocrd_mets.py
+++ b/tests/model/test_ocrd_mets.py
@@ -132,7 +132,7 @@ def test_physical_pages_for_fileids(sbb_directory_ocrd_mets):
     assert sbb_directory_ocrd_mets.get_physical_pages(
         for_fileIds=['FILE_0002_IMAGE']) == ['PHYS_0002']
 
-def test_physical_pages_for_emtpy_fileids(sbb_directory_ocrd_mets):
+def test_physical_pages_for_empty_fileids(sbb_directory_ocrd_mets):
     assert sbb_directory_ocrd_mets.get_physical_pages(
         for_fileIds=[]) == []
 

--- a/tests/model/test_ocrd_page.py
+++ b/tests/model/test_ocrd_page.py
@@ -253,7 +253,7 @@ def test_all_regions_without_reading_order():
     assert len(pg.get_AllRegions(classes=['Text'], depth=2)) == 37
 
 
-def test_get_all_regions_invalid_order_raises_exeption():
+def test_get_all_regions_invalid_order_raises_exception():
     # arrange
     with open(assets.path_to('gutachten/data/TEMP1/PAGE_TEMP1.xml'), 'r') as f:
         pg = parseString(f.read().encode('utf8'), silence=True).get_Page()
@@ -266,7 +266,7 @@ def test_get_all_regions_invalid_order_raises_exeption():
     assert "Argument 'order' must be either 'document', 'reading-order' or 'reading-order-only', not 'random'" in str(exc.value)
 
 
-def test_get_all_regions_invalid_depth_raises_exeption():
+def test_get_all_regions_invalid_depth_raises_exception():
     # arrange
     with open(assets.path_to('gutachten/data/TEMP1/PAGE_TEMP1.xml'), 'r') as f:
         pg = parseString(f.read().encode('utf8'), silence=True).get_Page()
@@ -301,7 +301,7 @@ def test_all_regions_with_reading_order():
     assert len(pg.get_AllRegions(classes=['Text'], order='reading-order', depth=1)) == 17
 
 
-def test_get_unorderd_group_children():
+def test_get_unordered_group_children():
     # arrange
     with open(assets.path_to('gutachten/data/TEMP1/PAGE_TEMP1.xml'), 'r') as f:
         pcgts = parseString(f.read().encode('utf8'), silence=True)

--- a/tests/test_logging_conf.py
+++ b/tests/test_logging_conf.py
@@ -27,7 +27,7 @@ def resetLogging():
 
 
 @pytest.fixture(name="logging_conf")
-def _fixture_loggin_conf(tmpdir):
+def _fixture_logging_conf(tmpdir):
 
     path_logging_conf_orig = os.path.join(
         str(TEST_ROOT), 'src', 'ocrd_utils', 'ocrd_logging.conf')

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -217,9 +217,9 @@ def test_workspace_from_nothing():
 
 
 def test_workspace_from_nothing_makedirs(tmp_path):
-    non_existant_dir = tmp_path / 'target'
-    ws1 = Resolver().workspace_from_nothing(non_existant_dir)
-    assert ws1.directory == non_existant_dir
+    non_existent_dir = tmp_path / 'target'
+    ws1 = Resolver().workspace_from_nothing(non_existent_dir)
+    assert ws1.directory == non_existent_dir
 
 
 def test_workspace_from_nothing_noclobber(tmp_path):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -268,7 +268,7 @@ def test_remove_file_force(sbb_data_workspace):
     """Enforce removal of non-existing-id doesn't yield any error
     but also returns no ocrd-file identifier"""
 
-    # TODO check semantics - can a non-existend thing be removed?
+    # TODO check semantics - can a non-existent thing be removed?
     assert not sbb_data_workspace.remove_file('non-existing-id', force=True)
     # should also succeed
     sbb_data_workspace.overwrite_mode = True

--- a/tests/utils/test_deprecate.py
+++ b/tests/utils/test_deprecate.py
@@ -4,7 +4,7 @@ from ocrd.cli import command_with_replaced_help
 
 from tests.base import CapturingTestCase as TestCase, main
 
-class TestDeprectateUtils(TestCase):
+class TestDeprecateUtils(TestCase):
 
     def test_help_replace(self):
         @click.command('foo', help='foo foo foo', cls=command_with_replaced_help(('foo', 'bar')))


### PR DESCRIPTION
Most typos were found by `codespell` and `typos`.