### PR TITLE
Fix mets server: clean leftover zombie processes

### DIFF
--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -447,7 +447,7 @@ class OcrdMetsServer:
                 Path(self.url).unlink()
 
     def startup(self):
-        self.log.info(f"Configuring up the Mets Server")
+        self.log.info(f"Configuring the Mets Server")
 
         workspace = self.workspace
 

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -157,13 +157,13 @@ class ClientSideOcrdMets:
         Request writing the changes to the file system
         """
         if not self.multiplexing_mode:
-            self.session.request("PUT", url=self.url)
+            return self.session.request("PUT", url=self.url).text
         else:
-            self.session.request(
+            return self.session.request(
                 "POST",
                 self.url,
                 json=MpxReq.save(self.ws_dir_path)
-            )
+            ).json()["text"]
 
     def stop(self):
         """
@@ -171,14 +171,13 @@ class ClientSideOcrdMets:
         """
         try:
             if not self.multiplexing_mode:
-                self.session.request("DELETE", self.url)
-                return
+                return self.session.request("DELETE", self.url).text
             else:
-                self.session.request(
+                return self.session.request(
                     "POST",
                     self.url,
                     json=MpxReq.stop(self.ws_dir_path)
-                )
+                ).json()["text"]
         except ConnectionError:
             # Expected because we exit the process without returning
             pass
@@ -348,12 +347,12 @@ class MpxReq:
     @staticmethod
     def save(ws_dir_path: str) -> Dict:
         return MpxReq.__args_wrapper(
-            ws_dir_path, method_type="PUT", response_type="empty", request_url="", request_data={})
+            ws_dir_path, method_type="PUT", response_type="text", request_url="", request_data={})
 
     @staticmethod
     def stop(ws_dir_path: str) -> Dict:
         return MpxReq.__args_wrapper(
-            ws_dir_path, method_type="DELETE", response_type="empty", request_url="", request_data={})
+            ws_dir_path, method_type="DELETE", response_type="text", request_url="", request_data={})
 
     @staticmethod
     def reload(ws_dir_path: str) -> Dict:

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -437,11 +437,8 @@ class OcrdMetsServer:
         except ProcessLookupError as e:
             pass
 
-    def shutdown(self):
-        if self.is_uds:
-            if Path(self.url).exists():
-                self.log.warning(f"Due to a server shutdown, removing the existing UDS socket file: {self.url}")
-                Path(self.url).unlink()
+    @staticmethod
+    def shutdown():
         # os._exit because uvicorn catches SystemExit raised by sys.exit
         _exit(0)
 
@@ -472,7 +469,8 @@ class OcrdMetsServer:
             """
             Write current changes to the file system
             """
-            return workspace.save_mets()
+            workspace.save_mets()
+            return Response(status_code=200, content="The Mets Server is writing changes to disk.")
 
         @app.delete(path='/')
         async def stop():
@@ -482,6 +480,7 @@ class OcrdMetsServer:
             getLogger('ocrd.models.ocrd_mets').info(f'Shutting down METS Server {self.url}')
             workspace.save_mets()
             self.shutdown()
+            return Response(status_code=200, content="The Mets Server is shutting down...")
 
         @app.post(path='/reload')
         async def workspace_reload_mets():

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -443,6 +443,10 @@ class OcrdMetsServer:
         pid = os.getpid()
         self.log.info(f"Shutdown method of mets server[{pid}] invoked, sending SIGTERM signal.")
         os.kill(pid, signal.SIGTERM)
+        if self.is_uds:
+            if Path(self.url).exists():
+                self.log.warning(f"Due to a server shutdown, removing the existing UDS socket file: {self.url}")
+                Path(self.url).unlink()
 
     def startup(self):
         self.log.info(f"Configuring up the Mets Server")

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -438,8 +438,6 @@ class OcrdMetsServer:
             pass
 
     def shutdown(self):
-        # os._exit because uvicorn catches SystemExit raised by sys.exit
-        # _exit(0)
         pid = os.getpid()
         self.log.info(f"Shutdown method of mets server[{pid}] invoked, sending SIGTERM signal.")
         os.kill(pid, signal.SIGTERM)

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -516,13 +516,13 @@ class OcrdMetsServer:
         @app.get(path='/physical_pages', response_model=OcrdPageListModel)
         async def physical_pages():
             response = {'physical_pages': workspace.mets.physical_pages}
-            self.log.info(f"GET /physical_pages -> {response.__dict__}")
+            self.log.info(f"GET /physical_pages -> {response}")
             return response
 
         @app.get(path='/file_groups', response_model=OcrdFileGroupListModel)
         async def file_groups():
             response = {'file_groups': workspace.mets.file_groups}
-            self.log.info(f"GET /file_groups -> {response.__dict__}")
+            self.log.info(f"GET /file_groups -> {response}")
             return response
 
         @app.get(path='/agent', response_model=OcrdAgentListModel)

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -1,8 +1,10 @@
 """
 # METS server functionality
 """
+import os
 import re
 from os import _exit, chmod
+import signal
 from typing import Dict, Optional, Union, List, Tuple
 from time import sleep
 from pathlib import Path
@@ -428,8 +430,12 @@ class OcrdMetsServer:
 
     @staticmethod
     def kill_process(mets_server_pid: int):
-        subprocess_run(args=["kill", "-s", "SIGINT", f"{mets_server_pid}"], shell=False, universal_newlines=True)
-        return
+        os.kill(mets_server_pid, signal.SIGINT)
+        sleep(3)
+        try:
+            os.kill(mets_server_pid, signal.SIGKILL)
+        except ProcessLookupError as e:
+            pass
 
     def shutdown(self):
         if self.is_uds:

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -484,7 +484,7 @@ class OcrdMetsServer:
             workspace.save_mets()
             response = Response(content="The Mets Server will shut down soon...", media_type='text/plain')
             self.shutdown()
-            self.log.info(f"POST /reload -> {response.__dict__}")
+            self.log.info(f"DELETE / -> {response.__dict__}")
             return response
 
         @app.post(path='/reload')

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -440,7 +440,8 @@ class OcrdMetsServer:
     @staticmethod
     def shutdown():
         # os._exit because uvicorn catches SystemExit raised by sys.exit
-        _exit(0)
+        # _exit(0)
+        os.kill(os.getpid(), signal.SIGTERM)
 
     def startup(self):
         self.log.info("Starting up METS server")

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -479,7 +479,7 @@ class OcrdMetsServer:
             return response
 
         @app.delete(path='/')
-        async def stop():
+        def stop():
             """
             Stop the mets server
             """
@@ -490,7 +490,7 @@ class OcrdMetsServer:
             return response
 
         @app.post(path='/reload')
-        async def workspace_reload_mets():
+        def workspace_reload_mets():
             """
             Reload mets file from the file system
             """

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -601,14 +601,3 @@ class OcrdMetsServer:
 
         self.log.info("Starting the uvicorn Mets Server")
         uvicorn.run(app, **uvicorn_kwargs)
-
-# TODO: Not required after #1284, consider removing
-def is_socket_in_use(socket_path):
-    if Path(socket_path).exists():
-        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        try:
-            client.connect(socket_path)
-        except OSError:
-            return False
-        client.close()
-        return True

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -444,7 +444,7 @@ class OcrdMetsServer:
         os.kill(os.getpid(), signal.SIGTERM)
 
     def startup(self):
-        self.log.info("Starting up METS server")
+        self.log.info(f"Starting up METS server: {self.url}")
 
         workspace = self.workspace
 
@@ -564,9 +564,12 @@ class OcrdMetsServer:
             # Create socket and change to world-readable and -writable to avoid permission errors
             self.log.debug(f"chmod 0o677 {self.url}")
             server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            # TODO: Not required after #1284, consider removing
+            """
             if Path(self.url).exists() and not is_socket_in_use(self.url):
                 # remove leftover unused socket which blocks startup
                 Path(self.url).unlink()
