### PR TITLE
Identify provides the wrong ResolutionUnit for pyramid Tiff Files

### DIFF
--- a/src/ocrd_models/ocrd_exif.py
+++ b/src/ocrd_models/ocrd_exif.py
@@ -48,11 +48,11 @@ class OcrdExif():
         for prop in ['compression', 'photometric_interpretation']:
             setattr(self, prop, img.info[prop] if prop in img.info else None)
         if img.filename:
-            ret = run(['identify', '-format', r'%[resolution.x] %[resolution.y] %U', img.filename], check=False, stderr=PIPE, stdout=PIPE)
+            ret = run(['identify', '-format', r'%[resolution.x] %[resolution.y] %U ', img.filename], check=False, stderr=PIPE, stdout=PIPE)
         else:
             with BytesIO() as bio:
                 img.save(bio, format=img.format)
-                ret = run(['identify', '-format', r'%[resolution.x] %[resolution.y] %U', '/dev/stdin'], check=False, stderr=PIPE, stdout=PIPE, input=bio.getvalue())
+                ret = run(['identify', '-format', r'%[resolution.x] %[resolution.y] %U ', '/dev/stdin'], check=False, stderr=PIPE, stdout=PIPE, input=bio.getvalue())
         if ret.returncode:
             stderr = ret.stderr.decode('utf-8')
             if 'no decode delegate for this image format' in stderr:

--- a/tests/model/test_exif.py
+++ b/tests/model/test_exif.py
@@ -27,7 +27,10 @@ from ocrd_models import OcrdExif
      1457, 2084, 1, 1, 1, 'inches', 'RGB', None),
     # tolerate multi-frame TIFF:
     ('gutachten/data/IMG/IMG_1.tif',
-     2088, 2634, 300, 300, 300, 'inches', 'RGB', 'raw')
+     2088, 2634, 300, 300, 300, 'inches', 'RGB', 'raw'),
+    # multi-frame TIFF with metric pixel density (is actually YCBCR not RGB but Pillow thinks otherwise...)
+    ('indian-ferns/data/OCR-D-IMG/0004.tif',
+     2626, 3620, 28, 28, 28, 'cm', 'RGB', 'jpeg'),
 ])
 def test_ocrd_exif(path, width, height, xResolution, yResolution, resolution, resolutionUnit, photometricInterpretation, compression):
     """Check EXIF attributes for different input formats

--- a/tests/model/test_exif.py
+++ b/tests/model/test_exif.py
@@ -24,7 +24,10 @@ from ocrd_models import OcrdExif
     ('leptonica_samples/data/OCR-D-IMG/OCR-D-IMG_1555_007.jpg',
      944, 1472, 1, 1, 1, 'inches', 'RGB', None),
     ('kant_aufklaerung_1784-jp2/data/OCR-D-IMG/INPUT_0020.jp2',
-     1457, 2084, 1, 1, 1, 'inches', 'RGB', None)
+     1457, 2084, 1, 1, 1, 'inches', 'RGB', None),
+    # tolerate multi-frame TIFF:
+    ('gutachten/data/IMG/IMG_1.tif',
+     2088, 2634, 300, 300, 300, 'inches', 'RGB', 'raw')
 ])
 def test_ocrd_exif(path, width, height, xResolution, yResolution, resolution, resolutionUnit, photometricInterpretation, compression):
     """Check EXIF attributes for different input formats


### PR DESCRIPTION
Added space after %U in ImageMagick identify format prameter.

We work with pyramid Tiffs in our project. Since several images are combined in one file, identify provides all resolutions and resolution units one after the other. However, there is no space between the first and second image and the resolution unit is therefore read incorrectly. 

```
ret = run(['identify', '-format', r'%[resolution.x] %[resolution.y] %U', img.filename], check=False, stderr=PIPE, stdout=PIPE)
...
tokens = ret.stdout.decode('utf-8').split(' ', 3)
```

`['118.11', '118.11', 'PixelsPerCentimeter118.11', '118.11 PixelsPerCentimeter118.11 118.11 PixelsPerCentimeter118.11 118.11 PixelsPerCentimeter118.11 118.11 PixelsPerCentimeter']`

A simple space after the %U should solve the problem

```
ret = run(['identify', '-format', r'%[resolution.x] %[resolution.y] %U ', img.filename], check=False, stderr=PIPE, stdout=PIPE)
...
tokens = ret.stdout.decode('utf-8').split(' ', 3)
```

`['118.11', '118.11', 'PixelsPerCentimeter', '118.11 118.11 PixelsPerCentimeter 118.11 118.11 PixelsPerCentimeter 118.11 118.11 PixelsPerCentimeter 118.11 118.11 PixelsPerCentimeter ']`