### PR TITLE
fix: resmgr list-available * includes non-processors (again) #1218

### DIFF
--- a/src/ocrd/resource_manager.py
+++ b/src/ocrd/resource_manager.py
@@ -102,7 +102,7 @@ class OcrdResourceManager:
             for exec_dir in environ['PATH'].split(':'):
                 for exec_path in Path(exec_dir).glob(f'{executable}'):
                     self.log.debug(f"Inspecting '{exec_path} --dump-json' for resources")
-                    ocrd_tool = get_ocrd_tool_json(exec_path, True)
+                    ocrd_tool = get_ocrd_tool_json(exec_path)
                     for resdict in ocrd_tool.get('resources', ()):
                         if exec_path.name not in database:
                             database[exec_path.name] = []

--- a/src/ocrd/resource_manager.py
+++ b/src/ocrd/resource_manager.py
@@ -103,8 +103,7 @@ class OcrdResourceManager:
             for exec_dir in environ['PATH'].split(':'):
                 for exec_path in Path(exec_dir).glob(f'{executable}'):
                     if not exec_path.name.startswith('ocrd-'):
-                        self.log.debug(f"Not in 'ocrd-*' format, skipping '{exec_path}'")
-                        continue
+                        self.log.warning(f"OCR-D processor executable '{exec_path}' has no 'ocrd-' prefix")
                     if exec_path.name in skip_executables:
                         self.log.debug(f"No dump json available, skipping '{exec_path}'")
                         continue

--- a/src/ocrd/resource_manager.py
+++ b/src/ocrd/resource_manager.py
@@ -102,7 +102,7 @@ class OcrdResourceManager:
             for exec_dir in environ['PATH'].split(':'):
                 for exec_path in Path(exec_dir).glob(f'{executable}'):
                     self.log.debug(f"Inspecting '{exec_path} --dump-json' for resources")
-                    ocrd_tool = get_ocrd_tool_json(exec_path)
+                    ocrd_tool = get_ocrd_tool_json(exec_path, True)
                     for resdict in ocrd_tool.get('resources', ()):
                         if exec_path.name not in database:
                             database[exec_path.name] = []

--- a/src/ocrd/resource_manager.py
+++ b/src/ocrd/resource_manager.py
@@ -105,7 +105,7 @@ class OcrdResourceManager:
                     if not exec_path.name.startswith('ocrd-'):
                         self.log.warning(f"OCR-D processor executable '{exec_path}' has no 'ocrd-' prefix")
                     if exec_path.name in skip_executables:
-                        self.log.debug(f"No dump json available, skipping '{exec_path}'")
+                        self.log.debug(f"Not an OCR-D processor CLI, skipping '{exec_path}'")
                         continue
                     self.log.debug(f"Inspecting '{exec_path} --dump-json' for resources")
                     ocrd_tool = get_ocrd_tool_json(exec_path)

--- a/src/ocrd/resource_manager.py
+++ b/src/ocrd/resource_manager.py
@@ -99,8 +99,15 @@ class OcrdResourceManager:
         if not executable:
             return database.items()
         if dynamic:
+            skip_executables = ["ocrd-cis-data", "ocrd-import", "ocrd-make"]
             for exec_dir in environ['PATH'].split(':'):
                 for exec_path in Path(exec_dir).glob(f'{executable}'):
+                    if not exec_path.name.startswith('ocrd-'):
+                        self.log.debug(f"Not in 'ocrd-*' format, skipping '{exec_path}'")
+                        continue
+                    if exec_path.name in skip_executables:
+                        self.log.debug(f"No dump json available, skipping '{exec_path}'")
+                        continue
                     self.log.debug(f"Inspecting '{exec_path} --dump-json' for resources")
                     ocrd_tool = get_ocrd_tool_json(exec_path)
                     for resdict in ocrd_tool.get('resources', ()):

--- a/src/ocrd_utils/os.py
+++ b/src/ocrd_utils/os.py
@@ -75,27 +75,38 @@ def unzip_file_to_dir(path_to_zip, output_directory):
     z.close()
 
 @lru_cache()
-def get_ocrd_tool_json(executable):
+def get_ocrd_tool_json(executable, skip_error_print: bool = False):
     """
     Get the ``ocrd-tool`` description of ``executable``.
     """
+    ocrd_tool = {}
     executable_name = Path(executable).name
