### PR TITLE
METS Server: improve logging

### DIFF
--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -100,7 +100,7 @@ class ClientSideOcrdMets():
 
     def __init__(self, url):
         self.protocol = 'tcp' if url.startswith('http://') else 'uds'
-        self.log = getLogger(f'ocrd.mets_client[{url}]')
+        self.log = getLogger(f'ocrd.models.ocrd_mets.client.{url}')
         self.url = url if self.protocol == 'tcp' else f'http+unix://{url.replace("/", "%2F")}'
 
     @property
@@ -197,7 +197,7 @@ class OcrdMetsServer():
         self.workspace = workspace
         self.url = url
         self.is_uds = not (url.startswith('http://') or url.startswith('https://'))
-        self.log = getLogger(f'ocrd.mets_server[{self.url}]')
+        self.log = getLogger(f'ocrd.models.ocrd_mets.server.{self.url}')
 
     def shutdown(self):
         if self.is_uds:
@@ -300,7 +300,7 @@ class OcrdMetsServer():
             """
             Stop the server
             """
-            getLogger('ocrd.models.ocrd_mets').info(f'Shutting down METS Server {self.url}')
+            self.log.info(f'Shutting down')
             workspace.save_mets()
             self.shutdown()
 

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -202,7 +202,7 @@ class OcrdMetsServer():
     def shutdown(self):
         if self.is_uds:
             if Path(self.url).exists():
-                self.log.warning(f'UDS socket {self.url} still exists, removing it')
+                self.log.debug(f'UDS socket {self.url} still exists, removing it')
                 Path(self.url).unlink()
         # os._exit because uvicorn catches SystemExit raised by sys.exit
         _exit(0)
@@ -319,6 +319,8 @@ class OcrdMetsServer():
         else:
             parsed = urlparse(self.url)
             uvicorn_kwargs = {'host': parsed.hostname, 'port': parsed.port}
+        uvicorn_kwargs['log_config'] = None
+        uvicorn_kwargs['access_log'] = False
 
         self.log.debug("Starting uvicorn")
         uvicorn.run(app, **uvicorn_kwargs)

--- a/src/ocrd_utils/ocrd_logging.conf
+++ b/src/ocrd_utils/ocrd_logging.conf
@@ -99,11 +99,11 @@ level=INFO
 handlers=consoleHandler
 qualname=uvicorn
 [logger_uvicorn_access]
-level=DEBUG
+level=WARN
 handlers=consoleHandler
 qualname=uvicorn.access
 [logger_uvicorn_error]
-level=DEBUG
+level=INFO
 handlers=consoleHandler
 qualname=uvicorn.error
 [logger_multipart]


### PR DESCRIPTION
This fixes some cosmetic issues for the METS Server's log output:
- we don't need the access_log – it's quite verbose and we can always just enable the workspace debug logging instead
- we should not allow Uvicorn to initialise its own log config – but have it use our preconfigured logging facility for consistency
- the loggers should all have the same name, and to be configurable, the URL should not be part of the top-level name
- removing the UDS socket on shutdown is the normal case – no need for a warning there