### PR TITLE
remove: DOCKER_RABBIT_MQ_FEATURES env

### DIFF
--- a/src/ocrd_network/constants.py
+++ b/src/ocrd_network/constants.py
@@ -2,8 +2,6 @@ from enum import Enum
 
 DOCKER_IMAGE_MONGO_DB = "mongo"
 DOCKER_IMAGE_RABBIT_MQ = "rabbitmq:4.2-management"
-# These feature flags are required by default to use the newer version
-DOCKER_RABBIT_MQ_FEATURES = "quorum_queue,implicit_default_bindings,classic_mirrored_queue_version"
 
 NETWORK_PROTOCOLS = ["http://", "https://"]
 OCRD_ALL_TOOL_JSON = "ocrd-all-tool.json"

--- a/src/ocrd_network/runtime_data/network_services.py
+++ b/src/ocrd_network/runtime_data/network_services.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from logging import Logger
 from typing import Any, Dict, List, Optional, Union
 
-from ..constants import DOCKER_IMAGE_MONGO_DB, DOCKER_IMAGE_RABBIT_MQ, DOCKER_RABBIT_MQ_FEATURES
+from ..constants import DOCKER_IMAGE_MONGO_DB, DOCKER_IMAGE_RABBIT_MQ
 from ..database import verify_mongodb_available
 from ..rabbitmq_utils import verify_rabbitmq_available
 from .connection_clients import create_docker_client
@@ -136,9 +136,7 @@ class DataRabbitMQ(DataNetworkService):
             env = [
                 # The default credentials to be used by the processing workers
                 f"RABBITMQ_DEFAULT_USER={rmq_user}",
-                f"RABBITMQ_DEFAULT_PASS={rmq_password}",
-                # These feature flags are required by default to use the newer version
-                f"RABBITMQ_FEATURE_FLAGS={DOCKER_RABBIT_MQ_FEATURES}"
+                f"RABBITMQ_DEFAULT_PASS={rmq_password}"
             ]
         if not ports_mapping:
             # 5672, 5671 - used by AMQP 0-9-1 and AMQP 1.0 clients without and with TLS

--- a/tests/network/.env
+++ b/tests/network/.env
@@ -16,7 +16,6 @@ MONGODB_HOST=mongodb-docker-host
 MONGODB_PORT=27017
 MONGODB_URL=mongodb://${MONGODB_USER}:${MONGODB_PASS}@${MONGODB_HOST}.${DOCKER_OCRD_NETWORK_NAME}:${MONGODB_PORT}
 
-RABBITMQ_FEATURE_FLAGS=quorum_queue,implicit_default_bindings,classic_mirrored_queue_version
 RABBITMQ_USER=network_test
 RABBITMQ_PASS=network_test
 RABBITMQ_HOST=rabbitmq-docker-host

--- a/tests/network/docker-compose.yml
+++ b/tests/network/docker-compose.yml
@@ -38,7 +38,6 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_USER}
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASS}
-      - RABBITMQ_FEATURE_FLAGS=${RABBITMQ_FEATURE_FLAGS}
     healthcheck:
       test: rabbitmq-diagnostics check_port_connectivity
       interval: 1s


### PR DESCRIPTION
The v4.2 RabbitMQ is smart enough to determine the used features and enable them by default. Hence, `DOCKER_RABBIT_MQ_FEATURES` is now irrelevant.

Since there is no volume mapping in `ocrd_network` no extra steps are required. 