### PR TITLE
Processor: allow empty output file grp

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,7 +25,6 @@ jobs:
           - '3.12'
         os:
           - ubuntu-22.04
-          - ubuntu-20.04
           - macos-latest
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ deps-torch:
 
 # Dependencies for deployment in an ubuntu/debian linux
 deps-ubuntu:
+	apt-get update
 	apt-get install -y python3 imagemagick libgeos-dev libxml2-dev libxslt-dev libssl-dev
 
 # Dependencies for deployment via Conda

--- a/src/ocrd/decorators/__init__.py
+++ b/src/ocrd/decorators/__init__.py
@@ -107,7 +107,7 @@ def ocrd_cli_wrap_processor(
     if 'parameter_override' in kwargs:
         set_json_key_value_overrides(kwargs['parameter'], *kwargs.pop('parameter_override'))
     # Assert -I / -O
-    if 'input_file_grp' not in kwargs:
+    if not kwargs.get('input_file_grp', None):
         raise ValueError('-I/--input-file-grp is required')
     if 'output_file_grp' not in kwargs:
         raise ValueError('-O/--output-file-grp is required') # actually, it may be None

--- a/src/ocrd/decorators/__init__.py
+++ b/src/ocrd/decorators/__init__.py
@@ -107,10 +107,10 @@ def ocrd_cli_wrap_processor(
     if 'parameter_override' in kwargs:
         set_json_key_value_overrides(kwargs['parameter'], *kwargs.pop('parameter_override'))
     # Assert -I / -O
-    if not kwargs['input_file_grp']:
+    if 'input_file_grp' not in kwargs:
         raise ValueError('-I/--input-file-grp is required')
-    if not kwargs['output_file_grp']:
-        raise ValueError('-O/--output-file-grp is required')
+    if 'output_file_grp' not in kwargs:
+        raise ValueError('-O/--output-file-grp is required') # actually, it may be None
     resolver = Resolver()
     working_dir, mets, _, mets_server_url = \
             resolver.resolve_mets_arguments(working_dir, mets, None, mets_server_url)

--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -1112,7 +1112,7 @@ class Processor():
                 if not ifiles[i]:
                     # could be from non-unique with on_error=skip or from true gap
                     self._base_logger.error(f'Found no file for page {page} in file group {ifg}')
-                    if config.OCRD_MISSING_INPUT == 'abort':
+                    if config.OCRD_MISSING_INPUT == 'ABORT':
                         raise MissingInputFile(ifg, page, mimetype)
             if not any(ifiles):
                 # must be from non-unique with on_error=skip

--- a/src/ocrd/processor/builtin/dummy/ocrd-tool.json
+++ b/src/ocrd/processor/builtin/dummy/ocrd-tool.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0",
   "git_url": "https://github.com/OCR-D/core",
+  "dockerhub": "ocrd/core",
   "tools": {
     "ocrd-dummy": {
       "executable": "ocrd-dummy",

--- a/src/ocrd/processor/helpers.py
+++ b/src/ocrd/processor/helpers.py
@@ -276,7 +276,7 @@ def get_processor(
         # set current processing parameters
         processor.workspace = workspace
         processor.page_id = page_id
-        processor.input_file_grp = input_file_grp
-        processor.output_file_grp = output_file_grp
+        processor.input_file_grp = input_file_grp or ''
+        processor.output_file_grp = output_file_grp or ''
         return processor
     raise ValueError("Processor class is not known")


### PR DESCRIPTION
Spec actually says this is legitimate. We have processors like ocrd-docstruct, or might have evaluators etc. that simply do not produce output in the form of a file group.