### PR TITLE
Fix docker cuda deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,26 @@
-ARG BASE_IMAGE
-FROM $BASE_IMAGE as ocrd_core_base
+ARG BASE_IMAGE=ubuntu:20.04
+ENV BASE_IMAGE=$BASE_IMAGE
+FROM $BASE_IMAGE AS ocrd_core_base
 ARG FIXUP=echo
-MAINTAINER OCR-D
-ENV DEBIAN_FRONTEND noninteractive
-ENV PYTHONIOENCODING utf8
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+LABEL \
+    maintainer="https://ocr-d.de/en/contact" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/OCR-D/core" \
+    org.label-schema.build-date=$BUILD_DATE \
+    org.opencontainers.image.vendor="DFG-Funded Initiative for Optical Character Recognition Development" \
+    org.opencontainers.image.title="core" \
+    org.opencontainers.image.description="OCR-D framework" \
+    org.opencontainers.image.source="https://github.com/OCR-D/core" \
+    org.opencontainers.image.documentation="https://github.com/OCR-D/core/blob/${VCS_REF}/README.md" \
+    org.opencontainers.image.revision=$VCS_REF \
+    org.opencontainers.image.created=$BUILD_DATE \
+    org.opencontainers.image.base.name=$BASE_IMAGE
+
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONIOENCODING=utf8
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV PIP=pip
@@ -45,7 +62,7 @@ WORKDIR /data
 
 CMD ["/usr/local/bin/ocrd", "--help"]
 
-FROM ocrd_core_base as ocrd_core_test
+FROM ocrd_core_base AS ocrd_core_test
 # Optionally skip make assets with this arg
 ARG SKIP_ASSETS
 WORKDIR /build/core

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=docker.io/ocrd/core
 FROM $BASE_IMAGE AS ocrd_core_base
 
 ENV MAMBA_EXE=/usr/local/bin/conda

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -13,6 +13,8 @@ WORKDIR /build/core
 COPY Makefile .
 
 RUN make deps-cuda
+# Smoke Test
+RUN ocrd --version
 
 WORKDIR /data
 

--- a/Dockerfile.cuda-tf1
+++ b/Dockerfile.cuda-tf1
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=docker.io/ocrd/core-cuda
 FROM $BASE_IMAGE AS ocrd_core_base
 
 WORKDIR /build/core

--- a/Dockerfile.cuda-tf1
+++ b/Dockerfile.cuda-tf1
@@ -6,6 +6,8 @@ WORKDIR /build/core
 COPY Makefile .
 
 RUN make deps-tf1
+# Smoke Test
+RUN ocrd --version
 
 WORKDIR /data
 

--- a/Dockerfile.cuda-tf2
+++ b/Dockerfile.cuda-tf2
@@ -6,6 +6,8 @@ WORKDIR /build/core
 COPY Makefile .
 
 RUN make deps-tf2
+# Smoke Test
+RUN ocrd --version
 
 WORKDIR /data
 

--- a/Dockerfile.cuda-tf2
+++ b/Dockerfile.cuda-tf2
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=docker.io/ocrd/core-cuda
 FROM $BASE_IMAGE AS ocrd_core_base
 
 WORKDIR /build/core

--- a/Dockerfile.cuda-torch
+++ b/Dockerfile.cuda-torch
@@ -6,6 +6,8 @@ WORKDIR /build
 COPY Makefile .
 
 RUN make deps-torch
+# Smoke Test
+RUN ocrd --version
 
 WORKDIR /data
 

--- a/Dockerfile.cuda-torch
+++ b/Dockerfile.cuda-torch
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=docker.io/ocrd/core-cuda
 FROM $BASE_IMAGE AS ocrd_core_base
 
 WORKDIR /build

--- a/Makefile
+++ b/Makefile
@@ -145,20 +145,24 @@ deps-tf1:
 	  pushd $$name && for path in $$name*; do mv $$path $${path/$$name/$$newname}; done && popd && \
 	  $(PYTHON) -m wheel pack $$name && \
 	  $(PIP) install $$newname*.whl && popd && rm -fr $$OLDPWD; \
-	  $(PIP) install "numpy<1.24"; \
+	  $(PIP) install "numpy<1.24" -r requirements.txt; \
 	else \
-	$(PIP) install "tensorflow-gpu<2.0"; \
+	  $(PIP) install "tensorflow-gpu<2.0" -r requirements.txt; \
 	fi
 
 deps-tf2:
 	if $(PYTHON) -c 'import sys; print("%u.%u" % (sys.version_info.major, sys.version_info.minor))' | fgrep 3.8; then \
-	$(PIP) install tensorflow; \
+	$(PIP) install tensorflow -r requirements.txt; \
 	else \
-	$(PIP) install "tensorflow[and-cuda]"; \
+	$(PIP) install "tensorflow[and-cuda]"  -r requirements.txt; \
 	fi
 
 deps-torch:
-	$(PIP) install -i https://download.pytorch.org/whl/cu118 torchvision==0.16.2+cu118 torch==2.1.2+cu118
+	$(PIP) install -i https://download.pytorch.org/whl/cu118 torchvision==0.16.2+cu118 torch==2.1.2+cu118 -r requirements.txt
+
+# deps-*: always mix core's requirements.txt with additional deps,
+# so pip does not ignore the older version reqs,
+# but instead tries to find a mutually compatible set.
 
 # Dependencies for deployment in an ubuntu/debian linux
 deps-ubuntu:

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,10 @@ deps-torch:
 deps-ubuntu:
 	apt-get install -y python3 imagemagick libgeos-dev libxml2-dev libxslt-dev libssl-dev
 
+# Dependencies for deployment via Conda
+deps-conda: get-conda
+	conda install -c conda-forge python==3.8.* imagemagick geos pkgconfig
+
 # Install test python deps via pip
 deps-test:
 	$(PIP) install -U pip


### PR DESCRIPTION
Our current `ocrd/core-cuda-tf2` (and probably others) are broken, because of version clashes for `typing-extensions` between `beanie` and `fastapi` vs. `tensorflow`. This PR addresses this by making sure additional `pip install` steps are always used in tandem with core's base `requirements.txt`.

Plus some improvements.