### PR TITLE
ocrd ocrd-tool: add dump-module-dirs command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,14 @@ test-logging: assets
 	rm -rf $$tempdir/.coverage; \
 	rmdir $$tempdir
 
+# ensure shapely#1598 does not hit
+# ensure CUDA works for Torch or TF
+test-cuda-torch:
+	$(PYTHON) -c "from shapely.geometry import Polygon; import torch; torch.randn(10).cuda()"
+	$(PYTHON) -c "import torch, sys; sys.exit(0 if torch.cuda.is_available() else 1)"
+test-cuda-tf2 test-cuda-tf1:
+	$(PYTHON) -c "import tensorflow as tf, sys; sys.exit(0 if tf.test.is_gpu_available() else 1)"
+
 network-module-test: assets
 	$(PYTHON) \
 		-m pytest $(PYTEST_ARGS) -k 'test_modules_' -s -v --durations=10\

--- a/src/ocrd/cli/ocrd_tool.py
+++ b/src/ocrd/cli/ocrd_tool.py
@@ -18,7 +18,8 @@ from ocrd.processor import Processor
 from ocrd_utils import (
     set_json_key_value_overrides,
     parse_json_string_or_file,
-    parse_json_string_with_comments as loads
+    parse_json_string_with_comments as loads,
+    get_moduledir
 )
 from ocrd_validators import ParameterValidator, OcrdToolValidator
 
@@ -103,6 +104,13 @@ def ocrd_tool_list(ctx):
 @pass_ocrd_tool
 def ocrd_tool_dump(ctx):
     print(dumps(ctx.json['tools'], indent=True))
+
+@ocrd_tool_cli.command('dump-module-dirs', help="Dump module directory of each tool")
+@pass_ocrd_tool
+def ocrd_tool_dump_module_dirs(ctx):
+    print(dumps({tool_name: get_moduledir(tool_name)
+                 for tool_name in ctx.json['tools']},
+                indent=True))
 
 # ----------------------------------------------------------------------
 # ocrd ocrd-tool tool


### PR DESCRIPTION
Sounds silly, I know, but this will help adding another shortcircuit to all our Dockerfiles:

```Dockerfile
# prepackage ocrd-all-module-dir.json
RUN ocrd ocrd-tool ocrd-tool.json dump-module-dirs > $(dirname $(ocrd bashlib filename))/ocrd-all-module-dir.json
```

(circumvents dynamic lookup for `ocrd-some-processor --list-resources` / `ocrd resmgr list-installed` and for `ocrd resmgr download`)