-    try:
-        ocrd_tool = loads(run([executable, '--dump-json'], stdout=PIPE).stdout)
-    except (JSONDecodeError, OSError) as e:
-        getLogger('ocrd.utils.get_ocrd_tool_json').error(f'{executable} --dump-json produced invalid JSON: {e}')
-        ocrd_tool = {}
+    # TODO: Potentially these executables should be moved as a constant somewhere else
+    skip_executables = ["ocrd-cis-data", "ocrd-import", "ocrd-make"]
+    if executable_name not in skip_executables:
+        try:
+            ocrd_tool = loads(run([executable, '--dump-json'], stdout=PIPE).stdout)
+        except (JSONDecodeError, OSError) as e:
+            if not skip_error_print:
+                getLogger('ocrd.utils.get_ocrd_tool_json').error(f'{executable} --dump-json produced invalid JSON: {e}')
+        except Exception as e:
+            if not skip_error_print:
+                getLogger('ocrd.utils.get_ocrd_tool_json').error(f'{executable} --dump-json failed: {e}')
     if 'resource_locations' not in ocrd_tool:
         ocrd_tool['resource_locations'] = ['data', 'cwd', 'system', 'module']
     return ocrd_tool
 
 @lru_cache()
-def get_moduledir(executable):
+def get_moduledir(executable, skip_error_print: bool = False):
     moduledir = None
     try:
         moduledir = run([executable, '--dump-module-dir'], encoding='utf-8', stdout=PIPE).stdout.rstrip('\n')
     except (JSONDecodeError, OSError) as e:
-        getLogger('ocrd.utils.get_moduledir').error(f'{executable} --dump-module-dir failed: {e}')
+        if not skip_error_print:
+            getLogger('ocrd.utils.get_moduledir').error(f'{executable} --dump-module-dir failed: {e}')
+    except Exception as e:
+        if not skip_error_print:
+            getLogger('ocrd.utils.get_moduledir').error(f'{executable} --dump-module-dir failed: {e}')
     return moduledir
 
 def list_resource_candidates(executable, fname, cwd=getcwd(), moduled=None, xdg_data_home=None):

--- a/src/ocrd_utils/os.py
+++ b/src/ocrd_utils/os.py
@@ -79,12 +79,12 @@ def get_ocrd_tool_json(executable):
     """
     Get the ``ocrd-tool`` description of ``executable``.
     """
-    ocrd_tool = {}
     executable_name = Path(executable).name
     try:
         ocrd_tool = loads(run([executable, '--dump-json'], stdout=PIPE).stdout)
     except (JSONDecodeError, OSError) as e:
         getLogger('ocrd.utils.get_ocrd_tool_json').error(f'{executable} --dump-json produced invalid JSON: {e}')
+        ocrd_tool = {}
     if 'resource_locations' not in ocrd_tool:
         ocrd_tool['resource_locations'] = ['data', 'cwd', 'system', 'module']
     return ocrd_tool


### PR DESCRIPTION
A partial fix for #1218.

There are still some annoying Tensorflow prints. Unfortunately, these cannot be disabled from the core or I am unaware how.
```sh
(venv38-core) mm@MM-Notebook:~/repos/core$ ocrd resmgr list-available
2024-07-04 12:17:53.701854: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2024-07-04 12:17:53.778978: I tensorflow/core/util/port.cc:104] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
2024-07-04 12:17:53.781393: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /home/mm/venv38-core/lib/python3.8/site-packages/cv2/../../lib64:
2024-07-04 12:17:53.781404: I tensorflow/compiler/xla/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
2024-07-04 12:17:54.178713: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /home/mm/venv38-core/lib/python3.8/site-packages/cv2/../../lib64:
2024-07-04 12:17:54.178761: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /home/mm/venv38-core/lib/python3.8/site-packages/cv2/../../lib64:
2024-07-04 12:17:54.178766: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.
2024-07-04 12:17:59.115332: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2024-07-04 12:17:59.191225: I tensorflow/core/util/port.cc:104] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
2024-07-04 12:17:59.193509: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /home/mm/venv38-all/lib/python3.8/site-packages/cv2/../../lib64:/home/mm/venv38-core/lib/python3.8/site-packages/cv2/../../lib64:
2024-07-04 12:17:59.193522: I tensorflow/compiler/xla/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
2024-07-04 12:17:59.624514: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /home/mm/venv38-all/lib/python3.8/site-packages/cv2/../../lib64:/home/mm/venv38-core/lib/python3.8/site-packages/cv2/../../lib64:
2024-07-04 12:17:59.624560: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /home/mm/venv38-all/lib/python3.8/site-packages/cv2/../../lib64:/home/mm/venv38-core/lib/python3.8/site-packages/cv2/../../lib64:
2024-07-04 12:17:59.624565: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.
WARNING:tensorflow:From /home/mm/venv38-all/lib/python3.8/site-packages/tensorflow/python/compat/v2_compat.py:107: disable_resource_variables (from tensorflow.python.ops.variable_scope) is deprecated and will be removed in a future version.
Instructions for updating:
non-resource variables are not supported in the long term
...
```