### PR TITLE
introduce `-p/--print-status` to ocrd network client blocking commands

### DIFF
--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -434,7 +434,7 @@ class OcrdMetsServer:
     def shutdown(self):
         if self.is_uds:
             if Path(self.url).exists():
-                self.log.debug(f'UDS socket {self.url} still exists, removing it')
+                self.log.warning(f"Due to a server shutdown, removing the existing UDS socket file: {self.url}")
                 Path(self.url).unlink()
         # os._exit because uvicorn catches SystemExit raised by sys.exit
         _exit(0)

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -1,8 +1,10 @@
 """
 # METS server functionality
 """
+import os
 import re
 from os import _exit, chmod
+import signal
 from typing import Dict, Optional, Union, List, Tuple
 from time import sleep
 from pathlib import Path
@@ -428,8 +430,12 @@ class OcrdMetsServer:
 
     @staticmethod
     def kill_process(mets_server_pid: int):
-        subprocess_run(args=["kill", "-s", "SIGINT", f"{mets_server_pid}"], shell=False, universal_newlines=True)
-        return
+        os.kill(mets_server_pid, signal.SIGINT)
+        sleep(3)
+        try:
+            os.kill(mets_server_pid, signal.SIGKILL)
+        except ProcessLookupError as e:
+            pass
 
     def shutdown(self):
         if self.is_uds:

--- a/src/ocrd_network/cli/client.py
+++ b/src/ocrd_network/cli/client.py
@@ -104,7 +104,7 @@ def check_processing_job_status(address: Optional[str], processing_job_id: str):
 @click.option('--result-queue-name')
 @click.option('--callback-url')
 @click.option('--agent-type', default='worker')
