### PR TITLE
Install inotifytools for k8s sidecars log tailing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get -y install software-properties-common \
         curl \
         bzip2 \
         sudo \
+        inotify-tools \
         git \
         jq \
     && make deps-ubuntu


### PR DESCRIPTION
Does not add too many dependencies and allows a mechanism like

```
inotifywait -m /tmp/ocrd-network -e create |
while read dir event file; do
    tail -F "$dir/$file" &
done
```

to get the logging of the workers into the STDOUT stream for log analysis.

It's still not a great solution but the least invasive change. 

In the mid-term we should find a way to have the ocrd_network logging make fewer assumptions, perhaps carry the info from the filename (job UUID) as a logging metadata field or even just part of the log message.