### PR TITLE
ocrd network client workflow run: compare options in boolean context

### DIFF
--- a/src/ocrd_network/cli/client.py
+++ b/src/ocrd_network/cli/client.py
@@ -258,8 +258,9 @@ def send_workflow_job_request(
     as in ``ocrd process`` tasks arguments), or via `-w` file path
     (same syntax, but newline separated).
     """
-    if (path_to_workflow) != bool(len(tasks)):
-        raise ValueError("either -w/path-to-workflow or task argument(s) is required")
+    if bool(path_to_workflow) == bool(len(tasks)):
+        diag = 'not both' if bool(path_to_workflow) else 'but neither was provided'
+        raise ValueError(f"Either -w/--path-to-workflow option or task argument(s) is required, {diag}.")
 
     client = Client(server_addr_processing=address)
     with NamedTemporaryFile() as workflow_file:

--- a/tests/cli/test_network.py
+++ b/tests/cli/test_network.py
@@ -1,0 +1,26 @@
+import re
+from click.testing import CliRunner
+import pytest
+from ocrd_network.cli.client import workflow_cli
+
+
+runner = CliRunner()
+
+def test_check_workflow_tasks_argument():
+    """
+    https://github.com/OCR-D/core/pull/1358
+    """
+    with pytest.raises(ValueError, match=re.escape("Either -w/--path-to-workflow option or task argument(s) is required, but neither was provided.")):
+        runner.invoke(workflow_cli, [
+            'run',
+            '--address', 'https://irrelevant',
+            '--path-to-mets', 'irrelevant',
+        ], catch_exceptions=False)
+    with pytest.raises(ValueError, match=re.escape("Either -w/--path-to-workflow option or task argument(s) is required, not both.")):
+        runner.invoke(workflow_cli, [
+            'run',
+            '--address', 'https://irrelevant',
+            '--path-to-mets', 'irrelevant',
+            '--path-to-workflow', 'irrelevant',
+            'task1', 'task2'
+        ], catch_exceptions=False)


### PR DESCRIPTION
Comparison between path to workflow and tasks provided must be in a boolean context, otherwise we're comparing string to boolean.

Bug introduced in https://github.com/OCR-D/core/pull/1337/changes#diff-71be56139c9cf750a2a524a33517ef092a7a010fc8115d79370c292fb7f01f5cL212

How I did not spot this before I don't know 😨 