-@click.option('-b', '--block', default=False,
+@click.option('-b', '--block', default=False, is_flag=True,
               help='If set, the client will block till job timeout, fail or success.')
 def send_processing_job_request(
     address: Optional[str],
@@ -176,7 +176,7 @@ def check_workflow_job_status(address: Optional[str], workflow_job_id: str):
                                 'the "OCRD_NETWORK_SERVER_ADDR_PROCESSING" env variable is used by default')
 @click.option('-m', '--path-to-mets', required=True)
 @click.option('-w', '--path-to-workflow', required=True)
-@click.option('-b', '--block', default=False,
+@click.option('-b', '--block', default=False, is_flag=True,
               help='If set, the client will block till job timeout, fail or success.')
 def send_workflow_job_request(
     address: Optional[str],

--- a/src/ocrd_network/cli/client.py
+++ b/src/ocrd_network/cli/client.py
@@ -122,7 +122,8 @@ def send_processing_job_request(
     # TODO: This is temporally available to toggle
     #  between the ProcessingWorker/ProcessorServer
     agent_type: Optional[str],
-    block: Optional[bool]
+    block: Optional[bool],
+    print_state: Optional[bool]
 ):
     """
     Submit a processing job to the processing server.
@@ -186,7 +187,8 @@ def send_workflow_job_request(
     address: Optional[str],
     path_to_mets: str,
     path_to_workflow: str,
-    block: Optional[bool]
+    block: Optional[bool],
+    print_state: Optional[bool]
 ):
     """
     Submit a workflow job to the processing server.

--- a/src/ocrd_network/cli/client.py
+++ b/src/ocrd_network/cli/client.py
@@ -106,6 +106,8 @@ def check_processing_job_status(address: Optional[str], processing_job_id: str):
 @click.option('--agent-type', default='worker')
 @click.option('-b', '--block', default=False, is_flag=True,
               help='If set, the client will block till job timeout, fail or success.')
+@click.option('-p', '--print-state', default=False, is_flag=True,
+              help='If set, the client will print job states by each iteration.')
 def send_processing_job_request(
     address: Optional[str],
     processor_name: str,
@@ -146,7 +148,7 @@ def send_processing_job_request(
     assert processing_job_id
     print(f"Processing job id: {processing_job_id}")
     if block:
-        client.poll_job_status(job_id=processing_job_id)
+        client.poll_job_status(job_id=processing_job_id, print_state=print_state)
 
 
 @client_cli.group('workflow')
@@ -178,6 +180,8 @@ def check_workflow_job_status(address: Optional[str], workflow_job_id: str):
 @click.option('-w', '--path-to-workflow', required=True)
 @click.option('-b', '--block', default=False, is_flag=True,
               help='If set, the client will block till job timeout, fail or success.')
+@click.option('-p', '--print-state', default=False, is_flag=True,
+              help='If set, the client will print job states by each iteration.')
 def send_workflow_job_request(
     address: Optional[str],
     path_to_mets: str,
@@ -192,7 +196,7 @@ def send_workflow_job_request(
     assert workflow_job_id
     print(f"Workflow job id: {workflow_job_id}")
     if block:
-        client.poll_workflow_status(job_id=workflow_job_id)
+        client.poll_workflow_status(job_id=workflow_job_id, print_state=print_state)
 
 
 @client_cli.group('workspace')

--- a/src/ocrd_network/client.py
+++ b/src/ocrd_network/client.py
@@ -60,7 +60,7 @@ class Client:
         return post_ps_processing_request(
             ps_server_host=self.server_addr_processing, processor=processor_name, job_input=req_params)
 
-    def send_workflow_job_request(self, path_to_wf: str, path_to_mets: str, page_wise: bool):
+    def send_workflow_job_request(self, path_to_wf: str, path_to_mets: str, page_wise: bool = False):
         return post_ps_workflow_request(
             ps_server_host=self.server_addr_processing, path_to_wf=path_to_wf, path_to_mets=path_to_mets,
             page_wise=page_wise)

--- a/src/ocrd_network/client.py
+++ b/src/ocrd_network/client.py
@@ -19,7 +19,8 @@ class Client:
         self,
         server_addr_processing: Optional[str],
         timeout: int = config.OCRD_NETWORK_CLIENT_POLLING_TIMEOUT,
-        wait: int = config.OCRD_NETWORK_CLIENT_POLLING_SLEEP
+        wait: int = config.OCRD_NETWORK_CLIENT_POLLING_SLEEP,
+        print_output: bool = config.OCRD_NETWORK_CLIENT_POLLING_PRINT
     ):
         self.log = getLogger(f"ocrd_network.client")
         if not server_addr_processing:
@@ -29,6 +30,7 @@ class Client:
         self.polling_timeout = timeout
         self.polling_wait = wait
         self.polling_tries = int(timeout / wait)
+        self.polling_print_output = print_output
 
     def check_deployed_processors(self):
         return get_ps_deployed_processors(ps_server_host=self.server_addr_processing)
@@ -48,11 +50,13 @@ class Client:
 
     def poll_job_status(self, job_id: str) -> str:
         return poll_job_status_till_timeout_fail_or_success(
-            ps_server_host=self.server_addr_processing, job_id=job_id, tries=self.polling_tries, wait=self.polling_wait)
+            ps_server_host=self.server_addr_processing, job_id=job_id, tries=self.polling_tries, wait=self.polling_wait,
+            print_output=self.polling_print_output)
 
     def poll_workflow_status(self, job_id: str) -> str:
         return poll_wf_status_till_timeout_fail_or_success(
-            ps_server_host=self.server_addr_processing, job_id=job_id, tries=self.polling_tries, wait=self.polling_wait)
+            ps_server_host=self.server_addr_processing, job_id=job_id, tries=self.polling_tries, wait=self.polling_wait,
+            print_output=self.polling_print_output)
 
     def send_processing_job_request(self, processor_name: str, req_params: dict) -> str:
         return post_ps_processing_request(

--- a/src/ocrd_network/client.py
+++ b/src/ocrd_network/client.py
@@ -19,8 +19,7 @@ class Client:
         self,
         server_addr_processing: Optional[str],
         timeout: int = config.OCRD_NETWORK_CLIENT_POLLING_TIMEOUT,
-        wait: int = config.OCRD_NETWORK_CLIENT_POLLING_SLEEP,
-        print_output: bool = config.OCRD_NETWORK_CLIENT_POLLING_PRINT
+        wait: int = config.OCRD_NETWORK_CLIENT_POLLING_SLEEP
     ):
         self.log = getLogger(f"ocrd_network.client")
         if not server_addr_processing:
@@ -30,7 +29,6 @@ class Client:
         self.polling_timeout = timeout
         self.polling_wait = wait
         self.polling_tries = int(timeout / wait)
-        self.polling_print_output = print_output
 
     def check_deployed_processors(self):
         return get_ps_deployed_processors(ps_server_host=self.server_addr_processing)
@@ -48,15 +46,15 @@ class Client:
     def check_workflow_status(self, workflow_job_id: str):
         return get_ps_workflow_job_status(self.server_addr_processing, workflow_job_id=workflow_job_id)
 
-    def poll_job_status(self, job_id: str) -> str:
+    def poll_job_status(self, job_id: str, print_state: bool) -> str:
         return poll_job_status_till_timeout_fail_or_success(
             ps_server_host=self.server_addr_processing, job_id=job_id, tries=self.polling_tries, wait=self.polling_wait,
-            print_output=self.polling_print_output)
+            print_state=print_state)
 
-    def poll_workflow_status(self, job_id: str) -> str:
+    def poll_workflow_status(self, job_id: str, print_state: bool) -> str:
         return poll_wf_status_till_timeout_fail_or_success(
             ps_server_host=self.server_addr_processing, job_id=job_id, tries=self.polling_tries, wait=self.polling_wait,
-            print_output=self.polling_print_output)
+            print_state=print_state)
 
     def send_processing_job_request(self, processor_name: str, req_params: dict) -> str:
         return post_ps_processing_request(

--- a/src/ocrd_network/client.py
+++ b/src/ocrd_network/client.py
@@ -60,6 +60,7 @@ class Client:
         return post_ps_processing_request(
             ps_server_host=self.server_addr_processing, processor=processor_name, job_input=req_params)
 
-    def send_workflow_job_request(self, path_to_wf: str, path_to_mets: str):
+    def send_workflow_job_request(self, path_to_wf: str, path_to_mets: str, page_wise: bool):
         return post_ps_workflow_request(
-            ps_server_host=self.server_addr_processing, path_to_wf=path_to_wf, path_to_mets=path_to_mets)
+            ps_server_host=self.server_addr_processing, path_to_wf=path_to_wf, path_to_mets=path_to_mets,
+            page_wise=page_wise)

--- a/src/ocrd_network/client.py
+++ b/src/ocrd_network/client.py
@@ -46,12 +46,12 @@ class Client:
     def check_workflow_status(self, workflow_job_id: str):
         return get_ps_workflow_job_status(self.server_addr_processing, workflow_job_id=workflow_job_id)
 
-    def poll_job_status(self, job_id: str, print_state: bool) -> str:
+    def poll_job_status(self, job_id: str, print_state: bool = False) -> str:
         return poll_job_status_till_timeout_fail_or_success(
             ps_server_host=self.server_addr_processing, job_id=job_id, tries=self.polling_tries, wait=self.polling_wait,
             print_state=print_state)
 
-    def poll_workflow_status(self, job_id: str, print_state: bool) -> str:
+    def poll_workflow_status(self, job_id: str, print_state: bool = False) -> str:
         return poll_wf_status_till_timeout_fail_or_success(
             ps_server_host=self.server_addr_processing, job_id=job_id, tries=self.polling_tries, wait=self.polling_wait,
             print_state=print_state)

--- a/src/ocrd_network/client_utils.py
+++ b/src/ocrd_network/client_utils.py
@@ -4,7 +4,7 @@ from .constants import JobState, NETWORK_PROTOCOLS
 
 
 def _poll_endpoint_status(
-    ps_server_host: str, job_id: str, job_type: str, tries: int, wait: int, print_output: bool = False):
+    ps_server_host: str, job_id: str, job_type: str, tries: int, wait: int, print_state: bool = False):
     if job_type not in ["workflow", "processor"]:
         raise ValueError(f"Unknown job type '{job_type}', expected 'workflow' or 'processor'")
     job_state = JobState.unset
@@ -14,7 +14,7 @@ def _poll_endpoint_status(
             job_state = get_ps_processing_job_status(ps_server_host, job_id)
         if job_type == "workflow":
             job_state = get_ps_workflow_job_status(ps_server_host, job_id)
-        if print_output:
+        if print_state:
             print(f"State of the {job_type} job {job_id}: {job_state}")
         if job_state == JobState.success or job_state == JobState.failed:
             break
@@ -23,13 +23,13 @@ def _poll_endpoint_status(
 
 
 def poll_job_status_till_timeout_fail_or_success(
-    ps_server_host: str, job_id: str, tries: int, wait: int, print_output: bool = False) -> JobState:
-    return _poll_endpoint_status(ps_server_host, job_id, "processor", tries, wait, print_output)
+    ps_server_host: str, job_id: str, tries: int, wait: int, print_state: bool = False) -> JobState:
+    return _poll_endpoint_status(ps_server_host, job_id, "processor", tries, wait, print_state)
 
 
 def poll_wf_status_till_timeout_fail_or_success(
-    ps_server_host: str, job_id: str, tries: int, wait: int, print_output: bool = False) -> JobState:
-    return _poll_endpoint_status(ps_server_host, job_id, "workflow", tries, wait, print_output)
+    ps_server_host: str, job_id: str, tries: int, wait: int, print_state: bool = False) -> JobState:
+    return _poll_endpoint_status(ps_server_host, job_id, "workflow", tries, wait, print_state)
 
 
 def get_ps_deployed_processors(ps_server_host: str):

--- a/src/ocrd_network/client_utils.py
+++ b/src/ocrd_network/client_utils.py
@@ -3,7 +3,7 @@ from time import sleep
 from .constants import JobState, NETWORK_PROTOCOLS
 
 
-def _poll_endpoint_status(ps_server_host: str, job_id: str, job_type: str, tries: int, wait: int):
+def _poll_endpoint_status(ps_server_host: str, job_id: str, job_type: str, tries: int, wait: int, print_output: bool):
     if job_type not in ["workflow", "processor"]:
         raise ValueError(f"Unknown job type '{job_type}', expected 'workflow' or 'processor'")
     job_state = JobState.unset
@@ -13,18 +13,22 @@ def _poll_endpoint_status(ps_server_host: str, job_id: str, job_type: str, tries
             job_state = get_ps_processing_job_status(ps_server_host, job_id)
         if job_type == "workflow":
             job_state = get_ps_workflow_job_status(ps_server_host, job_id)
+        if print_output:
+            print(f"State of the {job_type} job {job_id}: {job_state}")
         if job_state == JobState.success or job_state == JobState.failed:
             break
         tries -= 1
     return job_state
 
 
-def poll_job_status_till_timeout_fail_or_success(ps_server_host: str, job_id: str, tries: int, wait: int) -> JobState:
-    return _poll_endpoint_status(ps_server_host, job_id, "processor", tries, wait)
+def poll_job_status_till_timeout_fail_or_success(
+    ps_server_host: str, job_id: str, tries: int, wait: int, print_output: bool) -> JobState:
+    return _poll_endpoint_status(ps_server_host, job_id, "processor", tries, wait, print_output)
 
 
-def poll_wf_status_till_timeout_fail_or_success(ps_server_host: str, job_id: str, tries: int, wait: int) -> JobState:
-    return _poll_endpoint_status(ps_server_host, job_id, "workflow", tries, wait)
+def poll_wf_status_till_timeout_fail_or_success(
+    ps_server_host: str, job_id: str, tries: int, wait: int, print_output: bool) -> JobState:
+    return _poll_endpoint_status(ps_server_host, job_id, "workflow", tries, wait, print_output)
 
 
 def get_ps_deployed_processors(ps_server_host: str):

--- a/src/ocrd_network/client_utils.py
+++ b/src/ocrd_network/client_utils.py
@@ -3,7 +3,8 @@ from time import sleep
 from .constants import JobState, NETWORK_PROTOCOLS
 
 
-def _poll_endpoint_status(ps_server_host: str, job_id: str, job_type: str, tries: int, wait: int, print_output: bool):
+def _poll_endpoint_status(
+    ps_server_host: str, job_id: str, job_type: str, tries: int, wait: int, print_output: bool = False):
     if job_type not in ["workflow", "processor"]:
         raise ValueError(f"Unknown job type '{job_type}', expected 'workflow' or 'processor'")
     job_state = JobState.unset
@@ -22,12 +23,12 @@ def _poll_endpoint_status(ps_server_host: str, job_id: str, job_type: str, tries
 
 
 def poll_job_status_till_timeout_fail_or_success(
-    ps_server_host: str, job_id: str, tries: int, wait: int, print_output: bool) -> JobState:
+    ps_server_host: str, job_id: str, tries: int, wait: int, print_output: bool = False) -> JobState:
     return _poll_endpoint_status(ps_server_host, job_id, "processor", tries, wait, print_output)
 
 
 def poll_wf_status_till_timeout_fail_or_success(
-    ps_server_host: str, job_id: str, tries: int, wait: int, print_output: bool) -> JobState:
+    ps_server_host: str, job_id: str, tries: int, wait: int, print_output: bool = False) -> JobState:
     return _poll_endpoint_status(ps_server_host, job_id, "workflow", tries, wait, print_output)
 
 

--- a/src/ocrd_network/client_utils.py
+++ b/src/ocrd_network/client_utils.py
@@ -86,7 +86,7 @@ def post_ps_workflow_request(
     ps_server_host: str,
     path_to_wf: str,
     path_to_mets: str,
-    page_wise: bool,
+    page_wise: bool = False,
 ) -> str:
     request_url = f"{ps_server_host}/workflow/run?mets_path={path_to_mets}&page_wise={'True' if page_wise else 'False'}"
     response = request_post(

--- a/src/ocrd_network/processing_server.py
+++ b/src/ocrd_network/processing_server.py
@@ -48,6 +48,7 @@ from .server_utils import (
     get_workflow_content,
     get_from_database_workspace,
     get_from_database_workflow_job,
+    kill_mets_server_zombies,
     parse_workflow_tasks,
     raise_http_exception,
     request_processor_server_tool_json,
@@ -199,6 +200,14 @@ class ProcessingServer(FastAPI):
             endpoint=self.forward_tcp_request_to_uds_mets_server,
             tags=[ServerApiTags.WORKSPACE],
             summary="Forward a TCP request to UDS mets server"
+        )
+        others_router.add_api_route(
+            path="/kill_mets_server_zombies",
+            endpoint=self.kill_mets_server_zombies,
+            methods=["DELETE"],
+            tags=[ServerApiTags.WORKFLOW, ServerApiTags.PROCESSING],
+            status_code=status.HTTP_200_OK,
+            summary="!! Workaround Do Not Use Unless You Have A Reason !! Kill all METS servers on this machine that have been created more than 60 minutes ago."
         )
         self.include_router(others_router)
 
@@ -816,6 +825,10 @@ class ProcessingServer(FastAPI):
         jobs = await db_get_processing_jobs(job_ids)
         response = self._produce_workflow_status_response(processing_jobs=jobs)
         return response
+
+    async def kill_mets_server_zombies(self) -> List[int]:
+        pids_killed = kill_mets_server_zombies(minutes_ago=60)
+        return pids_killed
 
     async def get_workflow_info_simple(self, workflow_job_id) -> Dict[str, JobState]:
         """

--- a/src/ocrd_network/processing_server.py
+++ b/src/ocrd_network/processing_server.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from os import getpid
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 from uvicorn import run as uvicorn_run
 
 from fastapi import APIRouter, FastAPI, File, HTTPException, Request, status, UploadFile
@@ -826,8 +826,8 @@ class ProcessingServer(FastAPI):
         response = self._produce_workflow_status_response(processing_jobs=jobs)
         return response
 
-    async def kill_mets_server_zombies(self) -> List[int]:
-        pids_killed = kill_mets_server_zombies(minutes_ago=60)
+    async def kill_mets_server_zombies(self, minutes_ago : Optional[int] = None, dry_run : Optional[bool] = None) -> List[int]:
+        pids_killed = kill_mets_server_zombies(minutes_ago=minutes_ago, dry_run=dry_run)
         return pids_killed
 
     async def get_workflow_info_simple(self, workflow_job_id) -> Dict[str, JobState]:

--- a/src/ocrd_network/server_utils.py
+++ b/src/ocrd_network/server_utils.py
@@ -264,8 +264,8 @@ def kill_mets_server_zombies(minutes_ago=60) -> List[int]:
             continue
         cmdline = cmdline_file.read_text().replace('\x00', ' ')
         if re.match(cmdline_pat, cmdline):
-            pid = procdir.name
+            pid = int(procdir.name)
             ret.append(pid)
             print(f'METS Server with PID {pid} was created {ctime_ago} minutes ago, more than {minutes_ago}, so killing (cmdline="{cmdline})', file=sys.stderr)
-            os.kill(int(pid), signal.SIGTERM)
+            os.kill(pid, signal.SIGTERM)
     return ret

--- a/src/ocrd_network/server_utils.py
+++ b/src/ocrd_network/server_utils.py
@@ -1,12 +1,18 @@
+import os
+import re
+import signal
+from pathlib import Path
+from json import dumps, loads
+from urllib.parse import urljoin
+from typing import Dict, List, Union
+from time import time
+
 from fastapi import HTTPException, status, UploadFile
 from fastapi.responses import FileResponse
 from httpx import AsyncClient, Timeout
-from json import dumps, loads
 from logging import Logger
-from pathlib import Path
 from requests import get as requests_get
-from typing import Dict, List, Union
-from urllib.parse import urljoin
+from requests_unixsocket import sys
 
 from ocrd.resolver import Resolver
 from ocrd.task_sequence import ProcessorTask
@@ -241,3 +247,25 @@ def validate_first_task_input_file_groups_existence(logger: Logger, mets_path: s
         if group not in available_groups:
             message = f"Input file group '{group}' of the first processor not found: {input_file_grps}"
             raise_http_exception(logger, status.HTTP_422_UNPROCESSABLE_ENTITY, message)
+
+
+def kill_mets_server_zombies(minutes_ago=60) -> List[int]:
+    now = time()
+    cmdline_pat = r'.*ocrd workspace -U.*server start $'
+    ret = []
+    for procdir in sorted(Path('/proc').glob('*'), key=os.path.getctime):
+        if not procdir.is_dir():
+            continue
+        cmdline_file = procdir.joinpath('cmdline')
+        if not cmdline_file.is_file():
+            continue
+        ctime_ago = int((now - procdir.stat().st_ctime) / 60)
+        if ctime_ago < minutes_ago:
+            continue
+        cmdline = cmdline_file.read_text().replace('\x00', ' ')
+        if re.match(cmdline_pat, cmdline):
+            pid = procdir.name
+            ret.append(pid)
+            print(f'METS Server with PID {pid} was created {ctime_ago} minutes ago, more than {minutes_ago}, so killing (cmdline="{cmdline})', file=sys.stderr)
+            os.kill(int(pid), signal.SIGTERM)
+    return ret

--- a/src/ocrd_utils/config.py
+++ b/src/ocrd_utils/config.py
@@ -167,11 +167,6 @@ config.add("OCRD_NETWORK_CLIENT_POLLING_TIMEOUT",
            parser=int,
            default=(True, 3600))
 
-config.add("OCRD_NETWORK_CLIENT_POLLING_PRINT",
-           description="Whether the blocking client commands should print status output each iteration.",
-           parser=bool,
-           default=(True, False))
-
 config.add("OCRD_NETWORK_SERVER_ADDR_WORKFLOW",
         description="Default address of Workflow Server to connect to (for `ocrd network client workflow`).",
         default=(True, ''))

--- a/src/ocrd_utils/config.py
+++ b/src/ocrd_utils/config.py
@@ -168,7 +168,7 @@ config.add("OCRD_NETWORK_CLIENT_POLLING_TIMEOUT",
            default=(True, 3600))
 
 config.add("OCRD_NETWORK_CLIENT_POLLING_PRINT",
-           description="Timeout for a blocking ocrd network client (in seconds).",
+           description="Whether the blocking client commands should print status output each iteration.",
            parser=bool,
            default=(True, False))
 

--- a/src/ocrd_utils/config.py
+++ b/src/ocrd_utils/config.py
@@ -160,12 +160,17 @@ config.add("OCRD_NETWORK_SERVER_ADDR_PROCESSING",
 config.add("OCRD_NETWORK_CLIENT_POLLING_SLEEP",
            description="How many seconds to sleep before trying again.",
            parser=int,
-           default=(True, 30))
+           default=(True, 10))
 
 config.add("OCRD_NETWORK_CLIENT_POLLING_TIMEOUT",
            description="Timeout for a blocking ocrd network client (in seconds).",
            parser=int,
            default=(True, 3600))
+
+config.add("OCRD_NETWORK_CLIENT_POLLING_PRINT",
+           description="Timeout for a blocking ocrd network client (in seconds).",
+           parser=bool,
+           default=(True, False))
 
 config.add("OCRD_NETWORK_SERVER_ADDR_WORKFLOW",
         description="Default address of Workflow Server to connect to (for `ocrd network client workflow`).",


### PR DESCRIPTION
Provide flexibility to ocrd network client blocking commands by letting users control the printing of outputs.