### PR TITLE
 make test-logging: remove .coverage if it exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ test-logging: assets
 	cd $$tempdir; \
 	$(PYTHON) -m pytest --continue-on-collection-errors -k TestLogging -k TestDecorators $(TESTDIR); \
 	rm -r $$tempdir/ocrd_logging.conf $$tempdir/.benchmarks; \
+	rm -rf $$tempdir/.coverage; \
 	rmdir $$tempdir
 
 network-module-test: assets


### PR DESCRIPTION
The `make coverage` test does not anticipate that `test-logging` is run in a temporary directory. This PR at least removes `.coverage` so `make coverage` won't fail, but we should find a way to have those results reflected in the total coverage.