+            """
             server.bind(self.url)  # creates the socket file
             atexit.register(self.shutdown)
             server.close()
@@ -581,7 +584,7 @@ class OcrdMetsServer:
         self.log.debug("Starting uvicorn")
         uvicorn.run(app, **uvicorn_kwargs)
 
-
+# TODO: Not required after #1284, consider removing
 def is_socket_in_use(socket_path):
     if Path(socket_path).exists():
         client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -588,12 +588,6 @@ class OcrdMetsServer:
             # Create socket and change to world-readable and -writable to avoid permission errors
             self.log.debug(f"chmod 0o677 {self.url}")
             server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            # TODO: Not required after #1284, consider removing
-            """
-            if Path(self.url).exists() and not is_socket_in_use(self.url):
-                # remove leftover unused socket which blocks startup
-                Path(self.url).unlink()
-            """
             server.bind(self.url)  # creates the socket file
             atexit.register(self.shutdown)
             server.close()

--- a/src/ocrd_network/client.py
+++ b/src/ocrd_network/client.py
@@ -60,7 +60,7 @@ class Client:
         return post_ps_processing_request(
             ps_server_host=self.server_addr_processing, processor=processor_name, job_input=req_params)
 
-    def send_workflow_job_request(self, path_to_wf: str, path_to_mets: str, page_wise: bool):
+    def send_workflow_job_request(self, path_to_wf: str, path_to_mets: str, page_wise: bool = False):
         return post_ps_workflow_request(
             ps_server_host=self.server_addr_processing, path_to_wf=path_to_wf, path_to_mets=path_to_mets,
             page_wise=page_wise)

--- a/src/ocrd_network/client.py
+++ b/src/ocrd_network/client.py
@@ -46,12 +46,12 @@ class Client:
     def check_workflow_status(self, workflow_job_id: str):
         return get_ps_workflow_job_status(self.server_addr_processing, workflow_job_id=workflow_job_id)
 
-    def poll_job_status(self, job_id: str, print_state: bool) -> str:
+    def poll_job_status(self, job_id: str, print_state: bool = False) -> str:
         return poll_job_status_till_timeout_fail_or_success(
             ps_server_host=self.server_addr_processing, job_id=job_id, tries=self.polling_tries, wait=self.polling_wait,
             print_state=print_state)
 
-    def poll_workflow_status(self, job_id: str, print_state: bool) -> str:
+    def poll_workflow_status(self, job_id: str, print_state: bool = False) -> str:
         return poll_wf_status_till_timeout_fail_or_success(
             ps_server_host=self.server_addr_processing, job_id=job_id, tries=self.polling_tries, wait=self.polling_wait,
             print_state=print_state)

--- a/src/ocrd_network/client_utils.py
+++ b/src/ocrd_network/client_utils.py
@@ -86,7 +86,7 @@ def post_ps_workflow_request(
     ps_server_host: str,
     path_to_wf: str,
     path_to_mets: str,
-    page_wise: bool,
+    page_wise: bool = False,
 ) -> str:
     request_url = f"{ps_server_host}/workflow/run?mets_path={path_to_mets}&page_wise={'True' if page_wise else 'False'}"
     response = request_post(

--- a/src/ocrd_network/processing_server.py
+++ b/src/ocrd_network/processing_server.py
@@ -602,8 +602,7 @@ class ProcessingServer(FastAPI):
                 # more internal callbacks are expected for that workspace
                 self.log.debug(f"Stopping the mets server: {mets_server_url}")
 
-                self.deployer.stop_uds_mets_server(
-                    mets_server_url=mets_server_url, path_to_mets=path_to_mets, stop_with_pid=True)
+                self.deployer.stop_uds_mets_server(mets_server_url=mets_server_url, path_to_mets=path_to_mets)
 
                 try:
                     # The queue is empty - delete it

--- a/src/ocrd_network/processing_server.py
+++ b/src/ocrd_network/processing_server.py
@@ -48,6 +48,7 @@ from .server_utils import (
     get_workflow_content,
     get_from_database_workspace,
     get_from_database_workflow_job,
+    kill_mets_server_zombies,
     parse_workflow_tasks,
     raise_http_exception,
     request_processor_server_tool_json,
@@ -199,6 +200,14 @@ class ProcessingServer(FastAPI):
             endpoint=self.forward_tcp_request_to_uds_mets_server,
             tags=[ServerApiTags.WORKSPACE],
             summary="Forward a TCP request to UDS mets server"
+        )
+        others_router.add_api_route(
+            path="/kill_mets_server_zombies",
+            endpoint=self.kill_mets_server_zombies,
+            methods=["DELETE"],
+            tags=[ServerApiTags.WORKFLOW, ServerApiTags.PROCESSING],
+            status_code=status.HTTP_200_OK,
+            summary="!! Workaround Do Not Use Unless You Have A Reason !! Kill all METS servers on this machine that have been created more than 60 minutes ago."
         )
         self.include_router(others_router)
 
@@ -574,7 +583,7 @@ class ProcessingServer(FastAPI):
         )
 
     async def _consume_cached_jobs_of_workspace(
-        self, workspace_key: str, mets_server_url: str
+        self, workspace_key: str, mets_server_url: str, path_to_mets: str
     ) -> List[PYJobInput]:
 
         # Check whether the internal queue for the workspace key still exists
@@ -593,7 +602,8 @@ class ProcessingServer(FastAPI):
                 # more internal callbacks are expected for that workspace
                 self.log.debug(f"Stopping the mets server: {mets_server_url}")
 
-                self.deployer.stop_uds_mets_server(mets_server_url=mets_server_url)
+                self.deployer.stop_uds_mets_server(
+                    mets_server_url=mets_server_url, path_to_mets=path_to_mets, stop_with_pid=True)
 
                 try:
                     # The queue is empty - delete it
@@ -643,7 +653,7 @@ class ProcessingServer(FastAPI):
             raise_http_exception(self.log, status.HTTP_404_NOT_FOUND, message, error)
 
         consumed_cached_jobs = await self._consume_cached_jobs_of_workspace(
-            workspace_key=workspace_key, mets_server_url=mets_server_url
+            workspace_key=workspace_key, mets_server_url=mets_server_url, path_to_mets=path_to_mets
         )
         await self.push_cached_jobs_to_agents(processing_jobs=consumed_cached_jobs)
 
@@ -816,6 +826,10 @@ class ProcessingServer(FastAPI):
         jobs = await db_get_processing_jobs(job_ids)
         response = self._produce_workflow_status_response(processing_jobs=jobs)
         return response
+
+    async def kill_mets_server_zombies(self) -> List[int]:
+        pids_killed = kill_mets_server_zombies(minutes_ago=60)
+        return pids_killed
 
     async def get_workflow_info_simple(self, workflow_job_id) -> Dict[str, JobState]:
         """

