### PR TITLE
fix: increase health check retries

### DIFF
--- a/tests/network/docker-compose.yml
+++ b/tests/network/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
       interval: 1s
       timeout: 3s
-      retries: 30
+      retries: 90
 
   ocrd_network_rabbit_mq:
     image: "rabbitmq:3.12-management"
@@ -42,7 +42,7 @@ services:
       test: rabbitmq-diagnostics check_port_connectivity
       interval: 1s
       timeout: 3s
-      retries: 30
+      retries: 90
 
   ocrd_network_processing_server:
     image: "ocrd_core_test"


### PR DESCRIPTION
Increase the retries amount in the health check block of RabbitMQ and MongoDB services to avoid rarely occurring timeouts.
Check https://github.com/OCR-D/core/pull/1239#issuecomment-2194441324