### PR TITLE
ocrd_utils.initLogging: also add handler to root logger

### DIFF
--- a/src/ocrd_utils/logging.py
+++ b/src/ocrd_utils/logging.py
@@ -181,11 +181,8 @@ def initLogging(builtin_only=False, force_reinit=False, silent=not config.OCRD_L
         ocrd_handler = logging.StreamHandler(stream=sys.stderr)
         ocrd_handler.setFormatter(logging.Formatter(fmt=LOG_FORMAT, datefmt=LOG_TIMEFMT))
         ocrd_handler.setLevel(logging.DEBUG)
-        for logger_name in ROOT_OCRD_LOGGERS:
-            logger = logging.getLogger(logger_name)
-            logger.addHandler(ocrd_handler)
-            if logger_name:
-                logger.propagate = False # avoid duplication (from root handler)
+        root_logger = logging.getLogger('')
+        root_logger.addHandler(ocrd_handler)
         for logger_name, logger_level in LOGGING_DEFAULTS.items():
             logging.getLogger(logger_name).setLevel(logger_level)
     _initialized_flag = True

--- a/src/ocrd_utils/logging.py
+++ b/src/ocrd_utils/logging.py
@@ -163,18 +163,6 @@ def initLogging(builtin_only=False, force_reinit=False, silent=not config.OCRD_L
     global _initialized_flag
     if _initialized_flag and not force_reinit:
         return
-    # disableLogging()
-
-    # https://docs.python.org/3/library/logging.html#logging.disable
-    # If logging.disable(logging.NOTSET) is called, it effectively removes this
-    # overriding level, so that logging output again depends on the effective
-    # levels of individual loggers.
-    logging.disable(logging.NOTSET)
-
-    # remove all handlers for the ocrd root loggers
-    for logger_name in ROOT_OCRD_LOGGERS:
-        for handler in logging.getLogger(logger_name).handlers[:]:
-            logging.getLogger(logger_name).removeHandler(handler)
 
     config_file = None
     if not builtin_only:

--- a/src/ocrd_utils/logging.py
+++ b/src/ocrd_utils/logging.py
@@ -50,6 +50,7 @@ __all__ = [
 
 # These are the loggers we add handlers to
 ROOT_OCRD_LOGGERS = [
+    '',
     'ocrd',
     'ocrd_network'
 ]
@@ -193,7 +194,10 @@ def initLogging(builtin_only=False, force_reinit=False, silent=not config.OCRD_L
         ocrd_handler.setFormatter(logging.Formatter(fmt=LOG_FORMAT, datefmt=LOG_TIMEFMT))
         ocrd_handler.setLevel(logging.DEBUG)
         for logger_name in ROOT_OCRD_LOGGERS:
-            logging.getLogger(logger_name).addHandler(ocrd_handler)
+            logger = logging.getLogger(logger_name)
+            logger.addHandler(ocrd_handler)
+            if logger_name:
+                logger.propagate = False # avoid duplication (from root handler)
         for logger_name, logger_level in LOGGING_DEFAULTS.items():
             logging.getLogger(logger_name).setLevel(logger_level)
     _initialized_flag = True
@@ -211,8 +215,8 @@ def disableLogging(silent=not config.OCRD_LOGGING_DEBUG):
     _initialized_flag = False
     # logging.basicConfig(level=logging.CRITICAL)
     # logging.disable(logging.ERROR)
-    # remove all handlers for the 'ocrd.' and root logger
-    for logger_name in ROOT_OCRD_LOGGERS + ['']:
+    # remove all handlers for the ocrd logger
+    for logger_name in ROOT_OCRD_LOGGERS:
         for handler in logging.getLogger(logger_name).handlers[:]:
             logging.getLogger(logger_name).removeHandler(handler)
     for logger_name in LOGGING_DEFAULTS:

--- a/src/ocrd_utils/logging.py
+++ b/src/ocrd_utils/logging.py
@@ -152,8 +152,11 @@ def initLogging(builtin_only=False, force_reinit=False, silent=not config.OCRD_L
         - silent (bool, True): Whether to log logging behavior by printing to stderr
     """
     global _initialized_flag
-    if _initialized_flag and not force_reinit:
-        return
+    if _initialized_flag:
+        if force_reinit:
+            disableLogging(silent=silent)
+        else:
+            return
 
     config_file = None
     if not builtin_only:

--- a/src/ocrd_utils/logging.py
+++ b/src/ocrd_utils/logging.py
@@ -49,6 +49,7 @@ __all__ = [
 ]
 
 LOGGING_DEFAULTS = {
+    '': logging.WARNING,
     'ocrd': logging.INFO,
     'ocrd_network': logging.INFO,
     # 'ocrd.resolver': logging.INFO,

--- a/src/ocrd_utils/logging.py
+++ b/src/ocrd_utils/logging.py
@@ -109,18 +109,15 @@ def setOverrideLogLevel(lvl, silent=not config.OCRD_LOGGING_DEBUG):
         lvl (string): Log level name.
         silent (boolean): Whether to log the override call
     """
-    if not _initialized_flag:
-        initLogging(silent=silent)
-    ocrd_logger = logging.getLogger('ocrd')
-
-    if lvl is None:
-        if not silent:
-            print('[LOGGING] Reset log level override', file=sys.stderr)
-        ocrd_logger.setLevel(logging.NOTSET)
-    else:
-        if not silent:
-            print(f'[LOGGING] Overriding ocrd log level to {lvl}', file=sys.stderr)
-        ocrd_logger.setLevel(lvl)
+    if lvl is not None:
+        lvl = getLevelName(lvl)
+        if not _initialized_flag:
+            initLogging(silent=silent)
+        # affect all configured loggers
+        for logger_name in logging.root.manager.loggerDict:
+            if not silent:
+                print(f'[LOGGING] Overriding {logger_name} log level to {lvl}', file=sys.stderr)
+            logging.getLogger(logger_name).setLevel(lvl)
 
 def get_logging_config_files():
     """

--- a/src/ocrd_utils/ocrd_logging.conf
+++ b/src/ocrd_utils/ocrd_logging.conf
@@ -56,22 +56,22 @@ handlers=consoleHandler,fileHandler
 # ocrd loggers
 [logger_ocrd]
 level=INFO
-handlers=consoleHandler,fileHandler
+handlers=
 qualname=ocrd
-propagate=0
 
 [logger_ocrd_network]
 level=INFO
-handlers=consoleHandler,processingServerHandler
+#handlers=consoleHandler,processingServerHandler
+handlers=processingServerHandler
 qualname=ocrd_network
-propagate=0
+#propagate=0
 
 #
 # logger tensorflow
 #
 [logger_ocrd_tensorflow]
 level=ERROR
-handlers=consoleHandler
+handlers=
 qualname=tensorflow
 
 #
@@ -79,7 +79,7 @@ qualname=tensorflow
 #
 [logger_ocrd_shapely_geos]
 level=ERROR
-handlers=consoleHandler
+handlers=
 qualname=shapely.geos
 
 
@@ -88,7 +88,7 @@ qualname=shapely.geos
 #
 [logger_ocrd_PIL]
 level=INFO
-handlers=consoleHandler
+handlers=
 qualname=PIL
 
 #
@@ -96,34 +96,32 @@ qualname=PIL
 #
 [logger_paramiko]
 level=INFO
-handlers=consoleHandler
+handlers=
 qualname=paramiko
-propagate=0
 
 [logger_paramiko_transport]
 level=INFO
-handlers=consoleHandler
+handlers=
 qualname=paramiko.transport
-propagate=0
 
 #
 # uvicorn loggers
 #
 [logger_uvicorn]
 level=INFO
-handlers=consoleHandler
+handlers=
 qualname=uvicorn
 [logger_uvicorn_access]
 level=WARN
-handlers=consoleHandler
+handlers=
 qualname=uvicorn.access
 [logger_uvicorn_error]
 level=INFO
-handlers=consoleHandler
+handlers=
 qualname=uvicorn.error
 [logger_multipart]
 level=INFO
-handlers=consoleHandler
+handlers=
 qualname=multipart
 
 

--- a/src/ocrd_utils/ocrd_logging.conf
+++ b/src/ocrd_utils/ocrd_logging.conf
@@ -34,7 +34,7 @@ keys=defaultFormatter,detailedFormatter
 # default logger "root" using consoleHandler
 #
 [logger_root]
-level=INFO
+level=WARNING
 handlers=consoleHandler,fileHandler
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -26,8 +26,6 @@ class TestCase(VanillaTestCase):
 
     def setUp(self):
         chdir(dirname(realpath(__file__)) + '/..')
-        disableLogging()
-        initLogging(builtin_only=True)
 
 class CapturingTestCase(TestCase):
     """

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -6,8 +6,8 @@ from os import environ as ENV
 from tests.base import CapturingTestCase as TestCase, main, assets, copy_of_directory
 
 from ocrd.decorators import ocrd_loglevel
-from ocrd_utils import setOverrideLogLevel, logging, disableLogging
-import logging as python_logging
+from ocrd_utils import disableLogging, initLogging
+import logging
 
 @click.group()
 @ocrd_loglevel
@@ -18,14 +18,19 @@ mock_ocrd_cli.add_command(log_cli)
 class TestLogCli(TestCase):
 
     def _get_log_output(self, *args):
-        disableLogging()
         code, out, err = self.invoke_cli(mock_ocrd_cli, args)
         print({'code': code, 'out': out, 'err': err})
         return err
 
+    def setUp(self):
+        super().setUp()
+        initLogging()
+
     def tearDown(self):
         if 'OCRD_TOOL_NAME' in ENV:
             del(ENV['OCRD_TOOL_NAME'])
+        super().tearDown()
+        disableLogging()
 
     def test_loglevel(self):
         assert 'DEBUG ocrd.log_cli - foo' not in self._get_log_output('log', 'debug', 'foo')

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -41,22 +41,20 @@ DEFAULT_IN_OUT = ('-I', 'OCR-D-IMG', '-O', 'OUTPUT')
 
 class TestDecorators(TestCase):
 
-    def setUp(self):
-        super().setUp()
-        disableLogging()
-
     def tearDown(self):
         super().tearDown()
         config.reset_defaults()
+        disableLogging()
 
     def test_minimal(self):
-        exit_code, out, err = self.invoke_cli(cli_with_ocrd_cli_options, ['-l', 'DEBUG'])
-        print(out, err)
-        assert not exit_code
+        initLogging()
+        code, out, err = self.invoke_cli(cli_with_ocrd_cli_options, ['-l', 'DEBUG'])
+        assert not code, (out, err)
 
     def test_loglevel_invalid(self):
-        code, _, err = self.invoke_cli(cli_with_ocrd_loglevel, ['--log-level', 'foo'])
-        assert code
+        initLogging()
+        code, out, err = self.invoke_cli(cli_with_ocrd_loglevel, ['--log-level', 'foo'])
+        assert code, (out, err)
         import click
         if int(click.__version__[0]) < 8:
             assert 'invalid choice: foo' in err
@@ -67,7 +65,6 @@ class TestDecorators(TestCase):
         if get_logging_config_files():
             pytest.skip(f"ocrd_logging.conf found at {get_logging_config_files()}, skipping logging test")
         import logging
-        disableLogging()
         assert logging.getLogger('').getEffectiveLevel() == logging.WARNING
         assert logging.getLogger('ocrd').getEffectiveLevel() == logging.WARNING
         initLogging()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -26,16 +26,22 @@ class TestLogging(TestCase):
     def setUp(self):
         pass # do not chdir
 
+    def tearDown(self):
+        super().tearDown()
+        disableLogging()
+
     def test_loglevel_inheritance(self):
         initLogging(builtin_only=True)
         ocrd_logger = logging.getLogger('ocrd')
         assert ocrd_logger.getEffectiveLevel() == logging.INFO
         some_logger = getLogger('ocrd.foo')
+        assert some_logger.level == logging.NOTSET
         assert some_logger.getEffectiveLevel() == logging.INFO
         setOverrideLogLevel('ERROR')
         assert ocrd_logger.getEffectiveLevel() == logging.ERROR
         assert some_logger.getEffectiveLevel() == logging.ERROR
         another_logger = getLogger('ocrd.bar')
+        assert another_logger.level == logging.NOTSET
         assert another_logger.getEffectiveLevel() == logging.ERROR
 
     def test_getLevelName(self):

--- a/tests/test_logging_conf.py
+++ b/tests/test_logging_conf.py
@@ -21,74 +21,67 @@ from tests.base import main
 # sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../ocrd')
 TEST_ROOT = pathlib.Path(os.path.dirname(os.path.abspath(__file__))).parent
 
-def resetLogging():
-    disableLogging()
-    initLogging()
-
-
 @pytest.fixture(name="logging_conf")
-def _fixture_logging_conf(tmpdir):
+def _fixture_logging_conf(tmpdir, capfd):
 
     path_logging_conf_orig = os.path.join(
         str(TEST_ROOT), 'src', 'ocrd_utils', 'ocrd_logging.conf')
     path_logging_conf_dest = os.path.join(str(tmpdir), 'ocrd_logging.conf')
     shutil.copy(path_logging_conf_orig, path_logging_conf_dest)
-    return str(tmpdir)
+    with pushd_popd(tmpdir):
+        with capfd.disabled():
+            initLogging()
+            yield str(tmpdir)
+            disableLogging()
 
 
-def test_configured_dateformat(logging_conf, capsys):
+def test_configured_dateformat(logging_conf, capfd):
     """Ensure example ocrd_logging.conf is valid and produces desired record format"""
 
     # arrange
-    with pushd_popd(logging_conf):
-        resetLogging()
-        test_logger = getLogger('')
+    test_logger = getLogger('ocrd')
 
-        # act
-        test_logger.info("test logger initialized")
+    # act
+    test_logger.info("test logger initialized")
 
-        log_info_output = capsys.readouterr().err
-        must_not_match = r"^\d{4}-\d{2}-\d{2}.*"
-        assert not re.match(must_not_match, log_info_output)
-        match_pattern = r"^\d{2}:\d{2}:\d{2}.*"
-        assert re.match(match_pattern, log_info_output)
+    log_info_output = capfd.readouterr().err
+    must_not_match = r"^\d{4}-\d{2}-\d{2}.*"
+    assert not re.match(must_not_match, log_info_output)
+    match_pattern = r"^\d{2}:\d{2}:\d{2}.*"
+    assert re.match(match_pattern, log_info_output), log_info_output
 
 
-def test_configured_tensorflow_logger_present(logging_conf, capsys):
+def test_configured_tensorflow_logger_present(logging_conf, capfd):
     """Ensure example ocrd_logging.conf is valid and contains logger tensorflow"""
 
     # arrange
-    os.chdir(logging_conf)
-    resetLogging()
     logger_under_test = getLogger('tensorflow')
 
     # act info
     logger_under_test.info("tensorflow logger initialized")
-    log_info_output = capsys.readouterr().err
+    log_info_output = capfd.readouterr().err
     assert not log_info_output
 
     # act error
     logger_under_test.error("tensorflow has error")
-    log_error_output = capsys.readouterr().err
+    log_error_output = capfd.readouterr().err
     assert log_error_output
 
 
-def test_configured_shapely_logger_present(logging_conf, capsys):
+def test_configured_shapely_logger_present(logging_conf, capfd):
     """Ensure example ocrd_logging.conf is valid and contains logger shapely.geos"""
 
     # arrange
-    os.chdir(logging_conf)
-    resetLogging()
     logger_under_test = getLogger('shapely.geos')
 
     # act info
     logger_under_test.info("shapely.geos logger initialized")
-    log_info_output = capsys.readouterr().err
+    log_info_output = capfd.readouterr().err
     assert not log_info_output
 
     # act error
     logger_under_test.error("shapely alert")
-    log_error_output = capsys.readouterr().err
+    log_error_output = capfd.readouterr().err
     assert log_error_output
 
 if __name__ == '__main__':


### PR DESCRIPTION
As a follow-up to https://github.com/OCR-D/core/commit/ccb416b13e7f91781568fda8e60ad8182bfea88c, but more general:

`initLogging` should _always_ affect the root logger `''`, too. (Not just when disabling logging.)

Reasons:
- to be consistent with file config (which by default _also_ configures the unqualified `root` logger for our default handlers
- to prevent imported libraries from initializing logging on their own (like `import tensorflow`) – the place to check whether logging has been set up yet is always `getLogger('').hasHandlers()`, also in Python's logging.basicConfig BTW

I know we deliberately changed this to _exclude_ the root logger earlier. But I cannot find the reasoning behind that anymore. Maybe "we are a library, not an application"? Well, I agree actually, but then just don't call `initLogging`. (Perhaps at that time we got distracted by the fact that we still **did** call `initLogging` unconditionally when importing `ocrd_utils.logging`.)

BTW, IMO most places (core and modules code) can get their loggers from Python stdlib's `logging.getLogger` instead of our `ocrd_utils.logging.getLogger`, because we don't add anything to that nowadays.