--- a/src/ocrd_network/processing_server.py
+++ b/src/ocrd_network/processing_server.py
@@ -585,18 +585,13 @@ class ProcessingServer(FastAPI):
     async def _consume_cached_jobs_of_workspace(
         self, workspace_key: str, mets_server_url: str, path_to_mets: str
     ) -> List[PYJobInput]:
-
-        # Check whether the internal queue for the workspace key still exists
-        if workspace_key not in self.cache_processing_requests.processing_requests:
-            self.log.debug(f"No internal queue available for workspace with key: {workspace_key}")
-            return []
-
         # decrease the internal cache counter by 1
         request_counter = self.cache_processing_requests.update_request_counter(
             workspace_key=workspace_key, by_value=-1
         )
         self.log.debug(f"Internal processing job cache counter value: {request_counter}")
-        if not len(self.cache_processing_requests.processing_requests[workspace_key]):
+        if (workspace_key not in self.cache_processing_requests.processing_requests or
+            not len(self.cache_processing_requests.processing_requests[workspace_key])):
             if request_counter <= 0:
                 # Shut down the Mets Server for the workspace_key since no
                 # more internal callbacks are expected for that workspace
@@ -616,6 +611,10 @@ class ProcessingServer(FastAPI):
                     self.log.debug(f"{output_file_grp}: {locked_pages[output_file_grp]}")
             else:
                 self.log.debug(f"Internal request cache is empty but waiting for {request_counter} result callbacks.")
+            return []
+        # Check whether the internal queue for the workspace key still exists
+        if workspace_key not in self.cache_processing_requests.processing_requests:
+            self.log.debug(f"No internal queue available for workspace with key: {workspace_key}")
             return []
         consumed_requests = await self.cache_processing_requests.consume_cached_requests(workspace_key=workspace_key)
         return consumed_requests

--- a/src/ocrd_network/processing_server.py
+++ b/src/ocrd_network/processing_server.py
@@ -601,7 +601,6 @@ class ProcessingServer(FastAPI):
                 # Shut down the Mets Server for the workspace_key since no
                 # more internal callbacks are expected for that workspace
                 self.log.debug(f"Stopping the mets server: {mets_server_url}")
