### PR TITLE
skip input files

### DIFF
--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -232,8 +232,16 @@ class TestProcessor(TestCase):
     def test_run_output0(self):
         with pushd_popd(tempdir=True) as tempdir:
             ws = self.resolver.workspace_from_nothing(directory=tempdir)
-            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, file_id='foobar1', page_id='phys_0001')
-            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, file_id='foobar2', page_id='phys_0002')
+            file1 = ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, file_id='foobar1', page_id='phys_0001',
+                                url=assets.path_to('SBB0000F29300010000/data/OCR-D-GT-PAGE/FILE_0001_FULLTEXT.xml'))
+            file2 = ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, file_id='foobar2', page_id='phys_0002',
+                                url=assets.path_to('SBB0000F29300010000/data/OCR-D-GT-PAGE/FILE_0002_FULLTEXT.xml'))
+            run_processor(DummyProcessorWithOutput, workspace=ws,
+                          input_file_grp="GRP1",
+                          output_file_grp="OCR-D-OUT")
+            assert len(ws.mets.find_all_files(fileGrp="OCR-D-OUT")) == 0, "no output because no download"
+            ws.download_file(file1)
+            ws.download_file(file2)
             run_processor(DummyProcessorWithOutput, workspace=ws,
                           input_file_grp="GRP1",
                           output_file_grp="OCR-D-OUT")
@@ -312,8 +320,12 @@ class TestProcessor(TestCase):
     def test_run_output_overwrite(self):
         with pushd_popd(tempdir=True) as tempdir:
             ws = self.resolver.workspace_from_nothing(directory=tempdir)
-            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, file_id='foobar1', page_id='phys_0001')
-            ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, file_id='foobar2', page_id='phys_0002')
+            file1 = ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, file_id='foobar1', page_id='phys_0001',
+                                url=assets.path_to('SBB0000F29300010000/data/OCR-D-GT-PAGE/FILE_0001_FULLTEXT.xml'))
+            file2 = ws.add_file('GRP1', mimetype=MIMETYPE_PAGE, file_id='foobar2', page_id='phys_0002',
+                                url=assets.path_to('SBB0000F29300010000/data/OCR-D-GT-PAGE/FILE_0002_FULLTEXT.xml'))
+            ws.download_file(file1)
+            ws.download_file(file2)
             config.OCRD_EXISTING_OUTPUT = 'OVERWRITE'
             ws.add_file('OCR-D-OUT', mimetype=MIMETYPE_PAGE, file_id='OCR-D-OUT_phys_0001', page_id='phys_0001')
             config.OCRD_EXISTING_OUTPUT = 'ABORT'


### PR DESCRIPTION
This is a case of not seeing the forest for the trees: In the v3 changes, we did introduce `MissingInputFile` exception (for `OCRD_MISSING_INPUT=ABORT`). But this only applies narrowly: if there is no `mets:file` in one of the input fileGrps.

However, the more important case seems to be that there is a `mets:file` (regardless of the number of input fileGrps), but it is not available locally, and `OCRD_DOWNLOAD_INPUT=False` was set deliberately – to either trigger `OCRD_MISSING_INPUT=ABORT` or `OCRD_MISSING_INPUT=SKIP`. 

But we did not implement this case yet – instead, we let the function proceed without download, which will then fail (without the `SKIP` behaviour) at `page_from_file`.

So now the ABORT and SKIP behaviours are enforced for locally missing files, too.