### PR TITLE
remove pinning cryptography, update paramiko to versions without the warning issue from #1260

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 atomicwrites >= 1.3.0
 beanie>=2.0.1
 click >=7
-cryptography < 43.0.0
 cysignals
 Deprecated == 1.2.0
 docker>=7.1.0
@@ -26,6 +25,8 @@ numpy
 ocrd-fork-bagit >= 1.8.1.post2
 ocrd-fork-bagit_profile >= 1.3.0.post1
 opencv-python-headless
+paramiko >= 4; python_version > '3.9'
+paramiko >= 3.4.1; python_version <= '3.9'
 paramiko
 pika>=1.2.0
 Pillow >= 7.2.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,4 @@
 autopep8
-cryptography < 43.0.0
 pytest >= 4.0.0
 generateDS == 2.44.1
 pytest-benchmark >= 3.2.3


### PR DESCRIPTION
The problem with paramiko raising warnings about deprecated cryptography algorithms should have been fixed since at least 3.4.1 (https://github.com/paramiko/paramiko/pull/2421).

Also, paramiko dropped support for Python 3.9 in 4.0.0, so another `python_version` conditional requirement.