-
                 self.deployer.stop_uds_mets_server(mets_server_url=mets_server_url, path_to_mets=path_to_mets)
 
                 try:

--- a/src/ocrd_network/runtime_data/deployer.py
+++ b/src/ocrd_network/runtime_data/deployer.py
@@ -191,5 +191,5 @@ class Deployer:
             p.wait()
             self.log.info(f"Terminated mets server with pid: {mets_server_pid}")
         else:
-            self.log.info(f"Mets server has already terminated with pid: {mets_server_pid}")
+            self.log.info(f"Mets server with pid: {mets_server_pid} has already terminated.")
         return

--- a/src/ocrd_network/runtime_data/deployer.py
+++ b/src/ocrd_network/runtime_data/deployer.py
@@ -164,11 +164,6 @@ class Deployer:
         self.log.info(f"Path to the mets file: {path_to_mets}")
         self.log.debug(f"mets_server: {self.mets_servers}")
         self.log.debug(f"mets_server_paths: {self.mets_servers_paths}")
-        # TODO: Reconsider this again
-        #  Not having this sleep here causes connection errors
-        #  on the last request processed by the processing worker.
-        #  Sometimes 3 seconds is enough, sometimes not.
-        sleep(5)
         mets_server_pid = self.mets_servers[str(self.mets_servers_paths[str(Path(path_to_mets).parent)])]
         self.log.info(f"Terminating mets server with pid: {mets_server_pid}")
         p = psutil.Process(mets_server_pid)

--- a/src/ocrd_network/runtime_data/deployer.py
+++ b/src/ocrd_network/runtime_data/deployer.py
@@ -162,8 +162,8 @@ class Deployer:
     def stop_uds_mets_server(self, mets_server_url: str, path_to_mets: str, stop_with_pid: bool = False) -> None:
         self.log.info(f"Stopping UDS mets server: {mets_server_url}")
         self.log.info(f"Path to the mets file: {path_to_mets}")
-        self.log.info(f"mets_server: {self.mets_servers}")
-        self.log.info(f"mets_server_paths: {self.mets_servers_paths}")
+        self.log.debug(f"mets_server: {self.mets_servers}")
+        self.log.debug(f"mets_server_paths: {self.mets_servers_paths}")
         if stop_with_pid:
             mets_server_url_uds = self.mets_servers_paths[str(Path(path_to_mets).parent)]
             if Path(mets_server_url_uds) not in self.mets_servers:

--- a/src/ocrd_network/runtime_data/deployer.py
+++ b/src/ocrd_network/runtime_data/deployer.py
@@ -159,25 +159,11 @@ class Deployer:
         self.mets_servers_paths[str(ws_dir_path)] = str(mets_server_url)
         return mets_server_url
 
-    def stop_uds_mets_server(self, mets_server_url: str, path_to_mets: str, stop_with_pid: bool = False) -> None:
+    def stop_uds_mets_server(self, mets_server_url: str, path_to_mets: str) -> None:
         self.log.info(f"Stopping UDS mets server: {mets_server_url}")
         self.log.info(f"Path to the mets file: {path_to_mets}")
         self.log.debug(f"mets_server: {self.mets_servers}")
         self.log.debug(f"mets_server_paths: {self.mets_servers_paths}")
-        if stop_with_pid:
-            mets_server_url_uds = self.mets_servers_paths[str(Path(path_to_mets).parent)]
-            if Path(mets_server_url_uds) not in self.mets_servers:
-                message = f"UDS Mets server not found at URL: {mets_server_url_uds}, mets path: {path_to_mets}"
-                self.log.warning(message)
-            mets_server_pid = self.mets_servers[str(mets_server_url_uds)]
-            self.log.info(f"Killing mets server pid: {mets_server_pid} of {mets_server_url_uds}")
-            OcrdMetsServer.kill_process(mets_server_pid=mets_server_pid)
-            self.log.info(f"Returning after the kill process")
-            if Path(mets_server_url_uds).exists():
-                self.log.warning(f"Deployer is removing the existing UDS socket file: {mets_server_url_uds}")
-                Path(mets_server_url_uds).unlink()
-            self.log.info(f"Returning from the stop_uds_mets_server")
-            return
         # TODO: Reconsider this again
         #  Not having this sleep here causes connection errors
         #  on the last request processed by the processing worker.

--- a/src/ocrd_network/runtime_data/deployer.py
+++ b/src/ocrd_network/runtime_data/deployer.py
@@ -182,5 +182,5 @@ class Deployer:
         #  on the last request processed by the processing worker.
         #  Sometimes 3 seconds is enough, sometimes not.
         sleep(5)
-        stop_mets_server(mets_server_url=mets_server_url, ws_dir_path=Path(path_to_mets).parent)
+        stop_mets_server(self.log, mets_server_url=mets_server_url, ws_dir_path=str(Path(path_to_mets).parent))
         return

