### PR TITLE
Fix broken ocrd_network processing worker logs

### DIFF
--- a/src/ocrd_network/processing_server.py
+++ b/src/ocrd_network/processing_server.py
@@ -79,7 +79,6 @@ class ProcessingServer(FastAPI):
     """
 
     def __init__(self, config_path: str, host: str, port: int) -> None:
-        initLogging()
         self.title = "OCR-D Processing Server"
         super().__init__(
             title=self.title,
@@ -87,6 +86,7 @@ class ProcessingServer(FastAPI):
             on_shutdown=[self.on_shutdown],
             description="OCR-D Processing Server"
         )
+        initLogging()
         self.log = getLogger("ocrd_network.processing_server")
         log_file = get_processing_server_logging_file_path(pid=getpid())
         configure_file_handler_with_formatter(self.log, log_file=log_file, mode="a")
@@ -156,7 +156,7 @@ class ProcessingServer(FastAPI):
             queue_names = self.deployer.find_matching_network_agents(
                 worker_only=True, str_names_only=True, unique_only=True
             )
-            self.log.debug(f"Creating message queues on RabbitMQ instance url: {self.rabbitmq_url}")
+            self.log.info(f"Creating message queues on RabbitMQ instance url: {self.rabbitmq_url}")
             create_message_queues(logger=self.log, rmq_publisher=self.rmq_publisher, queue_names=queue_names)
 
             self.deployer.deploy_network_agents(mongodb_url=self.mongodb_url, rabbitmq_url=self.rabbitmq_url)
@@ -168,6 +168,7 @@ class ProcessingServer(FastAPI):
         uvicorn_run(self, host=self.hostname, port=int(self.port))
 
     async def on_startup(self):
+        self.log.info(f"Initializing the Database on: {self.mongodb_url}")
         await initiate_database(db_url=self.mongodb_url)
 
     async def on_shutdown(self) -> None:

--- a/src/ocrd_network/processor_server.py
+++ b/src/ocrd_network/processor_server.py
@@ -42,13 +42,13 @@ class ProcessorServer(FastAPI):
     def __init__(self, mongodb_addr: str, processor_name: str = "", processor_class=None):
         if not (processor_name or processor_class):
             raise ValueError("Either 'processor_name' or 'processor_class' must be provided")
-        initLogging()
         super().__init__(
             on_startup=[self.on_startup],
             on_shutdown=[self.on_shutdown],
             title=f"Network agent - Processor Server",
             description="Network agent - Processor Server"
         )
+        initLogging()
         self.log = getLogger("ocrd_network.processor_server")
         log_file = get_processor_server_logging_file_path(processor_name=processor_name, pid=getpid())
         configure_file_handler_with_formatter(self.log, log_file=log_file, mode="a")
@@ -69,6 +69,7 @@ class ProcessorServer(FastAPI):
             self.processor_name = self.ocrd_tool["executable"]
 
         self.add_api_routes_processing()
+        self.log.info(f"Initialized processor server: {processor_name}")
 
     async def on_startup(self):
         await initiate_database(db_url=self.db_url)


### PR DESCRIPTION
The processing worker logger acted weirdly for some time. Pay attention to the log levels produced by `self.log.__dict__`

```python
2024-10-14 14:57:54,874.874 WARNING ocrd_network.processing_worker - ---------- __init__() CONFIGURED LOGGER: {'filters': [], 'name': 'ocrd_network.processing_worker', 'level': 0, 'parent': <Logger ocrd_network (WARNING)>, 'propagate': True, 'handlers': [<FileHandler /tmp/ocrd_network_logs/processing_workers/worker.843428.ocrd-cis-ocropy-binarize.log (NOTSET)>], 'disabled': False, '_cache': {10: False, 20: False, 40: True}, 'manager': <logging.Manager object at 0x7fa652ba9b50>}
2024-10-14 14:57:54,879.879 WARNING ocrd_network.processing_worker - ---------- start_consuming() CONFIGURED LOGGER: {'filters': [], 'name': 'ocrd_network.processing_worker', 'level': 0, 'parent': <Logger ocrd_network (WARNING)>, 'propagate': True, 'handlers': [<FileHandler /tmp/ocrd_network_logs/processing_workers/worker.843428.ocrd-cis-ocropy-binarize.log (NOTSET)>], 'disabled': False, '_cache': {10: False, 20: False, 40: True, 30: True}, 'manager': <logging.Manager object at 0x7fa652ba9b50>}
2024-10-14 14:58:12,140.140 WARNING ocrd_network.processing_worker - ---------- on_consumed_message() CONFIGURED LOGGER: {'filters': [], 'name': 'ocrd_network.processing_worker', 'level': 0, 'parent': <Logger ocrd_network (WARNING)>, 'propagate': True, 'handlers': [<FileHandler /tmp/ocrd_network_logs/processing_workers/worker.843428.ocrd-cis-ocropy-binarize.log (NOTSET)>], 'disabled': False, '_cache': {10: False, 20: False, 40: True, 30: True}, 'manager': <logging.Manager object at 0x7fa652ba9b50>}
2024-10-14 14:58:12,141.141 WARNING ocrd_network.processing_worker - ---------- process_message() CONFIGURED LOGGER: {'filters': [], 'name': 'ocrd_network.processing_worker', 'level': 0, 'parent': <Logger ocrd_network (WARNING)>, 'propagate': True, 'handlers': [<FileHandler /tmp/ocrd_network_logs/processing_workers/worker.843428.ocrd-cis-ocropy-binarize.log (NOTSET)>], 'disabled': False, '_cache': {10: False, 20: False, 40: True, 30: True}, 'manager': <logging.Manager object at 0x7fa652ba9b50>}
2024-10-14 14:58:15,279.279 WARNING ocrd_network.processing_worker - ---------- publish_result_to_all() CONFIGURED LOGGER: {'filters': [], 'name': 'ocrd_network.processing_worker', 'level': 0, 'parent': <Logger ocrd_network (INFO)>, 'propagate': True, 'handlers': [<FileHandler /tmp/ocrd_network_logs/processing_workers/worker.843428.ocrd-cis-ocropy-binarize.log (NOTSET)>], 'disabled': False, '_cache': {20: True, 40: True}, 'manager': <logging.Manager object at 0x7fa652ba9b50>}
2024-10-14 14:58:15,279.279 INFO ocrd_network.processing_worker - Result message: {'job_id': 'b3efe133-7c7d-4316-abc1-d99c35c5f62b', 'state': 'SUCCESS', 'workspace_id': '', 'path_to_mets': '/home/mm/repos/ocrd_network_tests/ws29/data/mets.xml'}
2024-10-14 14:58:15,280.280 INFO ocrd_network.processing_worker - Publishing result to internal callback url (Processing Server): None
2024-10-14 14:58:15,280.280 INFO ocrd_network.processing_worker - Posting result message to callback_url "http://localhost:8080/result_callback"
2024-10-14 14:58:15,317.317 INFO ocrd_network.processing_worker - Response from callback_url "<Response [200]>"
2024-10-14 14:58:15,318.318 INFO ocrd_network.processing_worker - Successfully processed RabbitMQ message
2024-10-14 14:58:15,320.320 WARNING ocrd_network.processing_worker - ---------- on_consumed_message() CONFIGURED LOGGER: {'filters': [], 'name': 'ocrd_network.processing_worker', 'level': 0, 'parent': <Logger ocrd_network (INFO)>, 'propagate': True, 'handlers': [<FileHandler /tmp/ocrd_network_logs/processing_workers/worker.843428.ocrd-cis-ocropy-binarize.log (NOTSET)>], 'disabled': False, '_cache': {20: True, 40: True, 30: True, 10: False}, 'manager': <logging.Manager object at 0x7fa652ba9b50>}
```

To reproduce it is enough to print the logger object at the beginning of each method:
```python
self.log.warning(f"{self.log.__dict__}")
```

Seems when jiggling with the logging in the past, the `initLogging()` call was removed from the processing worker. The logger level is still set to `INFO` at some point, but an implicit call to `initLogging()` sets the logger level earlier.
