### PR TITLE
Fix multi platform CD

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,9 @@ on:
 env:
   # FIXME: linux/arm/v7 disabled as long as scikit-build/cmake-python-distributions#503 is unresolved
   # PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le
-  PLATFORMS: linux/amd64,linux/arm64/v8,linux/ppc64le
+  # FIXME: linux/ppc64le probably similar cause for "Installing build dependencies: still running..."
+  # PLATFORMS: linux/amd64,linux/arm64/v8,linux/ppc64le
+  PLATFORMS: linux/amd64,linux/arm64/v8
 
 jobs:
 
@@ -19,17 +21,19 @@ jobs:
       packages: write
       contents: read
     env:
+      # build both tags at once:
       DOCKER_BASE_TAG: ghcr.io/ocr-d docker.io/ocrd
-      # TODO(kba): make the interpolation work correctly
-      # DOCKER_BUILD: docker buildx build --progress=plain --platform ${{ env.PLATFORMS }} --push
-      # TODO(kba): Investigate why ppc64le build hangs on "Installing build dependencies"
-      # TODO(kba): Investigate why arm64 fails with .buildkit_qemu_emulator: /usr/local/bin/conda: Invalid ELF image for this architecture
-      DOCKER_BUILD: docker buildx build --progress=plain --platform linux/amd64 --push
+      # replace native build with buildx
+      DOCKER_BUILD_CMD: docker buildx build --progress=plain --push --platform
     steps:
     - name: Export variables
       run: |
         echo "DOCKER_BASE_TAG=${{ env.DOCKER_BASE_TAG }}" >> $GITHUB_ENV
-        echo "DOCKER_BUILD=${{ env.DOCKER_BUILD }}" >> $GITHUB_ENV
+        echo "DOCKER_BUILD=${{ env.DOCKER_BUILD_CMD }} ${{ env.PLATFORMS }}" >> $GITHUB_ENV
+    - name: Print variables
+      run: |
+        echo DOCKER_BASE_TAG=${DOCKER_BASE_TAG}
+        echo DOCKER_BUILD=${DOCKER_BUILD}
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,9 @@ PIP_INSTALL_CONFIG_OPTION ?=
 deps-cuda: CONDA_EXE ?= /usr/local/bin/conda
 deps-cuda: export CONDA_PREFIX ?= /conda
 deps-cuda: PYTHON_PREFIX != $(PYTHON) -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'
+deps-cuda: ARCH != uname -p | sed 's/x86_64/64/'
 deps-cuda:
-	curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+	curl -Ls https://micro.mamba.pm/api/micromamba/linux-$(ARCH)/latest | tar -xvj bin/micromamba
 	mv bin/micromamba $(CONDA_EXE)
 # Install Conda system-wide (for interactive / login shells)
 	echo 'export MAMBA_EXE=$(CONDA_EXE) MAMBA_ROOT_PREFIX=$(CONDA_PREFIX) CONDA_PREFIX=$(CONDA_PREFIX) PATH=$(CONDA_PREFIX)/bin:$$PATH' >> /etc/profile.d/98-conda.sh


### PR DESCRIPTION
@kba I saw you struggle with my #1239 changes in https://github.com/OCR-D/core/actions/workflows/docker-image.yml afterwards. I did not test the last changes locally (and Github itself could not be used). Sorry about that!

Here is an attempt to at least gain the ARM64 target back. I am still looking for the problem with ppc64le – it used to work the first time, but perhaps now we are hitting the same scikit-build / cmake-python / opencv-python-headless issue as with arm/v7.

To test this locally, it suffices to do:

    docker buildx create --name container-builder --bootstrap --use
    make docker DOCKER_BUILD="docker buildx build --progress=plain --push --platform linux/amd64,linux/arm64/v8" DOCKER_BASE_TAG="ghcr.io/ocr-d docker.io/ocrd"

(or play with the platform argument, or do `make docker-cuda` etc)