--- a/src/ocrd_network/runtime_data/deployer.py
+++ b/src/ocrd_network/runtime_data/deployer.py
@@ -8,7 +8,6 @@ Each Processing Worker is an instance of an OCR-D processor.
 """
 from __future__ import annotations
 from pathlib import Path
-from subprocess import Popen, run as subprocess_run
 from time import sleep
 from typing import Dict, List, Union
 
@@ -30,6 +29,8 @@ class Deployer:
         self.data_hosts: List[DataHost] = parse_hosts_data(ps_config["hosts"])
         self.internal_callback_url = ps_config.get("internal_callback_url", None)
         self.mets_servers: Dict = {}  # {"mets_server_url": "mets_server_pid"}
+        # This is required to store UDS urls that are multiplexed through the TCP proxy and are not preserved anywhere
+        self.mets_servers_paths: Dict = {}  # {"ws_dir_path": "mets_server_url"}
         self.use_tcp_mets = ps_config.get("use_tcp_mets", False)
 
     # TODO: Reconsider this.
@@ -153,26 +154,33 @@ class Deployer:
             Path(mets_server_url).unlink()
         self.log.info(f"Starting UDS mets server: {mets_server_url}")
         pid = OcrdMetsServer.create_process(mets_server_url=mets_server_url, ws_dir_path=ws_dir_path, log_file=log_file)
-        self.mets_servers[mets_server_url] = pid
+        self.mets_servers[str(mets_server_url)] = pid
+        self.mets_servers_paths[str(ws_dir_path)] = str(mets_server_url)
         return mets_server_url
 
-    def stop_uds_mets_server(self, mets_server_url: str, stop_with_pid: bool = False) -> None:
+    def stop_uds_mets_server(self, mets_server_url: str, path_to_mets: str, stop_with_pid: bool = False) -> None:
         self.log.info(f"Stopping UDS mets server: {mets_server_url}")
+        self.log.info(f"Path to the mets file: {path_to_mets}")
+        self.log.info(f"mets_server: {self.mets_servers}")
+        self.log.info(f"mets_server_paths: {self.mets_servers_paths}")
         if stop_with_pid:
-            if Path(mets_server_url) not in self.mets_servers:
-                message = f"UDS Mets server not found at URL: {mets_server_url}"
-                self.log.exception(message)
-                raise Exception(message)
-            mets_server_pid = self.mets_servers[Path(mets_server_url)]
+            mets_server_url_uds = self.mets_servers_paths[str(Path(path_to_mets).parent)]
+            if Path(mets_server_url_uds) not in self.mets_servers:
+                message = f"UDS Mets server not found at URL: {mets_server_url_uds}, mets path: {path_to_mets}"
+                self.log.warning(message)
+            mets_server_pid = self.mets_servers[str(mets_server_url_uds)]
+            self.log.info(f"Killing mets server pid: {mets_server_pid} of {mets_server_url_uds}")
             OcrdMetsServer.kill_process(mets_server_pid=mets_server_pid)
-            if Path(mets_server_url).exists():
-                self.log.warning(f"Deployer is removing the existing UDS socket file: {mets_server_url}")
-                Path(mets_server_url).unlink()
+            self.log.info(f"Returning after the kill process")
+            if Path(mets_server_url_uds).exists():
+                self.log.warning(f"Deployer is removing the existing UDS socket file: {mets_server_url_uds}")
+                Path(mets_server_url_uds).unlink()
+            self.log.info(f"Returning from the stop_uds_mets_server")
             return
         # TODO: Reconsider this again
         #  Not having this sleep here causes connection errors
         #  on the last request processed by the processing worker.
         #  Sometimes 3 seconds is enough, sometimes not.
         sleep(5)
-        stop_mets_server(mets_server_url=mets_server_url)
+        stop_mets_server(mets_server_url=mets_server_url, ws_dir_path=Path(path_to_mets).parent)
         return

--- a/src/ocrd_network/runtime_data/deployer.py
+++ b/src/ocrd_network/runtime_data/deployer.py
@@ -8,6 +8,7 @@ Each Processing Worker is an instance of an OCR-D processor.
 """
 from __future__ import annotations
 from pathlib import Path
+import psutil
 from time import sleep
 from typing import Dict, List, Union
 
@@ -182,5 +183,13 @@ class Deployer:
         #  on the last request processed by the processing worker.
         #  Sometimes 3 seconds is enough, sometimes not.
         sleep(5)
+        mets_server_pid = self.mets_servers[str(self.mets_servers_paths[str(Path(path_to_mets).parent)])]
+        self.log.info(f"Terminating mets server with pid: {mets_server_pid}")
+        p = psutil.Process(mets_server_pid)
         stop_mets_server(self.log, mets_server_url=mets_server_url, ws_dir_path=str(Path(path_to_mets).parent))
+        if p.is_running():
+            p.wait()
+            self.log.info(f"Terminated mets server with pid: {mets_server_pid}")
+        else:
+            self.log.info(f"Mets server has already terminated with pid: {mets_server_pid}")
         return

--- a/src/ocrd_network/server_cache.py
+++ b/src/ocrd_network/server_cache.py
@@ -167,6 +167,7 @@ class CacheProcessingRequests:
             self.log.info(f"Creating an internal request counter for workspace key: {workspace_key}")
             self.processing_counter[workspace_key] = 0
         self.processing_counter[workspace_key] = self.processing_counter[workspace_key] + by_value
+        self.log.info(f"The new request counter of {workspace_key}: {self.processing_counter[workspace_key]}")
         return self.processing_counter[workspace_key]
 
     def cache_request(self, workspace_key: str, data: PYJobInput):
@@ -176,6 +177,7 @@ class CacheProcessingRequests:
             self.processing_requests[workspace_key] = []
         self.__print_job_input_debug_message(job_input=data)
         # Add the processing request to the end of the internal queue
+        self.log.info(f"Caching a processing request of {workspace_key}: {data.job_id}")
         self.processing_requests[workspace_key].append(data)
 
     async def cancel_dependent_jobs(self, workspace_key: str, processing_job_id: str) -> List[PYJobInput]:
@@ -229,4 +231,6 @@ class CacheProcessingRequests:
         if not len(self.processing_requests[workspace_key]):
             self.log.info(f"The processing requests cache is empty for workspace key: {workspace_key}")
             return False
+        self.log.info(f"The processing requests cache has {len(self.processing_requests[workspace_key])} "
+                      f"entries for workspace key: {workspace_key} ")
         return True

