### PR TITLE
Remove unused socket file on METS Server startup

### DIFF
--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -555,5 +555,3 @@ def is_socket_in_use(socket_path):
             return False
         client.close()
         return True
-    else:
-        return False

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -528,6 +528,9 @@ class OcrdMetsServer:
             # Create socket and change to world-readable and -writable to avoid permission errors
             self.log.debug(f"chmod 0o677 {self.url}")
             server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            if Path(self.url).exists() and not is_socket_in_use(self.url):
+                # remove leftover unused socket which blocks startup
+                Path(self.url).unlink()
             server.bind(self.url)  # creates the socket file
             atexit.register(self.shutdown)
             server.close()
@@ -541,3 +544,16 @@ class OcrdMetsServer:
 
         self.log.debug("Starting uvicorn")
         uvicorn.run(app, **uvicorn_kwargs)
+
+
+def is_socket_in_use(socket_path):
+    if Path(socket_path).exists():
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            client.connect(socket_path)
+        except OSError:
+            return False
+        client.close()
+        return True
+    else:
+        return False


### PR DESCRIPTION
The METS Server does not start if its desired socket file already exists. When experimenting with ocrd-network the socket file occasionally is not deleted on mets-server shutdown in some edge-cases e.g. killing the processing-server manually. Workaround is to just delete the socket file manually which is cumbersome.
This change tests if the socket file exists and deletes it in case it is not used by any socket.