### PR TITLE
docker: install jq in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get update && apt-get -y install software-properties-common \
         bzip2 \
         sudo \
         git \
+        jq \
     && make deps-ubuntu
 RUN python3 -m venv /usr/local \
     && hash -r \


### PR DESCRIPTION
For doing JSON query ops in derived containers. Small and few dependencies and we do need it for the `readinessProbe` of the processing worker pods:

```bash
curl -u "*:*" -s http://$(OCRD_RABBITMQ_SERVICE_HOST):15672/api/queues | \
jq '.[] | select(.name == "$(OCRD_PROCESSOR_NAME)")' >/dev/null || exit 1
```