### PR TITLE
run initLogging unconditionally

### DIFF
--- a/src/ocrd_utils/logging.py
+++ b/src/ocrd_utils/logging.py
@@ -205,3 +205,8 @@ def disableLogging(silent=not config.OCRD_LOGGING_DEBUG):
     # Python default log level is WARNING
     logging.root.setLevel(logging.WARNING)
 
+# Initialize logging now to prevent any other libraries (tensorflow,
+# matplotlib ...) from adding their own root handler, which might mangle the
+# STDOUT (our logging will log to STDERR so as not to interfere with
+# --dump-json etc.)
+initLogging()

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -24,6 +24,7 @@ class TestLogCli(TestCase):
 
     def setUp(self):
         super().setUp()
+        disableLogging()
         initLogging()
 
     def tearDown(self):


### PR DESCRIPTION
As discussed in the Tech Call today, we do still need to call `initLogging` to prevent other modules from adding handlers that might interfere with STDOUT.

And the `tests/cli/test_log.py` needs to call `disableLogging` before the first `initLogging` because otherwise pytest will highjack the logging :/