### PR TITLE
METS Server: fix problems with "." in path

### DIFF
--- a/src/ocrd/mets_server.py
+++ b/src/ocrd/mets_server.py
@@ -131,7 +131,7 @@ class ClientSideOcrdMets:
     def __init__(self, url, workspace_path: Optional[str] = None):
         self.protocol = "tcp" if url.startswith("http://") else "uds"
         self.log = getLogger(f"ocrd.models.ocrd_mets.client.{url}")
-        self.url = url if self.protocol == "tcp" else f'http+unix://{url.replace("/", "%2F")}'
+        self.url = url if self.protocol == "tcp" else f'http+unix://{url.replace("/", "%2F").replace(".", "%2E")}'
         self.ws_dir_path = workspace_path if workspace_path else None
 
         if self.protocol == "tcp" and "tcp_mets" in self.url:

--- a/src/ocrd/resolver.py
+++ b/src/ocrd/resolver.py
@@ -308,4 +308,8 @@ class Resolver():
                     if not is_file_in_directory(directory, mets_url):
                         raise ValueError("--mets '%s' has a directory part inconsistent with --directory '%s'" % (mets_url, directory))
 
+        if mets_server_url and not mets_server_url.startswith('http://'):
+            # UDS socket
+            mets_server_url = str(Path(mets_server_url).resolve())
+
         return str(Path(directory).resolve()), str(mets_url), str(mets_basename), mets_server_url

--- a/tests/test_mets_server.py
+++ b/tests/test_mets_server.py
@@ -181,7 +181,7 @@ def test_mets_server_str(start_mets_server):
     assert str(f) == '<ClientSideOcrdFile fileGrp=OCR-D-IMG, ID=FILE_0001_IMAGE, mimetype=image/tiff, url=---, local_filename=OCR-D-IMG/FILE_0001_IMAGE.tif]/>'
     a = workspace_server.mets.agents[0]
     assert str(a) == '<ClientSideOcrdAgent [type=OTHER, othertype=SOFTWARE, role=CREATOR, otherrole=---, name=DFG-Koordinierungsprojekt zur Weiterentwicklung von Verfahren der Optical Character Recognition (OCR-D)]/>'
-    assert str(workspace_server.mets) == '<ClientSideOcrdMets[url=%s]>' % ('http+unix://%2Ftmp%2Focrd-mets-server.sock' if mets_server_url == TRANSPORTS[0] else TRANSPORTS[1])
+    assert str(workspace_server.mets) == '<ClientSideOcrdMets[url=%s]>' % ('http+unix://%2Ftmp%2Focrd-mets-server%2Esock' if mets_server_url == TRANSPORTS[0] else TRANSPORTS[1])
 
 def test_mets_test_unimplemented(start_mets_server):
     _, workspace_server = start_mets_server


### PR DESCRIPTION
If you try to run a METS Server with relative paths starting with `./`, you would get an `InvalidURL` exception from requests-unixsocket (because dots need to be escaped to `%2E` also), and the client would try to complain about the workspace directory diverging from the server's (because in workspace.cli the `resolver.resolve_mets_arguments` resolved all paths to absolute, but not the METS Server URL). The latter however did not even reach the proper exception, because of the former.

This addresses both. Should really add specific tests for this, too.