--- a/src/ocrd_network/server_cache.py
+++ b/src/ocrd_network/server_cache.py
@@ -31,7 +31,7 @@ class CacheLockedPages:
         self, workspace_key: str, output_file_grps: List[str], page_ids: List[str]
     ) -> bool:
         if not self.locked_pages.get(workspace_key, None):
-            self.log.debug(f"No entry found in the locked pages cache for workspace key: {workspace_key}")
+            self.log.info(f"No entry found in the locked pages cache for workspace key: {workspace_key}")
             return False
         debug_message = f"Caching the received request due to locked output file grp pages."
         for file_group in output_file_grps:
@@ -46,46 +46,45 @@ class CacheLockedPages:
 
     def get_locked_pages(self, workspace_key: str) -> Dict[str, List[str]]:
         if not self.locked_pages.get(workspace_key, None):
-            self.log.debug(f"No locked pages available for workspace key: {workspace_key}")
+            self.log.info(f"No locked pages available for workspace key: {workspace_key}")
             return {}
         return self.locked_pages[workspace_key]
 
     def lock_pages(self, workspace_key: str, output_file_grps: List[str], page_ids: List[str]) -> None:
         if not self.locked_pages.get(workspace_key, None):
-            self.log.debug(f"No entry found in the locked pages cache for workspace key: {workspace_key}")
-            self.log.debug(f"Creating an entry in the locked pages cache for workspace key: {workspace_key}")
+            self.log.info(f"No entry found in the locked pages cache for workspace key: {workspace_key}")
+            self.log.info(f"Creating an entry in the locked pages cache for workspace key: {workspace_key}")
             self.locked_pages[workspace_key] = {}
         for file_group in output_file_grps:
             if file_group not in self.locked_pages[workspace_key]:
-                self.log.debug(f"Creating an empty list for output file grp: {file_group}")
+                self.log.info(f"Creating an empty list for output file grp: {file_group}")
                 self.locked_pages[workspace_key][file_group] = []
             # The page id list is not empty - only some pages are in the request
             if page_ids:
-                self.log.debug(f"Locking pages for '{file_group}': {page_ids}")
+                self.log.info(f"Locking pages for '{file_group}': {page_ids}")
                 self.locked_pages[workspace_key][file_group].extend(page_ids)
-                self.log.debug(f"Locked pages of '{file_group}': "
-                               f"{self.locked_pages[workspace_key][file_group]}")
+                self.log.info(f"Locked pages of '{file_group}': {self.locked_pages[workspace_key][file_group]}")
             else:
                 # Lock all pages with a single value
-                self.log.debug(f"Locking pages for '{file_group}': {self.placeholder_all_pages}")
+                self.log.info(f"Locking pages for '{file_group}': {self.placeholder_all_pages}")
                 self.locked_pages[workspace_key][file_group].append(self.placeholder_all_pages)
 
     def unlock_pages(self, workspace_key: str, output_file_grps: List[str], page_ids: List[str]) -> None:
         if not self.locked_pages.get(workspace_key, None):
-            self.log.debug(f"No entry found in the locked pages cache for workspace key: {workspace_key}")
+            self.log.info(f"No entry found in the locked pages cache for workspace key: {workspace_key}")
             return
         for file_group in output_file_grps:
             if file_group in self.locked_pages[workspace_key]:
                 if page_ids:
                     # Unlock the previously locked pages
-                    self.log.debug(f"Unlocking pages of '{file_group}': {page_ids}")
+                    self.log.info(f"Unlocking pages of '{file_group}': {page_ids}")
                     self.locked_pages[workspace_key][file_group] = \
                         [x for x in self.locked_pages[workspace_key][file_group] if x not in page_ids]
-                    self.log.debug(f"Remaining locked pages of '{file_group}': "
-                                   f"{self.locked_pages[workspace_key][file_group]}")
+                    self.log.info(f"Remaining locked pages of '{file_group}': "
+                                  f"{self.locked_pages[workspace_key][file_group]}")
                 else:
                     # Remove the single variable used to indicate all pages are locked
-                    self.log.debug(f"Unlocking all pages for: {file_group}")
+                    self.log.info(f"Unlocking all pages for: {file_group}")
                     self.locked_pages[workspace_key][file_group].remove(self.placeholder_all_pages)
 
 
@@ -127,11 +126,11 @@ class CacheProcessingRequests:
         debug_message += f", page ids: {job_input.page_id}"
         debug_message += f", job id: {job_input.job_id}"
         debug_message += f", job depends on: {job_input.depends_on}"
-        self.log.debug(debug_message)
+        self.log.info(debug_message)
 
     async def consume_cached_requests(self, workspace_key: str) -> List[PYJobInput]:
         if not self.has_workspace_cached_requests(workspace_key=workspace_key):
-            self.log.debug(f"No jobs to be consumed for workspace key: {workspace_key}")
+            self.log.info(f"No jobs to be consumed for workspace key: {workspace_key}")
             return []
         found_consume_requests = []
         for current_element in self.processing_requests[workspace_key]:
@@ -165,7 +164,7 @@ class CacheProcessingRequests:
         # If a record counter of this workspace key does not exist
         # in the requests counter cache yet, create one and assign 0
         if not self.processing_counter.get(workspace_key, None):
-            self.log.debug(f"Creating an internal request counter for workspace key: {workspace_key}")
+            self.log.info(f"Creating an internal request counter for workspace key: {workspace_key}")
             self.processing_counter[workspace_key] = 0
         self.processing_counter[workspace_key] = self.processing_counter[workspace_key] + by_value
         return self.processing_counter[workspace_key]
