### PR TITLE
Update WorkspaceValidator

### DIFF
--- a/src/ocrd/cli/workspace.py
+++ b/src/ocrd/cli/workspace.py
@@ -88,8 +88,8 @@ def workspace_cli(ctx, directory, mets, mets_basename, mets_server_url, backup):
 @pass_workspace
 @click.option('-a', '--download', is_flag=True, help="Download all files")
 @click.option('-s', '--skip', help="Tests to skip", default=[], multiple=True, type=click.Choice(
-    ['imagefilename', 'dimension', 'pixel_density', 'page', 'url', 'page_xsd', 'mets_fileid_page_pcgtsid',
-     'mets_unique_identifier', 'mets_file_group_names', 'mets_files', 'mets_xsd']))
+    ['imagefilename', 'alternativeimage_filename', 'dimension', 'pixel_density', 'page', 'url', 'page_xsd',
+     'mets_fileid_page_pcgtsid', 'mets_unique_identifier', 'mets_file_group_names', 'mets_files', 'mets_xsd']))
 @click.option('--page-textequiv-consistency', '--page-strictness', help="How strict to check PAGE multi-level textequiv consistency", type=click.Choice(['strict', 'lax', 'fix', 'off']), default='strict')
 @click.option('--page-coordinate-consistency', help="How fierce to check PAGE multi-level coordinate consistency", type=click.Choice(['poly', 'baseline', 'both', 'off']), default='poly')
 @click.argument('mets_url', default=None, required=False)

--- a/src/ocrd/cli/workspace.py
+++ b/src/ocrd/cli/workspace.py
@@ -88,8 +88,8 @@ def workspace_cli(ctx, directory, mets, mets_basename, mets_server_url, backup):
 @pass_workspace
 @click.option('-a', '--download', is_flag=True, help="Download all files")
 @click.option('-s', '--skip', help="Tests to skip", default=[], multiple=True, type=click.Choice(
-    ['imagefilename', 'alternativeimage_filename', 'dimension', 'pixel_density', 'page', 'url', 'page_xsd',
-     'mets_fileid_page_pcgtsid', 'mets_unique_identifier', 'mets_file_group_names', 'mets_files', 'mets_xsd']))
+    ['imagefilename', 'alternativeimage_filename', 'alternativeimage_comments', 'dimension', 'pixel_density', 'page', 'page_xsd',
+     'url', 'mets_fileid_page_pcgtsid', 'mets_unique_identifier', 'mets_files', 'mets_xsd']))
 @click.option('--page-textequiv-consistency', '--page-strictness', help="How strict to check PAGE multi-level textequiv consistency", type=click.Choice(['strict', 'lax', 'fix', 'off']), default='strict')
 @click.option('--page-coordinate-consistency', help="How fierce to check PAGE multi-level coordinate consistency", type=click.Choice(['poly', 'baseline', 'both', 'off']), default='poly')
 @click.argument('mets_url', default=None, required=False)

