### PR TITLE
only use multiprocessing if max_workers > 1 (partial revert of f95111ff)

### DIFF
--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -539,7 +539,7 @@ class Processor():
                     self._base_logger.info("limiting page timeout from %d to %d sec", max_seconds, self.max_page_seconds)
                     max_seconds = self.max_page_seconds
 
-                if isinstance(workspace.mets, ClientSideOcrdMets):
+                if max_workers > 1:
                     executor_cls = ProcessPoolExecutor
                     log_queue = mp.get_context('fork').Queue()
                 else:
@@ -553,7 +553,7 @@ class Processor():
                     initializer=_page_worker_set_ctxt,
                     initargs=(self, log_queue),
                 )
-                if isinstance(workspace.mets, ClientSideOcrdMets):
+                if max_workers > 1:
                     assert executor.active # ensure pre-forking
                     # forward messages from log queue (in subprocesses) to all root handlers
                     log_listener = logging.handlers.QueueListener(log_queue, *logging.root.handlers,


### PR DESCRIPTION
This was a self-own: in f95111ff I tried to be smarter than my past self and changed the criterion when to use the ProcessPool executor –

- from `max_workers > 1` (i.e. whether `OCRD_MAX_PARALLEL_PAGES` was requested **and** the processor implementation supports that)
- to `isinstance(workspace.mets, ClientSideOcrdMets)` (i.e. whether the workspace can be processed in parallel)

But for such important cases like Tensorflow, where (unless you put the model in a singleton background process connected via queues to the page workers) multiprocessing is impossible (because the CUDA context cannot be shared), this is clearly wrong. We have to be able to prohibit in the processor implementation (via `max_workers = 1`) multiprocessing.

