### PR TITLE
deployer: Remove any pre-existing socket file before starting the server (again)

### DIFF
--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -434,7 +434,7 @@ class OcrdMetsServer:
     def shutdown(self):
         if self.is_uds:
             if Path(self.url).exists():
-                self.log.debug(f'UDS socket {self.url} still exists, removing it')
+                self.log.warning(f"Due to a server shutdown, removing the existing UDS socket file: {self.url}")
                 Path(self.url).unlink()
         # os._exit because uvicorn catches SystemExit raised by sys.exit
         _exit(0)

--- a/src/ocrd_network/runtime_data/deployer.py
+++ b/src/ocrd_network/runtime_data/deployer.py
@@ -165,6 +165,9 @@ class Deployer:
                 raise Exception(message)
             mets_server_pid = self.mets_servers[Path(mets_server_url)]
             OcrdMetsServer.kill_process(mets_server_pid=mets_server_pid)
+            if Path(mets_server_url).exists():
+                self.log.warning(f"Deployer is removing the existing UDS socket file: {mets_server_url}")
+                Path(mets_server_url).unlink()
             return
         # TODO: Reconsider this again
         #  Not having this sleep here causes connection errors

--- a/src/ocrd_network/runtime_data/deployer.py
+++ b/src/ocrd_network/runtime_data/deployer.py
@@ -146,6 +146,11 @@ class Deployer:
         if is_mets_server_running(mets_server_url=str(mets_server_url)):
             self.log.debug(f"The UDS mets server for {ws_dir_path} is already started: {mets_server_url}")
             return mets_server_url
+        elif Path(mets_server_url).is_socket():
+            self.log.warning(
+                f"The UDS mets server for {ws_dir_path} is not running but the socket file exists: {mets_server_url}."
+                "Removing to avoid any weird behavior before starting the server.")
+            Path(mets_server_url).unlink()
         self.log.info(f"Starting UDS mets server: {mets_server_url}")
         pid = OcrdMetsServer.create_process(mets_server_url=mets_server_url, ws_dir_path=ws_dir_path, log_file=log_file)
         self.mets_servers[mets_server_url] = pid


### PR DESCRIPTION
Tackling those errors:

`
17:03:19.064 ERROR ocrd_network.tcp_to_uds_mets_proxy - Uds-Mets-Server gives unexpected error. Response: {'_content': b'"A file with ID==FILE_0015_OCR-D-DEWARP_region0002_region0002_line0011.IMG-DEWARP already exists <OcrdFile fileGrp=OCR-D-DEWARP ID=FILE_0015_OCR-D-DEWARP_region0002_region0002_line0011.IMG-DEWARP, mimetype=image/png, url=---, local_filename=OCR-D-DEWARP/FILE_0015_OCR-D-DEWARP_region0002_region0002_line0011.IMG-DEWARP.png]/>  and neither force nor ignore are set"', '_content_consumed': True, '_next': None, 'status_code': 400, 'headers': {'date': 'Tue, 01 Oct 2024 15:03:18 GMT', 'server': 'uvicorn', 'content-length': '364', 'content-type': 'application/json'}, 'raw': <urllib3.response.HTTPResponse object at 0x7fc5ad35cac0>, 'url': 'http+unix://%2Ftmp%2Focrd_network_sockets%2F_home_mm_repos_ocrd_network_tests_ws29_data.sock/file', 'encoding': 'utf-8', 'history': [], 'reason': 'Bad Request', 'cookies': <RequestsCookieJar[]>, 'elapsed': datetime.timedelta(microseconds=5356), 'request': <PreparedRequest [POST]>, 'connection': <requests_unixsocket.adapters.UnixAdapter object at 0x7fc5b00fb8e0>}
`

But before we merge, we should be absolutely sure that there really is no METS server running anymore at that location at this point. Because otherwise, we still have spurious METS server instances running and just hiding the error.