### PR TITLE
gdown: require newest release, remove old parse_url warning kwarg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ filetype
 Flask
 frozendict>=2.4.0
 gitpython
-gdown
+gdown < 6 ; python_version < '3.10'
+gdown >= 6 ; python_version >= '3.10'
 httpx>=0.22.0
 importlib_metadata ; python_version < '3.8'
 importlib_resources ; python_version < '3.10'

--- a/src/ocrd/resource_manager.py
+++ b/src/ocrd/resource_manager.py
@@ -289,7 +289,7 @@ class OcrdResourceManager:
     def _download_impl(log: Logger, url: str, filename):
         log.info(f"Downloading {url} to {filename}")
         try:
-            gdrive_file_id, is_gdrive_download_link = gparse_url(url, warning=False)
+            gdrive_file_id, is_gdrive_download_link = gparse_url(url)
             if gdrive_file_id:
                 if not is_gdrive_download_link:
                     url = f"https://drive.google.com/uc?id={gdrive_file_id}"


### PR DESCRIPTION
The newest release 6.0.0 of gdown [removes the `--fuzzy` mechanism and related `warning` kwarg for `parse_url`](https://github.com/wkentaro/gdown/commit/b1c6e1ce257d4fa247304adcd181cdf8e7651c74#diff-d4a064c8bbd8df8f31c38d304cf30a7fb58030db92ffb3d3d54e15b18328bbd4). This causes builds for Python 3.10+ [to fail](https://app.circleci.com/pipelines/gh/OCR-D/core/2996/workflows/3be07a53-7b33-4c32-8d5d-a7e66590ce9f/jobs/12476).

In addition gdown 6.0.0 requires 3.10+, so I've added a `python_version` guard in the `requirements.txt`.