### PR TITLE
fixup 39f76258: avoid explicit .stop() for QueueListener

### DIFF
--- a/src/ocrd/processor/helpers.py
+++ b/src/ocrd/processor/helpers.py
@@ -56,12 +56,18 @@ def run_processor(
     - :py:attr:`output_file_grp`
     - :py:attr:`parameter` (after applying any :py:attr:`parameter_override` settings)
 
-    Warning: Avoid setting the `instance_caching` flag to True. It may have unexpected side effects.
-    This flag is used for an experimental feature we would like to adopt in future.
-
     Run the processor on the workspace (creating output files in the filesystem).
 
     Finally, write back the workspace (updating the METS in the filesystem).
+
+    If :py:attr:`instance_caching` is True, then processor instances (for the same set
+    of :py:attr:`parameter` values) will be cached internally. Thus, these objects (and
+    all their memory resources, like loaded models) get re-used instead of re-instantiated
+    when a match occurs - as long as the program is being run. They only get deleted (and
+    their resources freed) when as many as :py:data:`~ocrd_utils.config.OCRD_MAX_PROCESSOR_CACHE`
+    instances have already been cached while this particular parameter set was re-used
+    least frequently. (See :py:class:`~ocrd_network.ProcessingWorker` and
+    :py:class:`~ocrd_network.ProcessorServer` for use-cases.)
 
     Args:
         processorClass (object): Python class of the module processor.

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -475,5 +475,33 @@ def test_run_output_parallel(start_mets_server):
     assert len(ws.mets.find_all_files(fileGrp="OCR-D-OUT")) == len(ws.mets.find_all_files(fileGrp="OCR-D-IMG"))
     config.reset_defaults()
 
+def test_run_output_parallel_caching(start_mets_server):
+    import time
+    mets_server_url, ws = start_mets_server
+    assert len(ws.mets.find_all_files(fileGrp="OCR-D-OUT")) == 0
+    # do not raise for single-page timeout
+    config.OCRD_PROCESSING_PAGE_TIMEOUT = -1
+    # do not raise for number of failures:
+    config.OCRD_MAX_MISSING_OUTPUTS = -1
+    config.OCRD_MAX_PARALLEL_PAGES = 3
+    kwargs = dict(workspace=ws,
+                  input_file_grp="OCR-D-IMG",
+                  output_file_grp="OCR-D-OUT",
+                  parameter={"sleep": 2},
+                  mets_server_url=mets_server_url,
+                  instance_caching=True)
+    start_time = time.time()
+    proc1 = run_processor(DummyProcessorWithOutputSleep, **kwargs)
+    run_time = time.time() - start_time
+    assert run_time < 3, f"run_processor took {run_time}s"
+    assert len(ws.mets.find_all_files(fileGrp="OCR-D-OUT")) == len(ws.mets.find_all_files(fileGrp="OCR-D-IMG"))
+    start_time = time.time()
+    proc2 = run_processor(DummyProcessorWithOutputSleep, **kwargs)
+    assert proc1 is proc2, "instance_caching must yield identical processor objects for equal parameters"
+    run_time = time.time() - start_time
+    # should be faster with default config.OCRD_EXISTING_OUTPUT==SKIP
+    assert run_time < 1, f"run_processor took {run_time}s"
+    config.reset_defaults()
+
 if __name__ == "__main__":
     main(__file__)


### PR DESCRIPTION
Needed for proper shutdown of page-parallel processors, esp. in pytest context (think CI).

Sorry to drag this on, but there were still fuzzy deadlocks in 3.0.2 that I did not see earlier.

It appears that is is sufficient to just let go of the QueueListener, without explicitly stopping it.

Tested with ocrd_cis (CLI), ocrd_kraken (Pytest), ocrd_tesserocr (both), ocrd_calamari (Pytest).