@@ -173,7 +172,7 @@ class CacheProcessingRequests:
     def cache_request(self, workspace_key: str, data: PYJobInput):
         # If a record queue of this workspace key does not exist in the requests cache
         if not self.processing_requests.get(workspace_key, None):
-            self.log.debug(f"Creating an internal request queue for workspace_key: {workspace_key}")
+            self.log.info(f"Creating an internal request queue for workspace_key: {workspace_key}")
             self.processing_requests[workspace_key] = []
         self.__print_job_input_debug_message(job_input=data)
         # Add the processing request to the end of the internal queue
@@ -181,9 +180,9 @@ class CacheProcessingRequests:
 
     async def cancel_dependent_jobs(self, workspace_key: str, processing_job_id: str) -> List[PYJobInput]:
         if not self.has_workspace_cached_requests(workspace_key=workspace_key):
-            self.log.debug(f"No jobs to be cancelled for workspace key: {workspace_key}")
+            self.log.info(f"No jobs to be cancelled for workspace key: {workspace_key}")
             return []
-        self.log.debug(f"Cancelling jobs dependent on job id: {processing_job_id}")
+        self.log.info(f"Cancelling jobs dependent on job id: {processing_job_id}")
         found_cancel_requests = []
         for i, current_element in enumerate(self.processing_requests[workspace_key]):
             if processing_job_id in current_element.depends_on:
@@ -192,7 +191,7 @@ class CacheProcessingRequests:
         for cancel_element in found_cancel_requests:
             try:
                 self.processing_requests[workspace_key].remove(cancel_element)
-                self.log.debug(f"For job id: '{processing_job_id}', cancelling job id: '{cancel_element.job_id}'")
+                self.log.info(f"For job id: '{processing_job_id}', cancelling job id: '{cancel_element.job_id}'")
                 cancelled_jobs.append(cancel_element)
                 await db_update_processing_job(job_id=cancel_element.job_id, state=JobState.cancelled)
                 # Recursively cancel dependent jobs for the cancelled job
@@ -225,9 +224,9 @@ class CacheProcessingRequests:
 
     def has_workspace_cached_requests(self, workspace_key: str) -> bool:
         if not self.processing_requests.get(workspace_key, None):
-            self.log.debug(f"In processing requests cache, no workspace key found: {workspace_key}")
+            self.log.info(f"In processing requests cache, no workspace key found: {workspace_key}")
             return False
         if not len(self.processing_requests[workspace_key]):
-            self.log.debug(f"The processing requests cache is empty for workspace key: {workspace_key}")
+            self.log.info(f"The processing requests cache is empty for workspace key: {workspace_key}")
             return False
         return True

--- a/src/ocrd_network/server_utils.py
+++ b/src/ocrd_network/server_utils.py
@@ -1,12 +1,18 @@
+import os
+import re
+import signal
+from pathlib import Path
+from json import dumps, loads
+from urllib.parse import urljoin
+from typing import Dict, List, Union
+from time import time
+
 from fastapi import HTTPException, status, UploadFile
 from fastapi.responses import FileResponse
 from httpx import AsyncClient, Timeout
-from json import dumps, loads
 from logging import Logger
-from pathlib import Path
 from requests import get as requests_get
-from typing import Dict, List, Union
-from urllib.parse import urljoin
+from requests_unixsocket import sys
 
 from ocrd.resolver import Resolver
 from ocrd.task_sequence import ProcessorTask
