### PR TITLE
RabbitMQ: create queues durable for 4.x compat

### DIFF
--- a/src/ocrd_network/rabbitmq_utils/connector.py
+++ b/src/ocrd_network/rabbitmq_utils/connector.py
@@ -174,7 +174,7 @@ class RMQConnector:
 
     @staticmethod
     def queue_declare(
-        channel: BlockingChannel, queue_name: str, passive: bool = False, durable: bool = False,
+        channel: BlockingChannel, queue_name: str, passive: bool = False, durable: bool = True,
         exclusive: bool = False, auto_delete: bool = False, arguments: Optional[Any] = None
     ) -> None:
         if arguments is None:
@@ -185,7 +185,9 @@ class RMQConnector:
                 # Only check to see if the queue exists and
                 # raise ChannelClosed exception if it does not
                 passive=passive,
-                # Survive reboots of the server
+                # Survive reboots of the server 
+                # default changed to true to avoid 541, 'INTERNAL_ERROR - Feature transient_nonexcl_queues is deprecated.
+                # kba Wed Jun  3 13:26:26 CEST 2026
                 durable=durable,
                 # Only allow access by the current connection
                 exclusive=exclusive,


### PR DESCRIPTION
Transient, non-exclusive queues (ie. queue created with `durable=False` and `exclusive=False` are [deprecated as of 4.0](https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements#removal-of-transient-non-exclusive-queues) and [removed as of 4.3. of RabbitMQ](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.0).

We have upgraded to RabbitMQ 4.3.1 for our deployment, therefore fixing this in core is now urgent for us.

The solution I went with is to just make the queues durable. That means the queues survive all workers for a processor being disconnected. They do reattach cleanly though, once this is set up.

The only issue I found so far is that I did need to delete the old queues manually, otherwise the different `durable` settings will lead to errors and somehow the non-durable queues did not automatically get deleted after shutting down the workers. But that could be a timing issue.

Since I am not a RabbitMQ expert, I'm not sure whether this might cause different problems or whether we need to configure some TTL mechanism. So I would appreciate feedback by those who know better e.g. @MehmedGIT 