--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -779,10 +779,14 @@ class Processor():
         to handle cases like multiple output fileGrps, non-PAGE input etc.)
         """
         input_pcgts : List[Optional[OcrdPage]] = [None] * len(input_files)
-        assert isinstance(input_files[0], get_args(OcrdFileType))
-        page_id = input_files[0].pageId
+        input_pos = next(i for i, input_file in enumerate(input_files) if input_file is not None)
+        page_id = input_files[input_pos].pageId
         self._base_logger.info("processing page %s", page_id)
         for i, input_file in enumerate(input_files):
+            if input_file is None:
+                grp = self.input_file_grp.split(',')[i]
+                self._base_logger.debug(f"ignoring missing file for input fileGrp {grp} for page {page_id}")
+                continue
             assert isinstance(input_file, get_args(OcrdFileType))
             self._base_logger.debug(f"parsing file {input_file.ID} for page {page_id}")
             try:
@@ -792,10 +796,10 @@ class Processor():
             except ValueError as err:
                 # not PAGE and not an image to generate PAGE for
                 self._base_logger.error(f"non-PAGE input for page {page_id}: {err}")
-        output_file_id = make_file_id(input_files[0], self.output_file_grp)
-        if input_files[0].fileGrp == self.output_file_grp:
+        output_file_id = make_file_id(input_files[input_pos], self.output_file_grp)
+        if input_files[input_pos].fileGrp == self.output_file_grp:
             # input=output fileGrp: re-use ID exactly
-            output_file_id = input_files[0].ID
+            output_file_id = input_files[input_pos].ID
         output_file = next(self.workspace.mets.find_files(ID=output_file_id), None)
         if output_file and config.OCRD_EXISTING_OUTPUT != 'OVERWRITE':
             # short-cut avoiding useless computation:

--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -793,6 +793,9 @@ class Processor():
                 # not PAGE and not an image to generate PAGE for
                 self._base_logger.error(f"non-PAGE input for page {page_id}: {err}")
         output_file_id = make_file_id(input_files[0], self.output_file_grp)
+        if input_files[0].fileGrp == self.output_file_grp:
+            # input=output fileGrp: re-use ID exactly
+            output_file_id = input_files[0].ID
         output_file = next(self.workspace.mets.find_files(ID=output_file_id), None)
         if output_file and config.OCRD_EXISTING_OUTPUT != 'OVERWRITE':
             # short-cut avoiding useless computation:

--- a/src/ocrd_models/constants.py
+++ b/src/ocrd_models/constants.py
@@ -28,6 +28,8 @@ __all__ = [
     'TAG_PAGE_TEXTEQUIV',
     'TAG_PAGE_TEXTREGION',
     'METS_PAGE_DIV_ATTRIBUTE',
+    'PAGE_REGION_TYPES',
+    'PAGE_ALTIMG_FEATURES',
 ]
 
 
@@ -71,6 +73,20 @@ PAGE_REGION_TYPES = [
     'LineDrawing', 'Map', 'Maths', 'Music', 'Noise',
     'Separator', 'Table', 'Text', 'Unknown'
 ]
+
+PAGE_ALTIMG_FEATURES = [
+    'binarized',
+    'grayscale_normalized',
+    'despeckled',
+    'cropped',
+    'deskewed',
+    'rotated-90',
+    'rotated-180',
+    'rotated-270',
+    'dewarped',
+    'clipped',
+]
+
 
 class METS_PAGE_DIV_ATTRIBUTE(Enum):
     ID = auto()

--- a/src/ocrd_validators/workspace_validator.py
+++ b/src/ocrd_validators/workspace_validator.py
@@ -295,6 +295,9 @@ class WorkspaceValidator():
             if f.url and 'url' not in self.skip:
                 if re.match(r'^file:/[^/]', f.url):
                     self.report.add_error(f"File '{f.ID}' has an invalid (Java-specific) file URL '{f.url}'")
+                elif ':' not in f.url:
+                    self.report.add_error(f"File '{f.ID}' has an invalid (non-URI) file URL '{f.url}'")
+                    continue
                 scheme = f.url[0:f.url.index(':')]
                 if scheme not in ('http', 'https', 'file'):
                     self.report.add_warning(f"File '{f.ID}' has non-HTTP, non-file URL '{f.url}'")

--- a/src/ocrd_validators/workspace_validator.py
+++ b/src/ocrd_validators/workspace_validator.py
@@ -99,6 +99,7 @@ class WorkspaceValidator():
         # there will be more options to come
         self.page_checks = [check for check in ['mets_fileid_page_pcgtsid',
                                                 'imagefilename',
+                                                'alternativeimage_filename',
                                                 'dimension',
                                                 'page',
                                                 'page_xsd']
@@ -344,6 +345,18 @@ class WorkspaceValidator():
                     self.report.add_error(f"PAGE '{f.ID}': imageFilename '{imageFilename}' not found in METS")
                 if is_local_filename(imageFilename) and not Path(imageFilename).exists():
                     self.report.add_warning(f"PAGE '{f.ID}': imageFilename '{imageFilename}' points to non-existent local file")
+            if 'alternativeimage_filename' in self.page_checks:
+                for altimg in page.get_AllAlternativeImages():
+                    if is_local_filename(altimg.filename):
+                        kwargs = dict(local_filename=altimg.filename, **self.find_kwargs)
+                    else:
+                        kwargs = dict(url=altimg.filename, **self.find_kwargs)
+                    if not self.mets.find_files(**kwargs):
+                        self.report.add_error(f"PAGE '{f.ID}': {altimg.parent_object_.id} AlternativeImage"
+                                              f"'{altimg.filename}' not found in METS")
+                    if is_local_filename(altimg.filename) and not Path(altimg.filename).exists():
+                        self.report.add_warning(f"PAGE '{f.ID}': {altimg.parent_object_.id} AlternativeImage"
+                                                f"'{altimg.filename}' points to non-existent local file")
             if 'mets_fileid_page_pcgtsid' in self.page_checks and pcgts.pcGtsId != f.ID:
                 self.report.add_warning('pc:PcGts/@pcGtsId differs from mets:file/@ID: "%s" !== "%s"' % (pcgts.pcGtsId or '', f.ID or ''))
 

--- a/src/ocrd_validators/workspace_validator.py
+++ b/src/ocrd_validators/workspace_validator.py
@@ -330,11 +330,11 @@ class WorkspaceValidator():
             pcgts = page_from_file(f)
             page = pcgts.get_Page()
             if 'dimension' in self.page_checks:
-                _, _, exif = self.workspace.image_from_page(page, f.pageId)
-                if page.imageHeight != exif.height:
-                    self.report.add_error(f"PAGE '{f.ID}': @imageHeight != image's actual height ({page.imageHeight} != {exif.height})")
-                if page.imageWidth != exif.width:
-                    self.report.add_error(f"PAGE '{f.ID}': @imageWidth != image's actual width ({page.imageWidth} != {exif.width})")
+                img = self.workspace._resolve_image_as_pil(page.imageFilename)
+                if page.imageHeight != img.height:
+                    self.report.add_error(f"PAGE '{f.ID}': @imageHeight != image's actual height ({page.imageHeight} != {img.height})")
+                if page.imageWidth != img.width:
+                    self.report.add_error(f"PAGE '{f.ID}': @imageWidth != image's actual width ({page.imageWidth} != {img.width})")
             if 'imagefilename' in self.page_checks:
                 imageFilename = page.imageFilename
                 if is_local_filename(imageFilename):

--- a/src/ocrd_validators/workspace_validator.py
+++ b/src/ocrd_validators/workspace_validator.py
@@ -120,7 +120,7 @@ class WorkspaceValidator():
             mets_url (string): URL of the METS file
             src_dir (string, None): Directory containing mets file
             skip (list): Validation checks to omit. One or more of 
-                'mets_unique_identifier', 'mets_file_group_names', 
+                'mets_unique_identifier',
                 'mets_files', 'pixel_density', 'dimension', 'url',
                 'multipage', 'page', 'page_xsd', 'mets_xsd', 
                 'mets_fileid_page_pcgtsid'
@@ -147,8 +147,6 @@ class WorkspaceValidator():
             try:
                 if 'mets_unique_identifier' not in self.skip:
                     self._validate_mets_unique_identifier()
-                if 'mets_file_group_names' not in self.skip:
-                    self._validate_mets_file_group_names()
                 if 'mets_files' not in self.skip:
                     self._validate_mets_files()
                 if 'pixel_density' not in self.skip:

--- a/src/ocrd_validators/workspace_validator.py
+++ b/src/ocrd_validators/workspace_validator.py
@@ -192,7 +192,11 @@ class WorkspaceValidator():
             self.workspace.download_file(f)
             page = page_from_file(f).get_Page()
             imageFilename = page.imageFilename
-            if not self.mets.find_files(url=imageFilename, **self.find_kwargs):
+            if is_local_filename(imageFilename):
+                kwargs = dict(local_filename=imageFilename, **self.find_kwargs)
+            else:
+                kwargs = dict(url=imageFilename, **self.find_kwargs)
+            if not self.mets.find_files(**kwargs):
                 self.report.add_error(f"PAGE '{f.ID}': imageFilename '{imageFilename}' not found in METS")
             if is_local_filename(imageFilename) and not Path(imageFilename).exists():
                 self.report.add_warning(f"PAGE '{f.ID}': imageFilename '{imageFilename}' points to non-existent local file")
@@ -331,7 +335,11 @@ class WorkspaceValidator():
                     self.report.add_error(f"PAGE '{f.ID}': @imageWidth != image's actual width ({page.imageWidth} != {exif.width})")
             if 'imagefilename' in self.page_checks:
                 imageFilename = page.imageFilename
-                if not self.mets.find_files(url=imageFilename):
+                if is_local_filename(imageFilename):
+                    kwargs = dict(local_filename=imageFilename, **self.find_kwargs)
+                else:
+                    kwargs = dict(url=imageFilename, **self.find_kwargs)
+                if not self.mets.find_files(**kwargs):
                     self.report.add_error(f"PAGE '{f.ID}': imageFilename '{imageFilename}' not found in METS")
                 if is_local_filename(imageFilename) and not Path(imageFilename).exists():
                     self.report.add_warning(f"PAGE '{f.ID}': imageFilename '{imageFilename}' points to non-existent local file")

--- a/src/ocrd_validators/workspace_validator.py
+++ b/src/ocrd_validators/workspace_validator.py
@@ -98,6 +98,7 @@ class WorkspaceValidator():
         self.page_coordinate_consistency = page_coordinate_consistency
         # there will be more options to come
         self.page_checks = [check for check in ['mets_fileid_page_pcgtsid',
+                                                'imagefilename',
                                                 'dimension',
                                                 'page',
                                                 'page_xsd']

--- a/tests/validator/test_workspace_validator.py
+++ b/tests/validator/test_workspace_validator.py
@@ -80,43 +80,6 @@ class TestWorkspaceValidator(TestCase):
             report = WorkspaceValidator.validate(self.resolver, join(tempdir, 'mets.xml'))
             self.assertEqual(len(report.errors), 2)
 
-    def test_validate_file_groups_non_ocrd(self):
-        with TemporaryDirectory() as tempdir:
-            workspace = self.resolver.workspace_from_nothing(directory=tempdir)
-            workspace.mets.unique_identifier = 'foobar'
-            workspace.mets.add_file_group('FOO')
-            workspace.save_mets()
-            report = WorkspaceValidator.validate(self.resolver, join(tempdir, 'mets.xml'))
-            self.assertEqual(len(report.errors), 1)
-            self.assertIn('No files', report.errors[0])
-            self.assertEqual(len(report.notices), 1)
-            self.assertIn("fileGrp USE 'FOO' does not begin with 'OCR-D-'", report.notices[0])
-
-    def test_validate_file_groups_unspecified(self):
-        with TemporaryDirectory() as tempdir:
-            workspace = self.resolver.workspace_from_nothing(directory=tempdir)
-            workspace.mets.unique_identifier = 'foobar'
-            workspace.mets.add_file_group('OCR-D-INVALID-FILEGRP')
-            workspace.save_mets()
-            report = WorkspaceValidator.validate(self.resolver, join(tempdir, 'mets.xml'))
-            print(report.notices)
-            self.assertEqual(len(report.errors), 1)
-            self.assertEqual(len(report.notices), 1)
-            self.assertEqual(report.notices[0], "Unspecified USE category 'INVALID' in fileGrp 'OCR-D-INVALID-FILEGRP'")
-            self.assertIn('No files', report.errors[0])
-
-    def test_validate_file_groups_bad_name(self):
-        with TemporaryDirectory() as tempdir:
-            workspace = self.resolver.workspace_from_nothing(directory=tempdir)
-            workspace.mets.unique_identifier = 'foobar'
-            workspace.mets.add_file_group('OCR-D-GT-X')
-            workspace.save_mets()
-            report = WorkspaceValidator.validate(self.resolver, join(tempdir, 'mets.xml'))
-            self.assertEqual(len(report.errors), 1)
-            self.assertEqual(len(report.notices), 1)
-            self.assertIn("Invalid USE name 'X' in fileGrp", report.notices[0])
-            self.assertIn('No files', report.errors[0])
-
     @pytest.mark.skip(reason="missing pageId means document-global now")
     def test_validate_files_nopageid(self):
         with TemporaryDirectory() as tempdir:


### PR DESCRIPTION
This fixes some current issues with `ocrd workspace validate`:

- we did not update to the `.url` vs `.local_filename` change yet
- the METS fileGrp names check is obsolete
- the `@imageFilename` check was disabled accidentally
- it did not cover `AlternativeImage/@filename`
- we did not check for `AlternativeImage/@comments` either
- the validator crashed during `dimension` check, because `image_from_page` depends on all other checks succeeding – I switched to `_resolve_image_pil` instead
- we did not have a check for the URL vs. OTHER FLocats