@@ -241,3 +247,25 @@ def validate_first_task_input_file_groups_existence(logger: Logger, mets_path: s
         if group not in available_groups:
             message = f"Input file group '{group}' of the first processor not found: {input_file_grps}"
             raise_http_exception(logger, status.HTTP_422_UNPROCESSABLE_ENTITY, message)
+
+
+def kill_mets_server_zombies(minutes_ago=60) -> List[int]:
+    now = time()
+    cmdline_pat = r'.*ocrd workspace -U.*server start $'
+    ret = []
+    for procdir in sorted(Path('/proc').glob('*'), key=os.path.getctime):
+        if not procdir.is_dir():
+            continue
+        cmdline_file = procdir.joinpath('cmdline')
+        if not cmdline_file.is_file():
+            continue
+        ctime_ago = int((now - procdir.stat().st_ctime) / 60)
+        if ctime_ago < minutes_ago:
+            continue
+        cmdline = cmdline_file.read_text().replace('\x00', ' ')
+        if re.match(cmdline_pat, cmdline):
+            pid = procdir.name
+            ret.append(pid)
+            print(f'METS Server with PID {pid} was created {ctime_ago} minutes ago, more than {minutes_ago}, so killing (cmdline="{cmdline})', file=sys.stderr)
+            os.kill(int(pid), signal.SIGTERM)
+    return ret

--- a/src/ocrd_network/tcp_to_uds_mets_proxy.py
+++ b/src/ocrd_network/tcp_to_uds_mets_proxy.py
@@ -49,12 +49,11 @@ class MetsServerProxy:
         else:
             raise ValueError("Expecting request_data to be empty or containing single key: params,"
                              f"form, or class but not {request_data.keys}")
-
+        if response_type == "empty":
+            return {}
         if not response:
             self.log.error(f"Uds-Mets-Server gives unexpected error. Response: {response.__dict__}")
             return {"error": response.text}
-        elif response_type == "empty":
-            return {}
         elif response_type == "text":
             return {"text": response.text}
         elif response_type == "class" or response_type == "dict":

--- a/src/ocrd_network/tcp_to_uds_mets_proxy.py
+++ b/src/ocrd_network/tcp_to_uds_mets_proxy.py
@@ -1,5 +1,5 @@
 from requests_unixsocket import Session as requests_unixsocket_session
-from .utils import get_uds_path
+from .utils import get_uds_path, convert_url_to_uds_format
 from typing import Dict
 from ocrd_utils import getLogger
 
@@ -31,7 +31,7 @@ class MetsServerProxy:
         if method_type not in SUPPORTED_METHOD_TYPES:
             raise NotImplementedError(f"Method type: {method_type} not recognized")
         ws_socket_file = str(get_uds_path(ws_dir_path=ws_dir_path))
-        ws_unix_socket_url = f'http+unix://{ws_socket_file.replace("/", "%2F")}'
+        ws_unix_socket_url = convert_url_to_uds_format(ws_socket_file)
         uds_request_url = f"{ws_unix_socket_url}/{request_url}"
 
         self.log.info(f"Forwarding TCP mets server request to UDS url: {uds_request_url}")

--- a/src/ocrd_network/tcp_to_uds_mets_proxy.py
+++ b/src/ocrd_network/tcp_to_uds_mets_proxy.py
@@ -34,6 +34,10 @@ class MetsServerProxy:
         ws_unix_socket_url = f'http+unix://{ws_socket_file.replace("/", "%2F")}'
         uds_request_url = f"{ws_unix_socket_url}/{request_url}"
 
+        self.log.info(f"Forwarding TCP mets server request to UDS url: {uds_request_url}")
+        self.log.info(f"Forwarding method type {method_type}, request data: {request_data}, "
+                      f"expected response type: {response_type}")
+
         if not request_data:
             response = self.session.request(method_type, uds_request_url)
         elif "params" in request_data:

--- a/src/ocrd_network/utils.py
+++ b/src/ocrd_network/utils.py
@@ -167,17 +167,8 @@ def stop_mets_server(logger: Logger, mets_server_url: str, ws_dir_path: str) -> 
         return response.status_code == 200
     elif protocol == "uds":
         logger.info(f"Sending DELETE request to: {mets_server_url}/")
-        try:
-            response = Session_UDS().delete(url=f"{mets_server_url}/")
-            return response.status_code == 200
-        finally:
-            if protocol == "uds":
-                ws_socket_file = str(get_uds_path(ws_dir_path))
-                if Path(ws_socket_file).exists():
-                    logger.info(f"Removing the inactive UDS file: {ws_socket_file}")
-                    Path(ws_socket_file).unlink()
-                else:
-                    logger.warning(f"The UDS file to be removed is not existing: {ws_socket_file}")
+        response = Session_UDS().delete(url=f"{mets_server_url}/")
+        return response.status_code == 200
     else:
         ValueError(f"Unexpected protocol type: {protocol}")
 

--- a/src/ocrd_network/utils.py
+++ b/src/ocrd_network/utils.py
@@ -151,7 +151,7 @@ def is_mets_server_running(mets_server_url: str, ws_dir_path: str = None) -> boo
         return False
 
 
-def stop_mets_server(mets_server_url: str, ws_dir_path: str = None) -> bool:
+def stop_mets_server(mets_server_url: str, ws_dir_path: Path = None) -> bool:
     protocol = "tcp" if (mets_server_url.startswith("http://") or mets_server_url.startswith("https://")) else "uds"
     session = Session_TCP() if protocol == "tcp" else Session_UDS()
     if protocol == "uds":
@@ -160,7 +160,7 @@ def stop_mets_server(mets_server_url: str, ws_dir_path: str = None) -> bool:
         if 'tcp_mets' in mets_server_url:
             if not ws_dir_path:
                 return False
-            response = session.post(url=f"{mets_server_url}", json=MpxReq.stop(ws_dir_path))
+            response = session.post(url=f"{mets_server_url}", json=MpxReq.stop(str(ws_dir_path)))
         else:
             response = session.delete(url=f"{mets_server_url}/")
     except Exception:

--- a/src/ocrd_network/utils.py
+++ b/src/ocrd_network/utils.py
@@ -151,7 +151,7 @@ def is_mets_server_running(mets_server_url: str, ws_dir_path: str = None) -> boo
         return False
 
 
-def stop_mets_server(mets_server_url: str, ws_dir_path: Path = None) -> bool:
+def stop_mets_server(mets_server_url: str, ws_dir_path: str = None) -> bool:
     protocol = "tcp" if (mets_server_url.startswith("http://") or mets_server_url.startswith("https://")) else "uds"
     session = Session_TCP() if protocol == "tcp" else Session_UDS()
     if protocol == "uds":
@@ -160,7 +160,7 @@ def stop_mets_server(mets_server_url: str, ws_dir_path: Path = None) -> bool:
         if 'tcp_mets' in mets_server_url:
             if not ws_dir_path:
                 return False
-            response = session.post(url=f"{mets_server_url}", json=MpxReq.stop(str(ws_dir_path)))
+            response = session.post(url=f"{mets_server_url}", json=MpxReq.stop(ws_dir_path))
         else:
             response = session.delete(url=f"{mets_server_url}/")
     except Exception:


### PR DESCRIPTION
This PR fixes:
- No more zombie processes for Mets Servers when they terminate!
- Appropriately deleting the Unix Domain Socket in more complicated configurations (e.g., UDS over TCP multiplexing)
- More extensive logging (to separate files as well) for:
  + `ocrd_network.server_cache.locked_pages`
  + `ocrd_network.server_cache.processing_requests`
  + `ocrd.models.ocrd_mets.server.{self.url}`
  + `ocrd_network.tcp_to_uds_mets_proxy`
  
Please make sure you adapt your logging configuration file appropriately to avoid extreme amounts of logs. Maybe an adaption is needed to the default logging configuration file - open for discussions.