### PR TITLE
Raise FileExistsError in Resolver.workspace_from_url if clobber_mets is False

### DIFF
--- a/src/ocrd/resolver.py
+++ b/src/ocrd/resolver.py
@@ -221,7 +221,7 @@ class Resolver():
 
         log.debug("workspace_from_url\nmets_basename='%s'\nmets_url='%s'\nsrc_baseurl='%s'\ndst_dir='%s'",
             mets_basename, mets_url, src_baseurl, dst_dir)
-        self.download_to_directory(dst_dir, mets_url, basename=mets_basename, if_exists='overwrite' if clobber_mets else 'skip')
+        self.download_to_directory(dst_dir, mets_url, basename=mets_basename, if_exists='overwrite' if clobber_mets else 'raise')
 
         workspace = Workspace(self, dst_dir, mets_basename=mets_basename, baseurl=src_baseurl, mets_server_url=mets_server_url)
 

--- a/src/ocrd/resolver.py
+++ b/src/ocrd/resolver.py
@@ -95,12 +95,15 @@ class Resolver():
                 log.debug("Stop early, src_path and dst_path are the same: '%s' (url: '%s')" % (src_path, url))
                 return str(ret)
 
-        # Respect 'if_exists' arg
+        # Respect 'if_exists' kwarg
         if dst_path.exists():
             if if_exists == 'skip':
+                log.debug(f"File already exists but if_exists == {if_exists}, skipping.")
                 return str(ret)
-            if if_exists == 'raise':
-                raise FileExistsError(f"File already exists and if_exists == 'raise': {dst_path}")
+            elif if_exists == 'raise':
+                raise FileExistsError(f"File already exists and if_exists == '{if_exists}': {dst_path}")
+            else:
+                log.debug(f"File already exists but if_exists == {if_exists}, overwriting.")
 
         # Create dst_path parent dir
         dst_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -117,6 +117,9 @@ def test_workspace_from_url_kant_with_resources(mock_request, tmp_path):
 
 @patch.object(Session, "get")
 def test_workspace_from_url_kant_with_resources_existing_local(mock_request, tmp_path):
+    """
+    Fail with clobber_mets=False, succeeed with clobber_mets=True
+    """
 
     # arrange
     url_src = 'https://raw.githubusercontent.com/OCR-D/assets/master/data/kant_aufklaerung_1784/data/mets.xml'
@@ -127,12 +130,14 @@ def test_workspace_from_url_kant_with_resources_existing_local(mock_request, tmp
     dst_mets = Path(dst_dir, 'mets.xml')
     shutil.copyfile(src_mets, dst_mets)
 
-    # act
-    Resolver().workspace_from_url(url_src, clobber_mets=False, dst_dir=dst_dir)
+    # fail
+    with pytest.raises(FileExistsError) as exc:
+        Resolver().workspace_from_url(url_src, clobber_mets=False, dst_dir=dst_dir)
+        assert mock_request.call_count == 0
 
-    # assert
-    # no real request was made, since mets already present
-    assert mock_request.call_count == 0
+    # succeed
+    Resolver().workspace_from_url(url_src, clobber_mets=True, dst_dir=dst_dir)
+    assert mock_request.call_count == 1
 
 
 @patch.object(Session, "get")
@@ -229,7 +234,7 @@ def test_workspace_from_nothing_noclobber(tmp_path):
     ws2 = Resolver().workspace_from_nothing(tmp_path)
     assert ws2.directory == tmp_path
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(FileExistsError) as exc:
         Resolver().workspace_from_nothing(tmp_path)
 
     # assert


### PR DESCRIPTION
As laid out in #563, the `clobber_mets` behavior was different from what the docstring said. Instead of raising and Exception if the METS file already existed and `clobber_mets` being `False`, the METS file was silently skipped.

The easiest way would have been to just change the docstring. But the current behavior is problematic because silently skipping downloading/copying the METS XML will lead to hard-to-debug errors when users subsequently work on the wrong METS XML file.